### PR TITLE
fix: report the governing load combination in the design results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ from the release history and are summaries rather than complete lists.
 - Public design results API: `beam.flexure_design` and `beam.shear_design` return plain,
   frozen data objects with the reinforcement a check or design produced, so results no
   longer have to be read from private attributes such as `_A_s_bot` or `_stirrup_s_l`.
-  Reading either before running a check raises `DesignNotRunError`. See
+  Reading either before running a check raises `DesignNotRunError`. Required areas and
+  DCRs are the envelope over every load combination checked, so they describe the
+  combination that governs each face. See
   [Design results](https://mento-docs.readthedocs.io/en/latest/user_guide/design_results.html).
 
 ### Changed

--- a/docs/source/user_guide/design_results.rst
+++ b/docs/source/user_guide/design_results.rst
@@ -70,6 +70,25 @@ Shear
 
     str(shear)              # '1eØ10 mm/27 cm'
 
+Several load combinations
+-------------------------
+
+A section is normally checked against a list of combinations, and each face is often
+governed by a different one. The required areas and the DCRs are the envelope over the
+whole list, so they describe the combination that governs — not whichever one happened to
+be checked last:
+
+.. code-block:: python
+
+    node = Node(section=beam, forces=[f1, f2, f3])
+    node.design()
+
+    beam.flexure_design.bottom.DCR  # worst of the three on the bottom face
+    beam.shear_design.A_v_req       # largest stirrup requirement of the three
+
+The provided reinforcement — ``A_s``, the layers and the stirrup layout — describes the
+section itself and does not depend on the combination.
+
 Reading results too early
 -------------------------
 

--- a/mento/beam.py
+++ b/mento/beam.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from IPython.display import Markdown, display
-from typing import Optional, Dict
+from typing import Any, Optional, Dict
 import matplotlib.pyplot as plt
 from matplotlib.patches import Circle, Rectangle, FancyBboxPatch
 from pint import Quantity
@@ -136,6 +136,10 @@ class RectangularBeam(RectangularSection):
         self._DCRv: float = 0
         self._DCRb_top: float = 0
         self._DCRb_bot: float = 0
+        # Worst value of each per-combination quantity, kept by check_flexure and
+        # check_shear. The attributes above only hold the combination that ran last.
+        self._flexure_envelope: dict[str, dict[str, Any]] = {}
+        self._shear_envelope: dict[str, Any] = {}
         self._alpha: float = math.radians(90)
         self._V_s_req: Quantity = 0 * kN
 
@@ -556,6 +560,38 @@ class RectangularBeam(RectangularSection):
         all_results = self.check_flexure(forces)
         return all_results
 
+    def _update_flexure_envelope(self, suffix: str) -> None:
+        """Fold the flexure results of the current combination into the envelope.
+
+        The check functions leave the values of the combination they just ran on the
+        beam, so a reader of ``_A_s_req_bot`` after checking several combinations gets
+        whichever one happened to run last — zero, for a face that combination did not
+        put in tension. The envelope keeps the worst of each quantity instead, which is
+        what the public results in :mod:`mento.design_results` report.
+        """
+        face = self._flexure_envelope.setdefault(suffix, {})
+        for name in ("A_s_req", "A_s_min", "A_s_max"):
+            value = getattr(self, f"_{name}_{suffix}", None)
+            if value is None:
+                continue
+            current = face.get(name)
+            face[name] = value if current is None else max(current, value)
+        face["DCR"] = max(face.get("DCR", 0.0), getattr(self, f"_DCRb_{suffix}", 0.0))
+
+    def _update_shear_envelope(self) -> None:
+        """Fold the shear results of the current combination into the envelope.
+
+        Same reasoning as :meth:`_update_flexure_envelope`: ``_A_v_req`` and ``_DCRv``
+        describe the combination that ran last, not the one that governs.
+        """
+        for name in ("A_v_req", "A_v_min"):
+            value = getattr(self, f"_{name}", None)
+            if value is None:
+                continue
+            current = self._shear_envelope.get(name)
+            self._shear_envelope[name] = value if current is None else max(current, value)
+        self._shear_envelope["DCR"] = max(self._shear_envelope.get("DCR", 0.0), self._DCRv)
+
     def check_flexure(self, forces: list[Forces]) -> DataFrame:
         # Initialize variables to track limiting cases
         max_dcr_top: float = 0
@@ -568,6 +604,7 @@ class RectangularBeam(RectangularSection):
         # To compile results for all forces
         self._flexure_results_list = []  # Store individual results for each force
         self._flexure_results_detailed_list = {}  # Store detailed results by force ID
+        self._flexure_envelope = {}
 
         for force in forces:
             # Select the method based on design code
@@ -585,6 +622,11 @@ class RectangularBeam(RectangularSection):
                 "flexure_capacity_bot": self._flexure_capacity_bot.copy(),
                 "checks_pass": self._all_flexure_checks_passed,
             }
+
+            # Keep the worst value of each face across combinations, before the next
+            # one overwrites the attributes this combination just left on the beam.
+            self._update_flexure_envelope("bot")
+            self._update_flexure_envelope("top")
 
             # Extract the DCR values for top and bottom from the results
             current_dcr_top = self._DCRb_top
@@ -670,6 +712,7 @@ class RectangularBeam(RectangularSection):
         self._shear_results_detailed_list = {}  # Store detailed results by force ID
         max_dcr = 0  # Track the maximum DCR to identify the limiting case
         self._limiting_case_shear_details = None
+        self._shear_envelope = {}
 
         for force in forces:
             # Select the method based on design code
@@ -687,6 +730,10 @@ class RectangularBeam(RectangularSection):
                 "checks_pass": self._all_shear_checks_passed,
                 "shear_concrete": self._shear_concrete.copy(),
             }
+
+            # Keep the worst value across combinations, before the next one
+            # overwrites the attributes this combination just left on the beam.
+            self._update_shear_envelope()
 
             # Check if this result is the limiting case
             current_dcr = result["DCR"][0]

--- a/mento/design_results.py
+++ b/mento/design_results.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 from pint import Quantity
 
@@ -53,6 +53,10 @@ class FlexureFaceDesign:
 
     ``layers`` only contains the layers that actually carry bars, so an
     empty tuple means no reinforcement was placed on this face.
+
+    ``A_s`` is what the section carries. ``A_s_req``, ``A_s_min``, ``A_s_max``
+    and ``DCR`` are the envelope over every load combination that was checked,
+    so ``DCR`` is the one of the combination that governs this face.
     """
 
     layers: Tuple[RebarLayer, ...]
@@ -95,6 +99,9 @@ class ShearDesign:
 
     ``n_stirrups`` counts the stirrups; ``n_legs`` counts the legs crossing
     the shear plane, which is what enters the ``A_v`` calculation.
+
+    ``A_v_req``, ``A_v_min`` and ``DCR`` are the envelope over every load
+    combination that was checked, so ``DCR`` is the governing one.
     """
 
     n_stirrups: int
@@ -132,18 +139,26 @@ def _face(beam: RectangularBeam, face: str) -> FlexureFaceDesign:
     # _A_s_bot is set when the section is built, so it always carries the area
     # unit of this beam and can seed the values a check may not have produced.
     zero: Quantity = 0 * beam._A_s_bot.units
+    # The envelope over every combination that was checked. The private attributes
+    # only describe the combination that ran last, which is not necessarily the one
+    # that governs this face.
+    envelope: Dict[str, Any] = getattr(beam, "_flexure_envelope", {}).get(suffix, {})
 
     def area(name: str) -> Quantity:
-        value: Optional[Quantity] = getattr(beam, name, None)
+        """Envelope value of a per-combination area, or the last one if there is none."""
+        value: Optional[Quantity] = envelope.get(name, getattr(beam, f"_{name}_{suffix}", None))
         return zero if value is None else value
+
+    # A_s is the reinforcement the section carries, not a per-combination result.
+    A_s: Optional[Quantity] = getattr(beam, f"_A_s_{suffix}", None)
 
     return FlexureFaceDesign(
         layers=_layers(beam, face),
-        A_s=area(f"_A_s_{suffix}"),
-        A_s_req=area(f"_A_s_req_{suffix}"),
-        A_s_min=area(f"_A_s_min_{suffix}"),
-        A_s_max=area(f"_A_s_max_{suffix}"),
-        DCR=float(getattr(beam, f"_DCRb_{suffix}", 0.0)),
+        A_s=zero if A_s is None else A_s,
+        A_s_req=area("A_s_req"),
+        A_s_min=area("A_s_min"),
+        A_s_max=area("A_s_max"),
+        DCR=float(envelope.get("DCR", getattr(beam, f"_DCRb_{suffix}", 0.0))),
     )
 
 
@@ -172,9 +187,13 @@ def build_shear_design(beam: RectangularBeam) -> ShearDesign:
         )
     A_v: Quantity = beam._A_v
     zero: Quantity = 0 * A_v.units
+    # As in _face: the private attributes describe the combination that ran last, the
+    # envelope describes every combination that was checked.
+    envelope: Dict[str, Any] = getattr(beam, "_shear_envelope", {})
 
     def area(name: str) -> Quantity:
-        value: Optional[Quantity] = getattr(beam, name, None)
+        """Envelope value of a per-combination area, or the last one if there is none."""
+        value: Optional[Quantity] = envelope.get(name, getattr(beam, f"_{name}", None))
         return zero if value is None else value
 
     return ShearDesign(
@@ -182,7 +201,7 @@ def build_shear_design(beam: RectangularBeam) -> ShearDesign:
         d_b=beam._stirrup_d_b,
         s_l=beam._stirrup_s_l,
         A_v=A_v,
-        A_v_req=area("_A_v_req"),
-        A_v_min=area("_A_v_min"),
-        DCR=float(getattr(beam, "_DCRv", 0.0)),
+        A_v_req=area("A_v_req"),
+        A_v_min=area("A_v_min"),
+        DCR=float(envelope.get("DCR", getattr(beam, "_DCRv", 0.0))),
     )

--- a/tests/test_design_results.py
+++ b/tests/test_design_results.py
@@ -6,7 +6,7 @@ import pytest
 from pandas import DataFrame
 
 from mento import Concrete_ACI_318_19, Forces, Node, RectangularBeam, SteelBar
-from mento import MPa, cm, kN, kNm, mm
+from mento import MPa, cm, kN, kNm, m, mm
 from mento.design_results import (
     DesignNotRunError,
     FlexureDesign,
@@ -219,6 +219,27 @@ def test_shear_reports_the_combination_that_governs(
     assert shear.DCR == pytest.approx(worst, abs=TABLE_ROUNDING)
     assert shear.A_v_req.magnitude > 0
     assert shear.A_v >= shear.A_v_req
+
+
+def test_envelope_skips_quantities_the_design_code_does_not_set() -> None:
+    """A design code that leaves a quantity unset must not break the envelope.
+
+    Both codes shipped today set all of them, so this is built directly rather than
+    through a check.
+    """
+    beam = object.__new__(RectangularBeam)
+    beam._flexure_envelope = {}
+    beam._shear_envelope = {}
+    beam._A_s_req_bot = 4 * cm**2  # _A_s_min_bot and _A_s_max_bot deliberately absent
+    beam._DCRb_bot = 0.5
+    beam._A_v_req = 3 * cm**2 / m
+    beam._DCRv = 0.4
+
+    beam._update_flexure_envelope("bot")
+    beam._update_shear_envelope()
+
+    assert beam._flexure_envelope["bot"] == {"A_s_req": 4 * cm**2, "DCR": 0.5}
+    assert beam._shear_envelope == {"A_v_req": 3 * cm**2 / m, "DCR": 0.4}
 
 
 def test_envelope_resets_between_checks(beam_two_combinations: RectangularBeam) -> None:

--- a/tests/test_design_results.py
+++ b/tests/test_design_results.py
@@ -3,6 +3,7 @@
 import math
 
 import pytest
+from pandas import DataFrame
 
 from mento import Concrete_ACI_318_19, Forces, Node, RectangularBeam, SteelBar
 from mento import MPa, cm, kN, kNm, mm
@@ -156,6 +157,80 @@ def test_shear_str_without_stirrups(beam: RectangularBeam) -> None:
     assert shear.n_legs == 0
     assert shear.A_v.magnitude == 0
     assert str(shear) == "no stirrups"
+
+
+# ============================================================================
+# Several load combinations: results are the envelope, not the last one checked
+# ============================================================================
+
+
+def _table_dcr(results: DataFrame) -> list[float]:
+    """DCR of every combination in a results table, dropping the units row."""
+    return [float(value) for value in results["DCR"][1:]]
+
+
+# The tables round the DCR to three decimals; the results API keeps full precision.
+TABLE_ROUNDING = 5e-4
+
+
+def _two_combinations() -> list[Forces]:
+    """Two combinations where the *first* governs both flexure and shear.
+
+    The second one puts the top face in tension and is mild in shear, so it leaves
+    the bottom face and the stirrup requirement at zero on its way out.
+    """
+    return [
+        Forces(label="C1", V_z=90 * kN, M_y=100 * kNm),
+        Forces(label="C2", V_z=20 * kN, M_y=-30 * kNm),
+    ]
+
+
+@pytest.fixture
+def beam_two_combinations(beam: RectangularBeam) -> RectangularBeam:
+    Node(section=beam, forces=_two_combinations()).design()
+    return beam
+
+
+def test_flexure_reports_the_combination_that_governs_each_face(
+    beam_two_combinations: RectangularBeam,
+) -> None:
+    beam = beam_two_combinations
+    worst = max(_table_dcr(beam.check_flexure(_two_combinations())))
+
+    flexure = beam.flexure_design
+
+    assert flexure.DCR == pytest.approx(worst, abs=TABLE_ROUNDING)
+    assert flexure.bottom.DCR == pytest.approx(worst, abs=TABLE_ROUNDING)
+    # The last combination checked required nothing at the bottom; the governing one
+    # is what the result has to describe.
+    assert flexure.bottom.A_s_req.magnitude > 0
+    assert flexure.bottom.A_s_min.magnitude > 0
+    assert flexure.bottom.A_s >= flexure.bottom.A_s_req
+
+
+def test_shear_reports_the_combination_that_governs(
+    beam_two_combinations: RectangularBeam,
+) -> None:
+    beam = beam_two_combinations
+    worst = max(_table_dcr(beam.check_shear(_two_combinations())))
+
+    shear = beam.shear_design
+
+    assert shear.DCR == pytest.approx(worst, abs=TABLE_ROUNDING)
+    assert shear.A_v_req.magnitude > 0
+    assert shear.A_v >= shear.A_v_req
+
+
+def test_envelope_resets_between_checks(beam_two_combinations: RectangularBeam) -> None:
+    """Checking a milder set of forces afterwards must not keep the earlier worst case."""
+    beam = beam_two_combinations
+    mild = [Forces(label="C3", V_z=10 * kN, M_y=10 * kNm)]
+
+    beam.check_flexure(mild)
+    beam.check_shear(mild)
+
+    assert beam.flexure_design.DCR == pytest.approx(max(_table_dcr(beam.check_flexure(mild))), abs=TABLE_ROUNDING)
+    assert beam.shear_design.DCR == pytest.approx(max(_table_dcr(beam.check_shear(mild))), abs=TABLE_ROUNDING)
 
 
 # ============================================================================


### PR DESCRIPTION
## What

`beam.flexure_design` and `beam.shear_design` read the private attributes the check
functions leave behind, and those describe whichever load combination ran **last**. With
more than one combination — the normal case — that is not the one that governs.

The effect is a silent understatement of the result. Same beam, two combinations, the first
governing:

| | results table | `flexure_design` / `shear_design` (before) |
|---|---|---|
| Flexure, bottom face | DCR 0.942, `A_s_req` 4.84 cm² | DCR 0.000, `A_s_req` 0.00 cm² |
| Shear | DCR 0.936 | DCR 0.280, `A_v_req` 0.00 cm²/m |

A reader of the public API would have seen a beam at 28 % of its shear capacity that is
actually at 94 %, and no stirrup requirement on a beam that needs stirrups.

## How

`check_flexure` and `check_shear` fold each combination into an envelope as they iterate,
and `design_results` reads that envelope: required areas, minimum and maximum areas, and
DCRs are now the worst over every combination checked. The provided reinforcement (`A_s`,
the layers, the stirrup layout) is untouched — it belongs to the section, not to a
combination. The envelope resets at the start of every check, so a later check with milder
forces does not inherit the earlier worst case.

No public name or signature changes. Nothing released is affected: `design_results` landed
in #129 and is still under `Unreleased`.

## Tests

Three new tests in `tests/test_design_results.py` covering a beam whose first combination
governs both flexure and shear, and the reset between checks. Full suite: 594 passed,
1 skipped. ruff, `ruff format --check` and mypy clean; docs build clean with `-W`.

## How it turned up

Writing the CIRSOC examples for the documentation (etapa 4), which printed these values on
a page right next to the results table they contradicted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)