### PR TITLE
fix: avoid ZeroDivisionError when clearing transverse rebar with zero spacing

### DIFF
--- a/mento/beam.py
+++ b/mento/beam.py
@@ -302,14 +302,21 @@ class RectangularBeam(RectangularSection):
         d_b: Quantity = 0 * mm,
         s_l: Quantity = 0 * cm,
     ) -> None:
-        """Sets the transverse rebar in the beam section."""
+        """Sets the transverse rebar in the beam section.
+
+        A zero spacing means no stirrups, which clears the transverse reinforcement.
+        """
         self._stirrup_n = n_stirrups
         self._stirrup_d_b = d_b
         self._stirrup_s_l = s_l
-        n_legs = n_stirrups * 2
-        A_db = (d_b**2) * math.pi / 4  # Area of one stirrup leg
-        A_vs = n_legs * A_db  # Total area of stirrups
-        self._A_v = A_vs / s_l  # Stirrup area per unit length
+        if s_l == 0 * cm:
+            # No stirrups: same state as a section without transverse rebar
+            self._A_v = 0 * cm**2 / m
+        else:
+            n_legs = n_stirrups * 2
+            A_db = (d_b**2) * math.pi / 4  # Area of one stirrup leg
+            A_vs = n_legs * A_db  # Total area of stirrups
+            self._A_v = A_vs / s_l  # Stirrup area per unit length
 
         # Update effective heights
         self._update_effective_heights()

--- a/mento/shear_wall.py
+++ b/mento/shear_wall.py
@@ -166,21 +166,29 @@ class ShearWall(RectangularBeam):
         """Set distributed horizontal (transverse) reinforcement.
 
         Bars are placed on each face (E.F.):  ρt = n_curtains · Ab / (t × s_h)
+        A zero spacing means no rebar, which clears the horizontal reinforcement.
         """
         self._d_b_h = d_b
         self._s_h = s
-        A_b = math.pi / 4 * d_b**2
-        self._rho_t = (self._n_curtains * A_b / (self.thickness * s)).to("")
+        if s == 0 * mm:
+            self._rho_t = 0 * dimensionless
+        else:
+            A_b = math.pi / 4 * d_b**2
+            self._rho_t = (self._n_curtains * A_b / (self.thickness * s)).to("")
 
     def set_vertical_rebar(self, d_b: Quantity, s: Quantity) -> None:
         """Set distributed vertical reinforcement.
 
         Bars are placed on each face (E.F.):  ρl = n_curtains · Ab / (t × s_v)
+        A zero spacing means no rebar, which clears the vertical reinforcement.
         """
         self._d_b_v = d_b
         self._s_v = s
-        A_b = math.pi / 4 * d_b**2
-        self._rho_l = (self._n_curtains * A_b / (self.thickness * s)).to("")
+        if s == 0 * mm:
+            self._rho_l = 0 * dimensionless
+        else:
+            A_b = math.pi / 4 * d_b**2
+            self._rho_l = (self._n_curtains * A_b / (self.thickness * s)).to("")
 
     # ------------------------------------------------------------------
     # Shear check and design (override RectangularBeam)

--- a/mento/slab.py
+++ b/mento/slab.py
@@ -72,11 +72,18 @@ class OneWaySlab(RectangularBeam):
         s_long: Quantity = 0 * cm,
         s_trans: Quantity = 0 * cm,
     ) -> None:
-        """Sets the transverse rebar in the slab section."""
+        """Sets the transverse rebar in the slab section.
+
+        A zero spacing means no stirrups, which clears the transverse reinforcement.
+        """
         self._stirrup_s_l = s_long
-        n_legs_per_unit_width = self.width / s_trans
-        A_db = (d_b**2) * math.pi / 4  # Area of one stirrup leg per unit width
-        self._A_v = A_db * n_legs_per_unit_width / s_long  # Legs area per unit length
+        if s_long == 0 * cm or s_trans == 0 * cm:
+            # No stirrups: same state as a section without transverse rebar
+            self._A_v = 0 * mm**2 / m
+        else:
+            n_legs_per_unit_width = self.width / s_trans
+            A_db = (d_b**2) * math.pi / 4  # Area of one stirrup leg per unit width
+            self._A_v = A_db * n_legs_per_unit_width / s_long  # Legs area per unit length
 
         # Update effective heights
         self._update_effective_heights()

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -145,6 +145,33 @@ def test_initialize_longitudinal_rebar_attributes_metric_defaults() -> None:
     assert beam._d_b1_t.magnitude == pytest.approx(8)
 
 
+def test_set_transverse_rebar_zero_spacing_clears_stirrups() -> None:
+    beam = build_metric_beam()
+    beam.set_transverse_rebar(n_stirrups=1, d_b=8 * mm, s_l=20 * cm)
+    assert beam._A_v.to("cm**2/m").magnitude > 0
+
+    # Clearing the stirrups must not divide by the zero spacing
+    beam.set_transverse_rebar(n_stirrups=0, d_b=0 * mm, s_l=0 * cm)
+
+    assert beam._stirrup_n == 0
+    assert beam._stirrup_d_b.to("mm").magnitude == 0
+    assert beam._stirrup_s_l.to("cm").magnitude == 0
+    assert beam._A_v.to("cm**2/m").magnitude == 0
+
+
+def test_set_transverse_rebar_defaults_clear_stirrups_imperial(
+    beam_example_imperial: RectangularBeam,
+) -> None:
+    beam_example_imperial.set_transverse_rebar(n_stirrups=1, d_b=0.5 * inch, s_l=6 * inch)
+    assert beam_example_imperial._A_v.to("inch**2/ft").magnitude > 0
+
+    beam_example_imperial.set_transverse_rebar()
+
+    assert beam_example_imperial._stirrup_n == 0
+    assert beam_example_imperial._stirrup_s_l.to("inch").magnitude == 0
+    assert beam_example_imperial._A_v.to("inch**2/ft").magnitude == 0
+
+
 def test_shear_check_EN_1992_2004_rebar_1(
     beam_example_EN_1992_2004_01: RectangularBeam,
 ) -> None:

--- a/tests/test_shear_wall.py
+++ b/tests/test_shear_wall.py
@@ -109,6 +109,17 @@ class TestShearWallInit:
         expected = 2 * (math.pi / 4 * 12**2) / (250 * 150)
         assert wall_metric._rho_l.to("").magnitude == pytest.approx(expected, rel=1e-4)
 
+    def test_zero_spacing_clears_rebar_ratios(self, wall_metric: ShearWall) -> None:
+        wall_metric.set_horizontal_rebar(d_b=12 * mm, s=200 * mm)
+        wall_metric.set_vertical_rebar(d_b=12 * mm, s=150 * mm)
+
+        # Clearing the mesh must not divide by the zero spacing
+        wall_metric.set_horizontal_rebar(d_b=0 * mm, s=0 * mm)
+        wall_metric.set_vertical_rebar(d_b=0 * mm, s=0 * mm)
+
+        assert wall_metric._rho_t.to("").magnitude == 0
+        assert wall_metric._rho_l.to("").magnitude == 0
+
 
 # ---------------------------------------------------------------------------
 # α_c

--- a/tests/test_slab.py
+++ b/tests/test_slab.py
@@ -82,6 +82,17 @@ def test_set_slab_transverse_rebar_computes_shear_area() -> None:
     assert slab._stirrup_s_l == 20 * cm
 
 
+def test_set_slab_transverse_rebar_zero_spacing_clears_shear_area() -> None:
+    slab = build_slab()
+    slab.set_slab_transverse_rebar(d_b=10 * mm, s_long=20 * cm, s_trans=25 * cm)
+
+    # Clearing the stirrups must not divide by the zero spacing
+    slab.set_slab_transverse_rebar()
+
+    assert slab._stirrup_s_l.magnitude == 0
+    assert slab._A_v.to("cm**2/m").magnitude == 0
+
+
 def test_longitudinal_rebar_spacing_updates_counts() -> None:
     slab = build_slab()
 


### PR DESCRIPTION
# Description

`RectangularBeam.set_transverse_rebar(n_stirrups=0, d_b=0 * mm, s_l=0 * cm)` is a plausible way for a user to clear the stirrups from a section — it mirrors the no-stirrup state a freshly built beam already has — but it crashed with a pint `ZeroDivisionError` on `A_vs / s_l`.

The setters now short-circuit on zero spacing and assign zero directly, which lands the section in exactly the state a freshly built one has (`_stirrup_n = 0`, `_A_v = 0 cm²/m`, `_stirrup_s_l = 0 cm`). A subsequent `check_shear()` then runs through the normal no-stirrup path.

The same divide-by-spacing pattern appears in two other public setters, fixed alongside:

| Setter | Failing call | Fix |
| --- | --- | --- |
| `RectangularBeam.set_transverse_rebar` | `s_l=0 * cm` | `_A_v = 0 cm²/m` |
| `OneWaySlab.set_slab_transverse_rebar` | divides by both `s_trans` and `s_long`, and **all its arguments default to zero**, so even the bare no-arg call crashed | `_A_v = 0 mm²/m` |
| `ShearWall.set_horizontal_rebar` / `set_vertical_rebar` | `s=0 * mm` when computing `ρt` / `ρl` | ratio set to `0` |

`Rebar.transverse_rebar` and the EN 1992-2004 shear check divide by spacing too, but neither is reachable with zero: the first iterates spacings derived from `s_max_l`, the second sits behind an `if _stirrup_n == 0` guard that returns early. Both left unchanged.

Found while writing tests for the new public results API (`mento/design_results.py`); that API reads the no-stirrup state correctly, so this fix is independent of it.

Closes #

## Type of change

- [x] Bug fix
- [ ] New feature or design code implementation
- [ ] Documentation
- [ ] Maintenance (tooling, CI, refactoring with no behaviour change)

## Checklist

- [x] Tests added or updated, and `pytest` passes locally — 574 passed, 1 skipped
- [x] `mypy mento/` passes
- [x] `pre-commit run --all-files` reports no changes
- [ ] Documentation updated where the change is user facing — no doc change needed; the documented calls are unaffected
- [x] Public class and method names left unchanged, or the change was agreed beforehand

## Notes for the reviewer

- No behaviour change for any non-zero spacing — the arithmetic branch is untouched, so all existing design/check results are identical.
- One test added per fixed setter: `tests/test_beam.py` (metric clear, plus an imperial case exercising the bare `set_transverse_rebar()` defaults), `tests/test_slab.py`, `tests/test_shear_wall.py`.

## Calculation validation

Not applicable — no design calculation is added or modified. The change only guards a degenerate zero-spacing input that previously raised.
