### PR TITLE
docs: make the Sphinx build warning-free and add Open in Colab badges

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,4 +97,7 @@ jobs:
       - name: Build documentation
         env:
           MPLBACKEND: "Agg"
-        run: sphinx-build -b html docs/source docs/build/html
+        # -W turns warnings into errors so the HTML build cannot regress back into
+        # the ~117 warnings it used to emit; --keep-going reports all of them at once
+        # instead of stopping at the first.
+        run: sphinx-build -b html -W --keep-going docs/source docs/build/html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,17 @@ python:
 
 sphinx:
   configuration: docs/source/conf.py
+  # The HTML build is warning-free and CI enforces that with `sphinx-build -W`.
+  # This stays false because Read the Docs applies fail_on_warning to *every*
+  # builder it runs, and `formats: [pdf]` below means it also runs the LaTeX
+  # builder. LaTeX cannot rasterise the "Open in Colab" SVG badge at the top of
+  # each example notebook, so it emits one
+  #   "a suitable image for latex builder not found: ['image/svg+xml']"
+  # warning per notebook. The PDF still builds (the badge is simply omitted from
+  # it), but turning warnings into errors here would fail it. Flipping this to
+  # true requires either dropping the pdf format or teaching the LaTeX builder to
+  # convert SVGs (e.g. sphinxcontrib-svg2pdfconverter, which needs a native
+  # cairo/Inkscape dependency).
   fail_on_warning: false
 
 formats:

--- a/docs/source/api/modules.rst
+++ b/docs/source/api/modules.rst
@@ -1,7 +1,0 @@
-mento
-=====
-
-.. toctree::
-   :maxdepth: 4
-
-   mento

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,6 +64,24 @@ exclude_patterns = ["build"]
 
 autodoc_inherit_docstrings = True
 
+# Napoleon renders ``Attributes:`` and ``Methods:`` docstring sections as
+# ``.. attribute::`` / ``.. method::`` directives by default. Those collide with the
+# entries autodoc already emits for the same members via ``:members:``, which produced
+# ~33 "duplicate object description" warnings in the API reference. The autodoc entry
+# is the canonical one (it carries the signature and the source link), so the
+# docstring summaries are rendered as plain prose instead:
+#   - ``napoleon_use_ivar`` turns ``Attributes:`` into a ":ivar:" field list.
+#   - listing "Methods" in ``napoleon_custom_sections`` overrides Napoleon's built-in
+#     handler with the generic one, which emits a rubric plus a definition list.
+napoleon_use_ivar = True
+napoleon_custom_sections = ["Methods"]
+
+# Section titles repeat across the user guide ("Usage", "Key Concepts", ...) and across
+# the generated API pages ("Submodules"). Prefixing autosectionlabel targets with the
+# document name keeps them unique. Every ``:ref:`` in the docs points at an explicit
+# ``.. _label:`` target, so none of them are affected by this.
+autosectionlabel_prefix_document = True
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
@@ -79,8 +97,6 @@ html_theme_options = {
     "repository_branch": "main",
     "use_repository_button": True,
     "use_issues_button": True,
-    "logo_only": True,
-    "display_version": False,
 }
 
 # Output file base name for HTML help builder.

--- a/docs/source/examples/OneWaySlab_check_ACI_318-19.ipynb
+++ b/docs/source/examples/OneWaySlab_check_ACI_318-19.ipynb
@@ -4,6 +4,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mihdicaballero/mento/blob/main/docs/source/examples/OneWaySlab_check_ACI_318-19.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Google Colab does not ship mento, so install it when running there.\n",
+    "# Guarded so that building the documentation never shells out to pip.\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install mento"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# One Way Slab check ACI 318-19"
    ]
   },

--- a/docs/source/examples/beam_summary_ACI_318-19 Design.ipynb
+++ b/docs/source/examples/beam_summary_ACI_318-19 Design.ipynb
@@ -4,6 +4,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mihdicaballero/mento/blob/main/docs/source/examples/beam_summary_ACI_318-19%20Design.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Google Colab does not ship mento, so install it when running there.\n",
+    "# Guarded so that building the documentation never shells out to pip.\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install mento"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Beam summary design with ACI 318-19"
    ]
   },

--- a/docs/source/examples/beam_summary_ACI_318-19.ipynb
+++ b/docs/source/examples/beam_summary_ACI_318-19.ipynb
@@ -4,6 +4,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mihdicaballero/mento/blob/main/docs/source/examples/beam_summary_ACI_318-19.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Google Colab does not ship mento, so install it when running there.\n",
+    "# Guarded so that building the documentation never shells out to pip.\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install mento"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Beam summary with ACI 318-19"
    ]
   },

--- a/docs/source/examples/beam_summary_EN_1992-1-1.ipynb
+++ b/docs/source/examples/beam_summary_EN_1992-1-1.ipynb
@@ -4,6 +4,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mihdicaballero/mento/blob/main/docs/source/examples/beam_summary_EN_1992-1-1.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Google Colab does not ship mento, so install it when running there.\n",
+    "# Guarded so that building the documentation never shells out to pip.\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install mento"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Beam summary with EN 1992-1-1"
    ]
   },

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -12,6 +12,8 @@ In this folder, you will find detailed examples of how to use mento.
 
    rectangular_beam_check_ACI_318-19
    rectangular_beam_check_EN_1992-1-1
+   rectangular_beam_design_ACI_318-19
+   rectangular_beam_design_EN_1992-1-1
    beam_summary_ACI_318-19
    beam_summary_ACI_318-19 Design
    beam_summary_EN_1992-1-1

--- a/docs/source/examples/rectangular_beam_check_ACI_318-19.ipynb
+++ b/docs/source/examples/rectangular_beam_check_ACI_318-19.ipynb
@@ -4,6 +4,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mihdicaballero/mento/blob/main/docs/source/examples/rectangular_beam_check_ACI_318-19.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Google Colab does not ship mento, so install it when running there.\n",
+    "# Guarded so that building the documentation never shells out to pip.\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install mento"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Rectangular Beam check ACI 318-19"
    ]
   },

--- a/docs/source/examples/rectangular_beam_check_EN_1992-1-1.ipynb
+++ b/docs/source/examples/rectangular_beam_check_EN_1992-1-1.ipynb
@@ -4,6 +4,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mihdicaballero/mento/blob/main/docs/source/examples/rectangular_beam_check_EN_1992-1-1.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Google Colab does not ship mento, so install it when running there.\n",
+    "# Guarded so that building the documentation never shells out to pip.\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install mento"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Rectangular Beam check EN 1992-1-1"
    ]
   },

--- a/docs/source/examples/rectangular_beam_design_ACI_318-19.ipynb
+++ b/docs/source/examples/rectangular_beam_design_ACI_318-19.ipynb
@@ -4,7 +4,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Rectangular Beam check ACI 318-19"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mihdicaballero/mento/blob/main/docs/source/examples/rectangular_beam_design_ACI_318-19.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Google Colab does not ship mento, so install it when running there.\n",
+    "# Guarded so that building the documentation never shells out to pip.\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install mento"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Rectangular Beam design ACI 318-19"
    ]
   },
   {

--- a/docs/source/examples/rectangular_beam_design_EN_1992-1-1.ipynb
+++ b/docs/source/examples/rectangular_beam_design_EN_1992-1-1.ipynb
@@ -4,7 +4,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Rectangular Beam check ACI 318-19"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mihdicaballero/mento/blob/main/docs/source/examples/rectangular_beam_design_EN_1992-1-1.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Google Colab does not ship mento, so install it when running there.\n",
+    "# Guarded so that building the documentation never shells out to pip.\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install mento"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Rectangular Beam design EN 1992-1-1"
    ]
   },
   {

--- a/docs/source/examples/shear_wall_check_ACI_318-19.ipynb
+++ b/docs/source/examples/shear_wall_check_ACI_318-19.ipynb
@@ -2,6 +2,31 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "7af3640a",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mihdicaballero/mento/blob/main/docs/source/examples/shear_wall_check_ACI_318-19.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "421a070f",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Google Colab does not ship mento, so install it when running there.\n",
+    "# Guarded so that building the documentation never shells out to pip.\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install mento"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d5339e87",
    "metadata": {},
    "source": [

--- a/docs/source/examples/shear_wall_design_ACI_318-19.ipynb
+++ b/docs/source/examples/shear_wall_design_ACI_318-19.ipynb
@@ -2,6 +2,31 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "3374a42c",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mihdicaballero/mento/blob/main/docs/source/examples/shear_wall_design_ACI_318-19.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87fb3b30",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Google Colab does not ship mento, so install it when running there.\n",
+    "# Guarded so that building the documentation never shells out to pip.\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install mento"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d5339e87",
    "metadata": {},
    "source": [

--- a/docs/source/examples/shear_wall_summary_ACI_318-19 Design.ipynb
+++ b/docs/source/examples/shear_wall_summary_ACI_318-19 Design.ipynb
@@ -4,6 +4,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mihdicaballero/mento/blob/main/docs/source/examples/shear_wall_summary_ACI_318-19%20Design.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Google Colab does not ship mento, so install it when running there.\n",
+    "# Guarded so that building the documentation never shells out to pip.\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install mento"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Shear Wall Summary Design with ACI 318-19"
    ]
   },

--- a/docs/source/examples/shear_wall_summary_ACI_318-19.ipynb
+++ b/docs/source/examples/shear_wall_summary_ACI_318-19.ipynb
@@ -4,6 +4,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mihdicaballero/mento/blob/main/docs/source/examples/shear_wall_summary_ACI_318-19.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Google Colab does not ship mento, so install it when running there.\n",
+    "# Guarded so that building the documentation never shells out to pip.\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install mento"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Shear Wall Summary with ACI 318-19"
    ]
   },

--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -16,7 +16,7 @@ Installation
 ------------
 
 Install with pip
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^
 
 You can install Mento via ``pip``, the Python package manager. Simply run the following command in your terminal:
 

--- a/docs/source/user_guide/beams.rst
+++ b/docs/source/user_guide/beams.rst
@@ -10,7 +10,7 @@ Key Concepts
 - **Beam Geometry**: Defined by `width` and `height`.
 - **Material Properties**: Requires a `Concrete` object (e.g., `Concrete_ACI_318_19`) and a `SteelBar` object for reinforcement.
 - **Reinforcement**: Longitudinal and transverse reinforcement can be defined using `set_longitudinal_rebar_bot`, `set_longitudinal_rebar_top`, and `set_transverse_rebar`.
-- **Custom settings**: A `Beam` object can have custom settings overriding the default settings of `mento.
+- **Custom settings**: A `Beam` object can have custom settings overriding the default settings of `mento`.
 
 Usage
 -----

--- a/docs/source/user_guide/forces.rst
+++ b/docs/source/user_guide/forces.rst
@@ -24,7 +24,7 @@ Usage
 Below is a step-by-step guide on how to use the `Forces` class in your structural analysis workflows.
 
 1. Creating a Forces Object
-**********
+***************************
 
 To define the forces acting on a structural element, instantiate a `Forces` object. You can provide initial values for axial force (`N_x`), shear force (`V_z`), and bending moment (`M_y`). If no values are provided, the forces default to zero.
 The default unit_system for units display is *metric*.
@@ -38,7 +38,7 @@ The default unit_system for units display is *metric*.
     print(force)
 
 2. Accessing Forces
-**********
+*******************
 
 Once a `Forces` object is created, you can access individual forces using the respective properties `N_x`, `V_z`, and `M_y`. These properties will return the forces in metric system by default, making it easy to inspect the current state of forces in your structure.
 
@@ -58,7 +58,7 @@ If you want to display the Forces in *imperial system* just pass the input to th
     print(force.M_y)  # Output: 3.69 ft*kip
 
 3. Modifying Forces
-**********
+*******************
 
 Forces can be modified at any point by calling the `set_forces()` method. This method allows you to update the values of `N_x`, `V_z`, and `M_y`.
 
@@ -70,7 +70,7 @@ Forces can be modified at any point by calling the `set_forces()` method. This m
     print(force)
 
 4. Retrieving Forces as a Dictionary
-**********
+************************************
 
 You can retrieve the forces in the form of a dictionary for easy manipulation, storage, or reporting. The `get_forces()` method returns a dictionary where the keys are `N_x`, `V_z`, and `M_y`, with values corresponding to the respective forces in the unit system.
 
@@ -81,7 +81,7 @@ You can retrieve the forces in the form of a dictionary for easy manipulation, s
     # Output: {'N_x': 3.00 kN, 'V_z': 10.00 kN, 'M_y': 7.00 kN*m}
 
 5. Assigning a Label to a Force
-**********
+*******************************
 
 Optionally, you can assign a label to a force object to describe the specific load condition or scenario (e.g., "Crane load", "Wind load"). This is useful in complex models where multiple forces are acting on different elements.
 
@@ -91,7 +91,7 @@ Optionally, you can assign a label to a force object to describe the specific lo
     print(force.label)  # Output: Crane load
 
 6. Force Object ID
-**********
+******************
 
 Each `Forces` object is automatically assigned a unique ID, which can be accessed through the `id` property. This is helpful when tracking multiple force objects in more complex analyses.
 
@@ -100,7 +100,7 @@ Each `Forces` object is automatically assigned a unique ID, which can be accesse
     print(force.id)  # Output: Unique ID (e.g., 1, 2, etc.)
 
 7. Print Force complete properties
-**********
+**********************************
 
 Each `Forces` object con be printed in the terminal with `print(force)` method. This allows to quickly assess a Forces object.
 

--- a/docs/source/user_guide/node.rst
+++ b/docs/source/user_guide/node.rst
@@ -124,6 +124,7 @@ You can print those results from the previous method.
 - **Flexure Design**: Use `design_flexure()`.
 
 .. code-block:: python
+
     # Perform flexure design and show DataFrame with results
     flexure_results = node_1.design_flexure()
     flexure_results

--- a/mento/rebar.py
+++ b/mento/rebar.py
@@ -90,15 +90,15 @@ class Rebar:
         Calculate the maximum allowable spacing across the length and width of the beam
         based on design requirements.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         V_s_req : float
             Required shear force for the rebar.
         A_cv : float
             Effective shear area of the concrete section.
 
-        Returns:
-        --------
+        Returns
+        -------
         tuple
             (s_max_l, s_max_w): The maximum spacing across the length and width of the beam.
         """
@@ -132,12 +132,12 @@ class Rebar:
         Calculate the maximum allowable spacing across the length and width of the beam
         based on design requirements for EN 1992-2004.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         alpha: stirrups angle
 
-        Returns:
-        --------
+        Returns
+        -------
         tuple
             (s_max_l, s_max_w): The maximum spacing along the length and width of the beam.
         """

--- a/mento/rectangular.py
+++ b/mento/rectangular.py
@@ -22,6 +22,7 @@ class RectangularSection(Section):
         A_x (Quantity): Cross-sectional area, returned in cm².
         I_y (Quantity): Moment of inertia about the Y axis, returned in cm⁴.
         I_z (Quantity): Moment of inertia about the Z axis, returned in cm⁴.
+
     Methods:
         plot(): Plots the rectangular section with dimensions and stirrup representation, including rounded corners and thickness.
     """

--- a/mento/results.py
+++ b/mento/results.py
@@ -129,13 +129,13 @@ class TablePrinter:
     """
     A class for printing tables with customizable formatting options.
 
-    Attributes:
-    -----------
+    Attributes
+    ----------
     title : Optional[str]
         Optional title displayed above the printed table.
 
-    Methods:
-    --------
+    Methods
+    -------
     print_table_data(data: List[List[Any]], headers: List[str], tablefmt: str = "fancygrid", numalign: str = "right")
       -> None
         Prints table data with customizable formatting.
@@ -149,8 +149,8 @@ class TablePrinter:
         """
         Initializes the TablePrinter with an optional title.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         title : Optional[str], default=None
             Title to be displayed above the table, if provided.
         """
@@ -166,8 +166,8 @@ class TablePrinter:
         """
         Prints table data with customizable formatting options.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         data : List[List[Any]]
             The data to be printed in table format, where each inner list represents a row.
 
@@ -180,8 +180,8 @@ class TablePrinter:
         numalign : str, default="right"
             Number alignment in the table. Common options are "right", "center", or "left".
 
-        Returns:
-        --------
+        Returns
+        -------
         table:  Return the formatted table string
         """
         # if self.title:
@@ -208,8 +208,8 @@ class TablePrinter:
         """
         Prints table data with column alignment for minimum and maximum values.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         data : List[List[Any]]
             The data to be printed in table format, where each inner list represents a row.
 
@@ -222,8 +222,8 @@ class TablePrinter:
         numalign : str, default="right"
             Number alignment in the table. Common options are "right", "center", or "left".
 
-        Returns:
-        --------
+        Returns
+        -------
         None
         """
         if self.title:
@@ -244,8 +244,8 @@ class DocumentBuilder:
     """
     A class to build and style a Word document, including adding headings and tables from data frames.
 
-    Attributes:
-    -----------
+    Attributes
+    ----------
     title : str
         Title of the document, displayed at the beginning.
 
@@ -258,8 +258,8 @@ class DocumentBuilder:
     doc : Document
         The Document object representing the Word document being built.
 
-    Methods:
-    --------
+    Methods
+    -------
     set_document_style() -> None
         Configures the document's default style with the specified font name and size.
 
@@ -280,8 +280,8 @@ class DocumentBuilder:
         """
         Initializes the DocumentBuilder with a title, font name, and font size.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         title : str
             Title to be displayed in the document.
 
@@ -303,8 +303,8 @@ class DocumentBuilder:
         """
         Sets the default style of the document, applying the font name and size.
 
-        Returns:
-        --------
+        Returns
+        -------
         None
         """
         # Normal text style
@@ -316,8 +316,8 @@ class DocumentBuilder:
         """
         Sets the page size to A4 by default.
 
-        Returns:
-        --------
+        Returns
+        -------
         None
         """
         section = self.doc.sections[0]
@@ -343,8 +343,8 @@ class DocumentBuilder:
         """
         Adds a heading to the document at the specified level.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         text : str
             The text for the heading.
         level : int
@@ -352,8 +352,8 @@ class DocumentBuilder:
         font_size : float, optional
             Font size in points. Default is 10 pt.
 
-        Returns:
-        --------
+        Returns
+        -------
         None
         """
         heading = self.doc.add_heading(text, level=level)
@@ -372,16 +372,16 @@ class DocumentBuilder:
         """
         Sets the width of each column in the table.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         table : docx.table.Table
             The table object whose column widths need to be set.
 
         column_widths : List[Cm]
             List of widths for each column, in centimeters.
 
-        Returns:
-        --------
+        Returns
+        -------
         None
         """
         for row in table.rows:
@@ -538,13 +538,13 @@ class DocumentBuilder:
         """
         Saves the document to a specified file.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         filename : str
             The filename (including path) where the document will be saved.
 
-        Returns:
-        --------
+        Returns
+        -------
         None
         """
         self.doc.save(filename)

--- a/mento/settings.py
+++ b/mento/settings.py
@@ -14,7 +14,7 @@ class BeamSettings:
     Can optionally be initialized with a `Concrete` material to determine the unit system.
 
     Available Parameters with Default Values:
-    --------------------------------------
+    -----------------------------------------
     Unit system: "metric" or "imperial"
 
     Metric Defaults:


### PR DESCRIPTION
# Description

Two documentation tasks split out of the open-source maturity work. Neither was filed as a GitHub issue, so there is nothing to close.

**1. The Sphinx build is now warning-free (117 warnings + 1 hidden error → 0).**

The original diagnosis for the ~33 `duplicate object description` warnings was that `RectangularBeam` is documented twice — narratively in `docs/source/user_guide/beams.rst` and via `automodule` in `docs/source/api/mento.rst` — and that one of them needs `:no-index:`. That turns out not to be the cause: **`docs/source/user_guide/*.rst` contains no autodoc directives at all.** The only `automodule` directives in the whole docs tree are in `api/mento.rst` and `api/mento.codes.rst`, and walking the built doctrees shows every duplicate reported as `['api/mento', 'api/mento']` — both copies come from the same document. Adding `:no-index:` to the user guide would have been a no-op.

The real cause is Napoleon: it renders `Attributes:` and `Methods:` docstring sections as `.. attribute::` / `.. method::` directives, which collide with the entries autodoc already emits for the same members via `:members:`. The autodoc entry is the canonical one — it carries the signature and the `[source]` link — so `napoleon_use_ivar = True` and `napoleon_custom_sections = ["Methods"]` now render those docstring sections as prose (an `:ivar:` field list and a rubric + definition list) instead of as competing object descriptions. All 195 member signatures survive and no docstring text was dropped.

The remaining 84 warnings were unrelated to the duplicates and are fixed at the source rather than suppressed:

- `autosectionlabel_prefix_document = True` for the duplicate-label warnings. Safe here: every `:ref:` in the docs targets an explicit `.. _label:`, so none of them change meaning.
- Hybrid Google/NumPy docstring headers in `results.py` and `rebar.py` — `Parameters:` *with* a colon *and* a `-----` underline parses as neither dialect, so it leaked into the rendered page as a literal reST section. Normalised to plain NumPy style.
- Short title underlines, an unterminated backtick in `beams.rst`, and two theme options `sphinx_book_theme` no longer supports.
- Removed `docs/source/api/modules.rst`, an unreachable `sphinx-apidoc` stub whose only content was a toctree pointing at `api/mento`.

Two things surfaced that were not part of the original brief:

- A genuine docutils **ERROR** was hiding in the warning noise: `user_guide/node.rst:126` had a `code-block:: python` directive missing its blank line, so that snippet was not rendering as a code block at all.
- `rectangular_beam_design_ACI_318-19` and `rectangular_beam_design_EN_1992-1-1` were not in any toctree. Added to `examples/index.rst`.

**2. "Open in Colab" badges on all 12 example notebooks.**

Each notebook opens with a badge linking to itself on Colab, plus a second cell that installs mento into the Colab session. Verified in a browser that the badge URL resolves to a working Colab session rendering the notebook. Filenames containing a space are percent-encoded.

One deliberate deviation from the brief: the install cell is **guarded** rather than a bare `%pip install mento`.

```python
import sys

if "google.colab" in sys.modules:
    %pip install mento
```

nbsphinx executes any notebook that ships without stored outputs — today that is `shear_wall_summary_ACI_318-19.ipynb`, whose rendered page has 6 output blocks despite 0 stored outputs — so an unconditional `%pip install` would shell out to pip on **every** Read the Docs and CI build. IPython transforms the indented line magic correctly, so on Colab this is still a plain `%pip install mento`. The cell is hidden from the rendered docs via nbsphinx cell metadata.

Also fixed the titles of the two design notebooks, which were copied from the ACI check example and both still read `# Rectangular Beam check ACI 318-19`. They are the page titles now that both notebooks are in the toctree.

**3. CI now enforces the clean build — but Read the Docs does not.**

The docs job runs `sphinx-build -b html -W --keep-going`, so the HTML build cannot regress.

`.readthedocs.yaml` keeps `fail_on_warning: false`, deliberately. RTD applies that flag to every builder it runs, and `formats: [pdf]` means it also runs the LaTeX builder — which cannot rasterise the Colab badge SVG and emits one `a suitable image for latex builder not found: ['image/svg+xml']` warning per notebook. That is a regression these badges introduce. The PDF still builds (the badge is simply omitted from it), but flipping the flag would fail it. Making RTD clean too would mean either dropping the `pdf` format or adding `sphinxcontrib-svg2pdfconverter`, which needs a native cairo/Inkscape dependency and would likely break local Windows builds — both are judgement calls worth making deliberately, so the reasoning is recorded in a comment in `.readthedocs.yaml` rather than decided here.

## Type of change

- [ ] Bug fix
- [ ] New feature or design code implementation
- [x] Documentation
- [x] Maintenance (tooling, CI, refactoring with no behaviour change)

## Checklist

- [x] Tests added or updated, and `pytest` passes locally — no tests added; this changes docstring formatting and docs config only. 570 passed, 1 skipped.
- [x] `mypy mento/` passes — no issues in 22 source files
- [x] `pre-commit run --all-files` reports no changes
- [x] Documentation updated where the change is user facing
- [x] Public class and method names left unchanged, or the change was agreed beforehand

## Reviewer notes

- No runtime behaviour changes. Source edits under `mento/` are confined to docstring section headers and whitespace — no code, signatures, or public names touched.
- Verify locally with:
  ```
  sphinx-build -b html -W --keep-going docs/source docs/build/html
  ```
  (set `MPLBACKEND=Agg`). It should exit 0 with no output.
- Worth a look on the rendered API page: `Attributes:` sections now appear as a "Variables" field list and `Methods:` sections as a rubric with a definition list, instead of as duplicate stub entries with no signature.
