### PR TITLE
Citation metadata, conda recipe and CIRSOC examples in Spanish

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -47,7 +47,8 @@
       "PowerShell(where.exe pytest 2>&1; Get-Item \\(where.exe pytest 2>&1 | Select-Object -First 1\\) 2>&1)",
       "PowerShell($env:PYTHONIOENCODING=\"utf-8\"; C:\\\\Users\\\\mihdi\\\\anaconda3\\\\envs\\\\py312\\\\python.exe C:\\\\Users\\\\mihdi\\\\Documents\\\\GitHub\\\\mento\\\\_tmp_design.py)",
       "PowerShell(& \"C:\\\\Users\\\\mihdi\\\\anaconda3\\\\envs\\\\py312\\\\python.exe\" -c \"import importlib.metadata as m, mento; print\\(m.version\\('mento'\\)\\); print\\(mento.__file__\\)\")",
-      "PowerShell(& \"C:\\\\Users\\\\mihdi\\\\anaconda3\\\\envs\\\\py312\\\\python.exe\" -m pip show mento)"
+      "PowerShell(& \"C:\\\\Users\\\\mihdi\\\\anaconda3\\\\envs\\\\py312\\\\python.exe\" -m pip show mento)",
+      "PowerShell(& \"C:\\\\Users\\\\mihdi\\\\anaconda3\\\\envs\\\\py312\\\\python.exe\" -c \"import mento, os; print\\(os.path.dirname\\(mento.__file__\\)\\)\")"
     ]
   }
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,9 @@ repos:
       - id: trailing-whitespace  # Removes trailing whitespace
       - id: end-of-file-fixer    # Ensures files end with a newline
       - id: check-yaml           # Validates YAML files
+        # The conda recipe is a Jinja template, not plain YAML — `{% set %}` at
+        # the top of the file is not something a YAML parser can read.
+        exclude: ^conda-recipe/meta\.yaml$
       - id: check-toml           # Validates TOML files
       - id: check-merge-conflict # Catches merge conflict markers
       - id: check-added-large-files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ from the release history and are summaries rather than complete lists.
 - A conda recipe under `conda-recipe/`, kept in step with `pyproject.toml`, ready to be
   submitted to conda-forge. The submission and update procedure, and the one-time Zenodo
   setup that gives releases a DOI, are documented in CONTRIBUTING.
+- Two example notebooks in Spanish, design and check of a rectangular beam under
+  CIRSOC 201-2025.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ from the release history and are summaries rather than complete lists.
   longer have to be read from private attributes such as `_A_s_bot` or `_stirrup_s_l`.
   Reading either before running a check raises `DesignNotRunError`. See
   [Design results](https://mento-docs.readthedocs.io/en/latest/user_guide/design_results.html).
+- A [citing guide](https://mento-docs.readthedocs.io/en/latest/getting_started/citing.html)
+  in the documentation, covering which version to cite and a BibTeX entry.
+- A conda recipe under `conda-recipe/`, kept in step with `pyproject.toml`, ready to be
+  submitted to conda-forge. The submission and update procedure, and the one-time Zenodo
+  setup that gives releases a DOI, are documented in CONTRIBUTING.
 
 ### Changed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,4 +26,5 @@ keywords:
   - CIRSOC 201
   - Python
 license: MIT
-version: 0.4.1
+version: 0.5.0
+date-released: "2026-08-02"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ By participating in this project you agree to abide by our
 - [Pull request checklist](#pull-request-checklist)
 - [Project structure](#project-structure)
 - [Making a release](#making-a-release)
+- [Archiving on Zenodo](#archiving-on-zenodo)
+- [Publishing on conda-forge](#publishing-on-conda-forge)
 - [Tools we use](#tools-we-use)
 
 ## Ways to contribute
@@ -212,7 +214,8 @@ a unit assumption in new code.
 For maintainers. **Merging a pull request does not publish anything** — it only updates
 `main`. Publishing to PyPI is triggered by creating a GitHub Release, and nothing else.
 
-1. On a branch, bump `version` in `pyproject.toml` and move the `Unreleased` entries of
+1. On a branch, bump `version` in `pyproject.toml`, bump `version` and `date-released` in
+   [CITATION.cff](CITATION.cff), and move the `Unreleased` entries of
    [CHANGELOG.md](CHANGELOG.md) under the new version number. Merge that branch.
 2. On GitHub, go to Releases → *Draft a new release*, create the tag `vX.Y.Z` against
    `main` (the leading `v` matters), and publish it. "Generate release notes" gives a
@@ -229,6 +232,80 @@ done, the workflow builds everything correctly and then fails on the upload step
 
 To rehearse the build without publishing, run the workflow manually from the Actions tab —
 `workflow_dispatch` runs the build job but skips the tag check and the upload.
+
+Publishing a release also sets two things in motion that are not PyPI: Zenodo archives the
+release and mints a DOI, and conda-forge's bot proposes a feedstock update. Both are
+described below.
+
+## Archiving on Zenodo
+
+A DOI is what lets someone cite a specific version of mento in a paper or a technical report,
+and what makes the software findable outside GitHub. [Zenodo](https://zenodo.org/) mints one
+automatically for every GitHub Release, at no cost.
+
+**One-time setup, by a maintainer with admin rights on the repository:**
+
+1. Sign in to Zenodo with the GitHub account that owns the repository.
+2. Go to the [GitHub settings page](https://zenodo.org/account/settings/github/) on Zenodo
+   and flip the switch next to `mihdicaballero/mento`.
+3. Publish the next GitHub Release as usual. Zenodo receives the webhook, archives the
+   source at that tag, and issues the DOIs.
+
+Zenodo issues **two** DOIs: a *version DOI* for that specific release, and a *concept DOI*
+that always resolves to the latest version. The concept DOI is the one to advertise.
+
+**After the first archived release**, wire the DOI into the repository once:
+
+- In [CITATION.cff](CITATION.cff), add the concept DOI so GitHub's *Cite this repository*
+  button includes it:
+
+  ```yaml
+  identifiers:
+    - type: doi
+      value: 10.5281/zenodo.XXXXXXX
+      description: Concept DOI for all versions of mento
+  ```
+
+- In [README.md](README.md), add the badge Zenodo shows on the repository's Zenodo page,
+  next to the other badges:
+
+  ```markdown
+  [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.XXXXXXX.svg)](https://doi.org/10.5281/zenodo.XXXXXXX)
+  ```
+
+Because the concept DOI does not change, this is done once and not per release. Only
+`version` and `date-released` in `CITATION.cff` move with each release, which is already part
+of the release procedure above.
+
+## Publishing on conda-forge
+
+Some engineering teams install everything through conda and cannot easily mix in pip.
+[conda-forge](https://conda-forge.org/) is how mento reaches them. The recipe lives in
+[`conda-recipe/`](conda-recipe/) so that it stays in step with `pyproject.toml`; conda-forge
+itself builds from a separate repository called a *feedstock*.
+
+**First submission** (once, to create the feedstock):
+
+1. Fork [conda-forge/staged-recipes](https://github.com/conda-forge/staged-recipes).
+2. Copy `conda-recipe/meta.yaml` and `conda-recipe/conda_build_config.yaml` into
+   `recipes/mento/` on a branch of your fork.
+3. Check that `version` and `sha256` in the recipe match the release you want packaged. The
+   checksum of the sdist on PyPI is:
+
+   ```bash
+   curl -sL https://pypi.org/packages/source/m/mento/mento-0.5.0.tar.gz | sha256sum
+   ```
+
+4. Open a pull request against `staged-recipes`. A conda-forge reviewer will comment; expect
+   a round or two on dependency names. When it merges, the bot creates
+   `conda-forge/mento-feedstock` and lists you as maintainer.
+
+**Every release after that** is mostly automatic: within a day of the sdist appearing on
+PyPI, `regro-cf-autotick-bot` opens a pull request on the feedstock with the new version and
+checksum. Review it — the bot updates the version but not the dependencies — and merge.
+
+When mento's runtime dependencies change in `pyproject.toml`, update `conda-recipe/meta.yaml`
+in the same pull request, so the copy here does not drift from what the feedstock needs.
 
 ## Tools we use
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Participation in this project is governed by our [Code of Conduct](CODE_OF_CONDU
 mento is a tool to assist structural engineers, not a replacement for engineering judgement. Results must be reviewed and accepted by a qualified engineer who takes responsibility for the design. The software is provided "as is", without warranty of any kind, and the authors accept no liability for its use. Verify the output against the applicable design code before relying on it for any real structure.
 
 #### Citing mento
-If mento supports your research or professional work, citation metadata is in [CITATION.cff](CITATION.cff), and GitHub's "Cite this repository" button will format it for you.
+If mento supports your research or professional work, citation metadata is in [CITATION.cff](CITATION.cff), and GitHub's "Cite this repository" button will format it for you. The [citing guide](https://mento-docs.readthedocs.io/en/latest/getting_started/citing.html) explains which version to cite and gives a BibTeX entry.
 
 #### License
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for the full text.

--- a/conda-recipe/README.md
+++ b/conda-recipe/README.md
@@ -1,0 +1,12 @@
+# conda-forge recipe
+
+This directory holds the conda recipe for mento. It is **not** used to build anything in
+this repository: conda-forge builds packages from its own feedstock, and this is the copy we
+keep in step with `pyproject.toml` so that submitting or updating the recipe is a copy, not a
+rewrite.
+
+- `meta.yaml` — the recipe itself, pinned to a released version on PyPI and its sha256.
+- `conda_build_config.yaml` — raises `python_min` to 3.10, mento's minimum.
+
+The submission and update procedure is in
+[CONTRIBUTING.md](../CONTRIBUTING.md#publishing-on-conda-forge).

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,0 +1,5 @@
+# mento requires Python 3.10 or newer (requires-python in pyproject.toml), which is
+# higher than the python_min conda-forge pins globally. Overriding it here keeps the
+# noarch package from advertising support for versions the project does not test.
+python_min:
+  - "3.10"

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,67 @@
+{% set name = "mento" %}
+{% set version = "0.5.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d8a20ce32e0f25c1ab614755190fa80ae329cf342ee22ace5b34c7ece13c75e7
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - setuptools >=64
+    - wheel
+    - pip
+  run:
+    - python >={{ python_min }}
+    # Keep in step with [project.dependencies] in pyproject.toml. The conda-forge
+    # names differ from the PyPI ones in three places: matplotlib-base and
+    # seaborn-base are the light variants (mento only uses seaborn for plot
+    # theming), and IPython is packaged as ipython.
+    - pint >=0.24
+    - numpy >=1.26
+    - pandas >=2.0
+    - matplotlib-base >=3.8
+    - seaborn-base >=0.13
+    - tabulate >=0.9
+    - python-docx >=1.1
+    - openpyxl >=3.1
+    - jinja2 >=3.1
+    - ipython >=8.0
+
+test:
+  imports:
+    - mento
+    - mento.codes
+  requires:
+    - python {{ python_min }}
+    - pip
+  commands:
+    - pip check
+
+about:
+  homepage: https://github.com/mihdicaballero/mento
+  summary: An intuitive tool for structural engineers to design concrete elements efficiently.
+  description: |
+    mento designs and verifies reinforced concrete elements — beams, one way slabs,
+    shear walls and two way slab punching — against ACI 318-19, EN 1992-2004 and
+    CIRSOC 201-2025. Calculations are unit aware through pint, results come back as
+    pandas DataFrames for batch work, and detailed calculation reports can be
+    exported to Word.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://mento-docs.readthedocs.io/
+  dev_url: https://github.com/mihdicaballero/mento
+
+extra:
+  recipe-maintainers:
+    - mihdicaballero

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -22,3 +22,16 @@ In this folder, you will find detailed examples of how to use mento.
    shear_wall_design_ACI_318-19
    shear_wall_summary_ACI_318-19
    shear_wall_summary_ACI_318-19 Design
+
+Ejemplos en español
+-------------------
+
+mento is, as far as we know, the only open source package that implements CIRSOC 201-2025,
+the Argentinian concrete design standard. These two examples are written in Spanish, for the
+engineers who work with it every day.
+
+.. toctree::
+   :maxdepth: 1
+
+   viga_rectangular_diseno_CIRSOC_201-25
+   viga_rectangular_verificacion_CIRSOC_201-25

--- a/docs/source/examples/viga_rectangular_diseno_CIRSOC_201-25.ipynb
+++ b/docs/source/examples/viga_rectangular_diseno_CIRSOC_201-25.ipynb
@@ -1,0 +1,798 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mihdicaballero/mento/blob/main/docs/source/examples/viga_rectangular_diseno_CIRSOC_201-25.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:21.082932Z",
+     "iopub.status.busy": "2026-08-13T02:49:21.082932Z",
+     "iopub.status.idle": "2026-08-13T02:49:21.087436Z",
+     "shell.execute_reply": "2026-08-13T02:49:21.086932Z"
+    },
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Google Colab no trae mento instalado, así que lo instalamos sólo cuando el\n",
+    "# notebook corre allí. La guarda evita que la documentación llame a pip.\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install mento"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Diseño de viga rectangular — CIRSOC 201-25\n",
+    "\n",
+    "Este ejemplo dimensiona la armadura de una viga rectangular de hormigón armado según el\n",
+    "**CIRSOC 201-2025**, el reglamento argentino. mento la implementa en `Concrete_CIRSOC_201_25`,\n",
+    "que comparte las expresiones del ACI 318-19 y trabaja siempre en unidades métricas.\n",
+    "\n",
+    "*Diseñar* significa que mento elige la armadura: le damos la sección, los materiales y los\n",
+    "estados de carga, y devuelve las barras longitudinales y los estribos necesarios. Si en\n",
+    "cambio ya tenés la armadura y querés verificarla, mirá el ejemplo de\n",
+    "[verificación](viga_rectangular_verificacion_CIRSOC_201-25.ipynb).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Materiales y geometría de la sección**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:21.088439Z",
+     "iopub.status.busy": "2026-08-13T02:49:21.088439Z",
+     "iopub.status.idle": "2026-08-13T02:49:22.330561Z",
+     "shell.execute_reply": "2026-08-13T02:49:22.330561Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "Beam V101, $b$=20.00 cm, $h$=50.00 cm, $c_{c}$=2.50 cm,                             Concrete H-25, Rebar ADN 420."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from mento import Concrete_CIRSOC_201_25, SteelBar, RectangularBeam, cm, kN, MPa, kNm\n",
+    "from mento import Forces, Node\n",
+    "\n",
+    "# Materiales\n",
+    "hormigon = Concrete_CIRSOC_201_25(name=\"H-25\", f_c=25 * MPa)\n",
+    "acero = SteelBar(name=\"ADN 420\", f_y=420 * MPa)\n",
+    "\n",
+    "# Geometría de la viga: ancho, altura y recubrimiento\n",
+    "viga = RectangularBeam(\n",
+    "    label=\"V101\",\n",
+    "    concrete=hormigon,\n",
+    "    steel_bar=acero,\n",
+    "    width=20 * cm,\n",
+    "    height=50 * cm,\n",
+    "    c_c=2.5 * cm,\n",
+    ")\n",
+    "viga.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Estados de carga**\n",
+    "\n",
+    "Cada `Forces` es una combinación mayorada. `M_y` es el momento flector y `V_z` el esfuerzo de\n",
+    "corte; el signo del momento distingue la cara traccionada (positivo tracciona abajo)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:22.358564Z",
+     "iopub.status.busy": "2026-08-13T02:49:22.358564Z",
+     "iopub.status.idle": "2026-08-13T02:49:22.362800Z",
+     "shell.execute_reply": "2026-08-13T02:49:22.362800Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Force ID: 1, Label: 1.2D+1.6L, N_x: 0.00 kN, V_z: 70.00 kN, M_y: 80.00 kN·m\n",
+      "Force ID: 2, Label: 1.2D+1.6L+W, N_x: 0.00 kN, V_z: 45.00 kN, M_y: -35.00 kN·m\n"
+     ]
+    }
+   ],
+   "source": [
+    "f1 = Forces(label=\"1.2D+1.6L\", M_y=80 * kNm, V_z=70 * kN)\n",
+    "f2 = Forces(label=\"1.2D+1.6L+W\", M_y=-35 * kNm, V_z=45 * kN)\n",
+    "print(f1)\n",
+    "print(f2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Nodo: sección más estados de carga**\n",
+    "\n",
+    "El `Node` une la sección con la lista de combinaciones. Es sobre el nodo donde se corre el\n",
+    "diseño, y mento dimensiona para la combinación más exigente de la lista."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:22.364811Z",
+     "iopub.status.busy": "2026-08-13T02:49:22.363804Z",
+     "iopub.status.idle": "2026-08-13T02:49:22.368691Z",
+     "shell.execute_reply": "2026-08-13T02:49:22.368691Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Node ID: 1 - Section label: V101\n",
+       "Forces Applied:\n",
+       "  - Force ID: 1, Label: 1.2D+1.6L, N_x: 0.00 kN, V_z: 70.00 kN, M_y: 80.00 kN·m\n",
+       "  - Force ID: 2, Label: 1.2D+1.6L+W, N_x: 0.00 kN, V_z: 45.00 kN, M_y: -35.00 kN·m"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nodo = Node(section=viga, forces=[f1, f2])\n",
+    "nodo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Diseño a flexión y corte**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:22.370695Z",
+     "iopub.status.busy": "2026-08-13T02:49:22.370695Z",
+     "iopub.status.idle": "2026-08-13T02:49:22.803978Z",
+     "shell.execute_reply": "2026-08-13T02:49:22.803978Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "Beam V101, $b$=20.00 cm, $h$=50.00 cm, $c_{c}$=2.50 cm,                             Concrete H-25, Rebar ADN 420."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "Top longitudinal rebar: 2Ø12+1Ø10, $A_{s,top}$ = 3.05 cm², $M_u$ = -35 kNm, $\\phi M_n$ = 51.63 kNm → $\\color{#439b00}{\\text{DCR}=0.68}$ \n",
+       "\n",
+       "Bottom longitudinal rebar: 2Ø16+1Ø12, $A_{s,bot}$ = 5.15 cm², $M_u$ = 80 kNm, $\\phi M_n$ = 84.91 kNm → $\\color{#439b00}{\\text{DCR}=0.94}$ "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "Shear reinforcing 1eØ6/22 cm, $A_v$=2.57 cm²/m, $V_u$=70 kN, $\\phi V_n$=96.19 kN → $\\color{#439b00}{\\text{DCR}=0.73}$ "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Dimensiona armadura longitudinal y estribos\n",
+    "nodo.design()\n",
+    "\n",
+    "# Resumen de resultados\n",
+    "nodo.results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:22.805982Z",
+     "iopub.status.busy": "2026-08-13T02:49:22.804989Z",
+     "iopub.status.idle": "2026-08-13T02:49:22.864843Z",
+     "shell.execute_reply": "2026-08-13T02:49:22.864843Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAARMAAAGFCAYAAADelhfmAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAJdJJREFUeJzt3Qd4FNX6x/E3IYEkkNClV6nSQaQJ6KUXQUBEBRWVS5EmKor8VaRJEVAUQTqWq6CIgshFqiDSQar00CQgPQQIqft/3sPdvUkI3ARONtnk+3mefXZ3drM7s7vzm/ecMzPxcjgcDgGAe+R9ry8AAIQJAGuoTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsMJHMqinnnpKLl68mNqzgf8hV65cMnfuXD4nD5Bhw0SDRC85cuRI7VnBbVy+fJnPxoNk2DBRGiRz5sxJ7dnAbXTt2pXPxoPQZwLAinQRJiFnKYeB1ObxYbJp1xEp2fwNGTV9cWrPCpCheXyYjJ31b3M9bf4aiY6OSe3ZATIsjw6TvYdPyc9rd5nbp8+Fyrylm1N7loAMy6PD5P3pi6Vwvpzmds2KJWTUjJ+pToBU4u3JVcn3y7dJn2camfudmteUwyfOUp0AqcRjw2T0zCVSrGBu6dDkQXP//iL3SeuGVUx1AsD9PDZMyhbPL5MGdxFfn0yuaSP7tZe6VUul6nwBGZXH7gH7do/HzPWZ86GuaWVLFJBp77HXJJAaPDZM0rKYmFhxSMbik8lji1xYQpjco4ioaFn3xxFZun6/7Dl8Wry8vCSTt5d4e3tJRuFwiERrgDocUjR/Tmlet5w0eqisBGXzS+1ZgxsRJvdQfYz9fKX8uu2w/KNWeen1dGOpV7W0ZMrAW2gNkz2HTsl3yzZLl7e/lGIFcsr7fVpLYFbPCpVLly5Jzpw3dznwVJdSYRkIk7sMkrc++UmKFrpPdi0Y7goQXZkuh12X0LBwcbi5oRMTEyOXLl6QwKDskiVLFnG3bP5ZJGdQVqlUprC5DO3dTr7+eaP8c/hcmf7OU24LlFmzZsnq1avl2LFj5nOoXLmy9OvXT4oXLx7veX/88YfMnDlTdu/eLZGRkebxTp06ydWrV2XHjh0ybtw48zx9zrp16+TAgQPi6+sra9asifc6Bw8eNEee79ixw5wyoUCBAtKhQwd55pln7noZVq1aJfPnz5f9+/dLaGiofP3111K2bNlbnmdrGdTp06dl1KhRsnXrVgkICJDWrVtLnz59xMcn6RFBmCRTbKzDBEmxwvnk/f4dTLNmy56jMu/fm2XBim0Scs79Bx1mlwuSX/4SH69oiXV4y3nJJ+ekgIi4t6mVPZu/GZ5/oumD0vzhStK5dR3z+ZhAefdpCQxI+ZDbvn27dOzYUSpUqGACdtKkSdK7d2+zcvr7+5vnrFixQgYPHiytWrWSqVOnmum6En388cfm8YULF7peLyoqSho3biyVKlWKN91p3759pgIYPny45MuXT3bt2iUjRoyQTJkymRU7MfqeISEhMnTo0EQfDw8Pl6pVq0qTJk3MayXG5jLo59S/f3/JkyePzJ49W86fPy/vvvuuCRINlKQiTJJp+/6TEhnjcAXJ7B/XSb9h06WwX6gUDoiSamVyS/WadaRU2QfM4ynt5LEj8vWsSa773l6xcp+clqea15KadRuKO5w+dVI2r18rp08Hy9bVwfL9zyvl+SdbyUdvPi3PtKotR0+dkwUrd8jzj9VK8XnR8IhLV1hdkXSlr169ullR33//fXn44YdlyJAhrudFRERI8+bNZcGCBWaL36BBAzO9Z8+e5nrRokWJvl/btm3j3S9cuLAJFK0ubhcm/4sGhNLASYztZdi4caMcPXpUpkyZIrlz5zZVUK9evUww9ejRw1QzSUGYJNPS9fvkuTb1TFDM/fcmGTBsipTzOSISFSPXLsVKeOhZOXZor7Rv316ef/55SWnjV/wg3t7eEhsbG2/6nzs2Sv9eL6T4+69du1a+nPahmQfdwmX29pb7vUJk7rcR4p/FV0YP6ChdWteVZwdNdUuYJKQlvwoKCjLXGzZsME2HuN+Nlvi6RR42bJhptixevNi1It7te2bPnl1Siu1l0PArVaqUCRKnOnXqmGbPkSNHpFy5ckl6nYzbW3iXTZx1fwRLkzoVzP0xM5dI2axnRRwxrpXZea1bB223p7SwsLBbgsQ5PaXduHFDPv30U9NXpEGinPNSzPcvmfLNcrlyNdzsqaw9SGcuXBF30nnRfoMqVaqYlUWdOHHCXJcoUcJcaz+HNlEGDhxotsB58+aV4ODgu37PnTt3yrJly6Rdu3aSUmwvw4ULF8y5duNy3tfHkorKJBl2Hw6RymWLiL9fZtkXHCKHgo9LWa/ET0qtW+rff//9lo4/26pVq2Y623SFjvveDz548zCDlKQrjgZKYmKioySz47IsXrPTNHUe/0d1WbnpoHRumfLz5TR69GizZdUOyIR0pdPmwqBBg0x/gXPluZcQPnz4sLz66qvSvXt3s2V30iZH37594/Vh6Pe1cuVK1zTt/2jZsmWy3i8lluFeECbJcPr8FSldNJ+5vWrTPsni4yVym1OoaDMoOjpaUpq2kdevX296/rXTTysE7RB89tlnU/y9daW4k6L5ssuqzftMmJQulk9Wbdgt7jJmzBgzgjF9+nTTMeqap6JFXSu+jvxoBVG+fHlXJaNb9MRGTv6X4OBg08+gzdtu3brFe0xf/5tvvnHd19vnzp0zo0xOCSuDO7G9DNq82bt3b7xpzv/cELfp878QJskQejVccmbPam5fuHxNAoNySV6fvOaHkZCu1Fo1pDQd/hw5cqRs2rTJbIXz589vOuZ0eC+lVaxYMdH+GqXTcxcsJhcu3eyzyBEUIFeuJV7F2KRb/LFjx5rh4WnTpkmhQoXiPa4Vg/ZnDBgwQNq0aSPNmjVzPabNk7///jtZIxhKP/eePXua4VQdOUrIz89PihQp4rqv73/t2rV405LD9jLo8LmGkgaIM9T095Q1a1YpWbJkkl+HPpNkiIyKEb/MN3u2I6OjJXNmH3nppZdufpDe3vGqEh050KE4d9AhvHr16slzzz0nTZs2dUuQOM/u/8QTT5jbzpEr57VO9w/IJpFRN6sz/dyiom8NnZRo2ixZssQErH4OOsypF2dzTIdQa9eubXbqOnPmjOzZs0dOnTol33//vRkhadiwobRo0SJex6bun6HP1dDU23q5fv26qzrQEY/atWtL586dXe+nr3+3tHNV38PZ73H8+HFzX183JZZBX0v7X9555x3TeauV7uTJk+XJJ5+UzJkzJ3m+qUzukW4ldPjxu+++k0OHDklgYKDZUmjp6Y6h4dSmO2dpNfTjjz+aLaI2KXS4tFGjRrJx7Pdunx/dn0Rpv0VcOoSqW3Edsv3rr7/MyMfnn39utuAaNDqk++KLL0qXLl3ifW+fffaZGRlxcu6Mpvt2aL+U9nvoSr1kyRJzcdKd1+L+XXLoTmVx90F56623XMukwWV7GbR5PHHiRDN6o/9eRMNKqyznkHJSeTni9tx5ID1quHjTgfLDxD7Son7lJP+dbsE1pZPzf3O+/HmL5MyRQ3p2elTe/mSBfPvvTbJq2n871hBf3zHzJTLaIT9PGSCbdwfLJ18tk1F9Wyf5Y9IftlZ8Wrrbov1YukV2DhV7oug0ugw0c5ChaJMwra2E6WUZCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQKAMAGQdlCZALCCMAFgBWECwArCBIAVhAkAKwgTAFYQJgCsIEwAWEGYALCCMAFgBWECwArCBIAVhAkAKwgTAFYQJgCsIEwAWEGYALCCMAFgBWECwArCBIAVhAkAKwgTAFYQJgCsIEwAWEGYALCCMAFgBWECwArCBIAVhAkAKwgTAFYQJgCsIEwAWEGYALCCMAFgBWECwArCBIAVhAkAKwgTAFYQJgCsIEwAWEGYALCCMAFgBWECwArCBIAVhAkAKwgTAFYQJgCsIEwAWEGYALCCMAFgBWECwArCBIAVhAkAKwgTAFYQJgCs8BE3ioiIkHnz5snWrVvl4sWLEhsbG+/xr7/+2p2zA8BTw2TYsGGyceNGadSokVSoUEG8vLzc+fYA0kuY/Pbbb/Lxxx9L1apV3fm2ANJbn8l9990nWbNmdedbAkiPYTJgwABTmZw+fdqdbwsgvTVzHnjgAdMJ26ZNG/Hz8xMfn/hvv3r1anfODgBPDZPBgwfLuXPnpHfv3pIrVy46YIF0xK1hsnPnTpkzZ46UKVPGnW8LIL31mRQvXtw0cwCkP24Nk759+8qHH35odlq7fPmyXL16Nd4FgOfycXeYqF69esWb7nA4TP/Jli1b3Dk7ADw1TKZOnerOtwOQXsOkRo0a7nw7AOm1z2TRokWyfPnyW6brtJ9++smdswLctbCwMImJieETTM0wmT17tuTIkeOW6brPiT4G2LB9+3Z55ZVXpFmzZqYavpudIaOjo+WLL76QJ598UurUqSOPPPKIvPrqq7J7927T97du3TrXcyMjI+XTTz+VVq1aSe3ataV169aycOHCW15z2rRp8vbbb0toaKiMHTtW2rdvL3Xr1pWWLVua+xpSTgcPHjT7Zelj+pwOHTqk+aPq3drMOXPmjBQqVOiW6QUKFDCPATaEh4ebfZl0T+uBAwcm++91QGDQoEFmQKBfv35Sq1YtM/qoAdG1a1dp27atNGzY0PV8fe6FCxfk3XfflSJFisj58+dvOb2G+vXXX83f646betHAK1GihDm8ZNSoUebvNFTUvn37JGfOnDJ8+HDJly+f7Nq1S0aMGCGZMmWSTp06iWT0MNEP59ChQ1KwYMF40zWFs2fP7s5ZQTpWr149c7kdZyXxyy+/mGrg/vvvN6Hx4IMPmsd1ulYz48aNk0cffdRMK1y4sGzatMlUH7///rt5jcyZM8v69etl27Ztpgnv/A0n/H0r3VgGBwebKiNbtmzywQcfuB7TAHr55ZflnXfeMRWRHmaigRWXvr8GyqpVq9JsmLi1mdO8eXPzIWria5tTL5s3bzZfWtOmTd05K8jAxowZY5orWg3MnTtXGjdubJouJ06cMI8vW7ZMihYt6goStWDBAtNE7969u6kg9Lw8as2aNeaYs88//9z8vtu1a2f2pbpx40a891y7dq1pcmmQJEb3s9Ij6hMer5bwOWl5o+vWykT3LwkJCTHXWq45S0pN+z59+rhzVpBBaZNCO/t//vlnyZs3r5n23HPPyYYNG0x1ob/D48ePm+ZH3OaJVtRvvvmmaw/uo0ePSoMGDeTUqVOyY8cOU6XoRlGbQ6NHjzb9Iu+9916819B+l8RcunRJZsyYYfpQ7nQoiobcxIkTJa1ya5j4+vqaD1q3AAcOHJAsWbJI6dKlTZ8J4A6HDx82FbFWEHFpsyXuVt9ZIehK/N1338lHH31k7sftJFXaN6I7XI4YMUICAwPNNO2ofeONN0xfih4drxWFdgprn0pC+lj//v2lZMmSpuq53Tzra+rj2hmcVrk1TJy0hNQLkBqds1oVf/XVV67q2Mnf39/1+zx27JipPrRJNGnSJLMhVEeOHHH1c6g8efKYCifwP0GitKrRivvs2bPmtbRfRcMif/788d7v2rVrpnmlzRutapzvEZf2s2glr1VLt27dJC3j7PTIUMqWLWsqE21aaCDEvWgwKO370NDQJo92iuquC046XBwUFGSGgJWeglRHZq5fv+56jjaTvL29zZkFnU2cuKM/zopET8WhATJhwgRTpSek89CjRw8z1KzPTetSpTIBUpKu2CdPnnTd1346bVZrCBQrVkxatGhhmhx65j8NFw0WHQjQJnf9+vXNULBWKVeuXDHNHL2tfSW6n4cOHmiTJiAgwBU82t/x3nvvSc+ePU2fifZrOE8ApqMzWpk8++yztwSJdtLq0K9WKHpxjnhqxaRNG309bdZ07tzZdPoqfUyfkxYRJkh3/vzzT7NFd9Itv9It/NChQ2XIkCEyc+ZMM+qiTREdpalUqZIJEqXBoP0T2nTR/hINB60gKlasKFOmTIl3WIiGig4zf/DBB9KlSxfzWjo6pEO9SvtK9Dnly5d3/c3+/ftlz5495vbjjz8eb961c1iHlleuXGlCbsmSJebipP2LixcvlrSIMEG6o/uL6L4ft6PBoFt9vSRGw8a59U/YUZsY7SOZPHlyoo9pE8cZUkmdP6VhGDcQPYFbw0TTWHe80b0FVe7cuaVy5com8YG0wmYzolSpUqbqyQjcEib63/t0t2Ztf2qPtrNDS6drCVqlShVTJsbt6ALSg/Z32HckvXFLmOi+JToeP3/+fHPqxrh0CE7/058+x3lcAgDP45ahYd27UPceTBgkSqdp1aLPAeC53BIm2uHlHPpKjD6W2A47ADyHW8JED+LTHnI94jHuiaP1tk7T4TodrwfgudzSZ6LHFWifiZ7sRfc+dFYhUVFRZiccPdxaz+0AwHO5JUz0iEoNEj1nhJ70Je7QsO7Mc7vDsgF4DrfuZ6KhUbNmTXe+JYD0vAesHrmpJ5HW4yf04Co9V2di54YF4Dnc0gH7xBNPmJPFOE9f17FjRxk/frw5DZ7+Lx29ryeZAeC53BImumOa818D6Lkh9NBsPVhJD+fWaz1aUw+WAuC53H4+Ez02x3lEptIjKvWAJj31HQDP5bYw0VPbOU+P5zwJjZNWKnoeCACey20dsHq4t+5Tonu76pmo9GjKuCf5Tctn3QaQRsIk4YlynefajPtvAKpVq+aOWQGQnsIkIfZ+BTwfJ5QGYAVhAsAKwgSAFYQJACsIEwBWECYArCBMAFhBmACwgjABYAVhAsAKwgSAFYQJACsIEwBWECYArCBMAFhBmACwgjABYAVhAsAKwgSAFYQJACsIEwCECYC0g8oEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKzwsfMyOH/+vKxYsUJOnjwpWbJkkdq1a0uNGjUkU6ZM6fbDcTgccvDgQVm9erVcuXJFcufOLY0aNZLixYuLJ7t06ZLkzJlTPNmlVFgGwsSCxYsXy4wZM8TLy8s1beXKlVKkSBEZOnSoWcnSm4iICBk3bpxs3rzZBGZsbKx4e3vLokWLpEmTJtKrV69Uma9Zs2aZcDt27JgJ9cqVK0u/fv1uCbg//vhDZs6cKbt375bIyEjzeKdOneTq1auyY8cOs2xKn7Nu3To5cOCA+Pr6ypo1axJ930WLFsm//vUvOXHihGTNmlUaN24sgwYNuqtl2L59u3zxxReyb98+s5HSeXn00Udved6hQ4dk+vTpsnXrVrl+/boULFhQ2rZtKwUKFJAvv/zSvIb+JhcsWCBLly6V/fv3y7Vr1+TXX3+VwMBA1+uEhISY3++WLVvkwoULkidPHmnZsqW89NJLZpmTijC5Rxs2bDBfqHNLHdepU6fkvffek48++ijdVShTpkwxPz4VExMT73r58uWSI0cOEfFz+3zpitixY0epUKGCmZ9JkyZJ7969Zf78+eLv72+eoxXk4MGDpVWrVjJ16lQzXVfIjz/+2Dy+cOFC1+tFRUWZYKhUqVK86XF99dVX5tK/f3+pWLGi3Lhxw6ygt6PBoxugadOmJfp4eHi4lClTRtq0aSMDBw5M9Dk7d+6Ul19+WWrWrCkTJ040n/fevXvN8p49e1Z++OEH18ZN56dOnTrmoo8npMGrGwP9THQDeOTIERkxYoSZjwEDBkhSESb3aN68eeZLSxgkSr8g3VLpD1y/9JSkW5y///5bcuXK9Z8VOeWcO3fObN0SW+a4K0zequ3c/hNLuLJoZahhoFv56tWrmxXk/fffl4cffliGDBkSr9Jq3ry52Ypr1dKgQQMzvWfPnq7lSYw27yZPnmw2GA899JBreunSpe96GerVq2cut6Of+7Bhw0w1NWHCBFMRKq0i6tata6qn3377TZ566ikz/ZlnnjHXGpiJ0b/Ri1PhwoXl+PHjJoCTEyZ0wCaDt5eXRMfEmtte4iWOqHA5evToHVcqrUi0ekkp0dHRphR//vnnzRfftWtXGTVqlPmRpxRnRXInunKGXwoRb++bW8eYWIfrtjtps0UFBQWZa/0uQkNDzefldPr0aZk9e7b5/LSy0KohqTZu3Gi+/7Nnz0qHDh2kRYsW8uabb8qZM2ckpWiTS6uJLl26uIJEv+/x48dL3759pVatWslahtt9bs7PLKkIk2QIzJpFrlwNN7ezB/rLtfCbt+9Ef2i6YqUUbWL99NNPphx3vp/2Y+gW+U4hdy90eeL2D93O9fAbkj1bgLl95ep1yRaQWdxJK0Ptb6hSpYqUKlXKTNNKUZUoUcJcX758WYYPH26aE7plz5s3rwQHByf5PbQpq+8za9Ysee2112Ts2LFmxdYmiPM7sS3hMuj38c4775jmnPaFaJ9HcpYhIR1EmDt3rrRv3z5Zf0czJxmyZ/OXgydPmdsPlCwol647pGiWzBIVGXnHv9N2aErQLeyyZctuCQ39cR8+fNh0LmoHpG26PPoe/8uRsxHSomVBc/vsxTDJntW9fSijR4827X+t3BLS4NAmj3aSal+HNg9VWFhYst5DP3utDgcOHGj6JJQ2o5o2bWoqOG0+aOWj/ThO2pejf6NNLacXX3zRXJJDl0G/Bw0SfX1nJ7OzGrsbWmH16dPHNA0JkxRUrWxhGf/lavMDalS7vARlyyr3FSgvp4N333bl0ufq6EZKbaFu975aOejWKSXCpFq1ambl0+HHxKofLb3z5Csoe0N8pEPjGmbaL7/vlo7/qCTuMmbMGDMKo5Vbvnz5XNOLFi1qrjVstZpo166dlC9f3kzTz1I/s7Jlyyb5fbQKUCVLlnRN0yFZ7bdyNnW02vnmm29cj69atcqM9o0cOdI1LTlNCufGSZvY3377rZn/uMGky3Y3GzDtC+vRo4ep5N5+++1k/z3NnGQIyuYnBfMGyZ5DpyRLZl/p0KSGrD/hK9lz5na1XZ2czYBu3bql2NDwnTpadSVPqY5Y7QfS/gVd5oTLrfd1ixkcUUiqlisi5UoWkPAbkbJz/0mpVi5lKrSEy61BosPDn332mRQqVCje41o9ZM+e3cy/NhOaNWvmekyrPO3ETk7464qnjh8/Hq9i1OaTDtEqHx8fs3I7Lxo2fn5+8abpPCVVuXLlTBWilZdWUi+88ILrsV27dpmRHq2MkluRdO/e3QSTdkwn/F6TgjBJpmZ1ysn8ZTc7IMe93klqVCojO8KKSYGSlcQ383/7BPSHqiV069atJaXoj1BHDRILsoCAALPjXErRikd/zFWrVnVN0/nIX7SMnPWvKt5+OeTb8S+b6cvW75WHq5V0SwesztOSJUvMVl8/A91PQy86PKp0GFg/F62qtHLYs2eP6ff4/vvvTfOkYcOGphPVSZso2uGpz9XKRW/rRffrUMWKFTN/M27cOLMSa1WgK6Ou7A8++OBdLYO+tvN9lA4z622dF+f3+8gjj5hl0NDS0Sd97JdffpHXX3/dDItr56yTLr/+vfaFKJ1Hva+hFzdI8ufPL6+88op5Xefnlhz0mSRT41plpdOgOdLmH9WkxgPF5YeJfeT1cfPk++Xb5EpEBcnp7yVZA/xl5zV/2Tl7q4heUpBXzH0SICfFW26IQ3RldYhDvOV8lnLSst/N/V9SVi6RvA3k+vVrcvFqtBz4K4s0rVtBJrzxlBQtkFtOn7sswz9bKKP6plyoxqXDmUpXjrh0Bdf9NrSJ8ddff5nRm88//9z0D2jQ6HCo9lnoShi3c1mrm7gjI85hVt0/xRkWOkw7YcIE0/eigapD0J988kmydviK688//zTNDSd9baUbJu1Y1/1JdDl0/nXXBO2v0QpFm3OPPfaY2dlMd9hz0qCMu0+LVstxPxMdkdKg0UvcIFXbtm1L8nx7OVKqy99NzpwPleJNB5qVukX9pPcPaBmoW5o5c+Yk+z2PnrogfcbMl1kjXjKBoiIio2TVpn3y55EQCb0aLrFu/FhjY2Lk7xMHJOzSWfHLGiQFSjwgvpnd29kZGOAnxQvlkeb1Kkr2wJsjOBokbfpMlFe7PCL1q92f7NfUYW5dObX5YYt2fOqWP7nDnmnNpTS4yz+VyV0oUSi3THrzCXnh/2bI442qyxNNa0ql0oVNmCUn0NKr4yEXZMGKrTLnx3Uy6IXGdxUkKUX7Lzw9SFRaCxJFmNxDoMwb3VVWbD4ogz/8VkLOXZH6NcrIfbmDzL4VPpkyTneUFrdajV0MvSrrdxw2O/c1q1NWZg55WvLn9vwVF0lDmNyDwKx+0u7RyuYSdu2G/HHgLwkNuyFXroa5tZmTFmQLyCIFS+aVJxtXIkAyKMLEYrA0qH5zL0sgI/LYWnzngZNy6cq1eNOioqJNmQ3A/Tw2TF4dO1f+OST+SMzY2Uvlsd4TU22egIzMY8PkxXYPy+I1O2XP4ZvHyly7HiGf/GuFvPD4f3crBuA+HhsmnZo/JKWK3icffXlzH4TFa3fKjcgoea3rf3ePBuA+HhsmPj6Z5K1urWTFhj/N/Z9+3Snd2jeQAnlT9sRAANJZmDirkxKFbh61GRUdTVUCpCKPDhOtTvp1vnmEZ9O6FalKgFTk8fuZdOtQXzbsPCyjXnkitWcFyNA8Pkx8fX3ki1H/TO3ZADI8j27mAEg7PL4yuRd6Yhk9zB1p9/txnpsVaV+GDRN+pJ7xHfE9eQ6PPzkSgLSBPhMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCJPb0P9G9/oH8yRX3T6cpNqy0LDrkrteX+n85lTZ+5/TbsLzsQdsIiEyfs4vMmPBWvHL7Ct9OzeWN15obo5Ohj1f/rReRkz9yfz3vw5Nasjgf7aWCqUK8RF7MMLkP079fUn6j/5alq3fI74+PtLm0arSqkFlyer/338ADbuiY2Lk180H5LtlW+TsxTCpW7WUjOzXXupU5f8PeSLC5D+eHTRNvlu2NXW/DZiThO/5cQSfhAciTOL8A68ZC36Tj79aLkdPnZfGdR6QV7o0kYqlC6fuN5SOnTp7ST79ZpV898sW8x8Ru3dsaD7zHEFZU3vWcBcIkwSio2Pk21+2yPvTF8vhE2eldcMqMmPYC5IjMOBuPl8kIjY2Vl4f961Mn79GsmfzlwHPNZUeTz4i2QL8+Lw8GGFyh1CZt3SzzP5xnYwf+JRUKVvEvd9MOqb/5P3xfp9Iy/qVCJF0hDABYAX7mQCwgjABYAVhAsAKwgSAFYQJACsIEwBWECYArCBMAFjBcfWpaNasWbJ69Wo5duyYZMmSRSpXriz9+vWT4sWLu54TEREhH374oSxbtkwiIyOlTp06MmjQIMmdO3dqzjpwCyqTVLR9+3bp2LGjzJkzRyZPnizR0dHSu3dvCQ8Pdz1n/PjxsnbtWhk9erRMnz5dzp07JwMHDkzN2QYSp/8eFGnDxYsXHdWrV3ds27bN3L9y5YrjoYcecixfvtz1nODgYPOcXbt23fZ1IiIiHBMnTnS0aNHCUatWLUebNm0cP/zwg3lsy5Yt5u9///13x9NPP+2oU6eOo3v37o4LFy441q1b52jfvr2jfv36jrfeestx/fp1Nyw10guaOWnI1atXzXVQUJC53rdvn6lWatWq5XpOiRIlJH/+/LJr1y6pVKlSoq/z7rvvmsdff/11KVOmjISEhMjly5fjPWfatGnyxhtviJ+fn2k26cXX11dGjhxpKqPXXntN5s2bJ127dk3RZUb6QZikocPyx40bJ1WqVJFSpW6eaezChQtmBQ8MDIz3XO0v0ccSc/z4cVm+fLlpNjlDqHDhW8/J8vLLL0vVqlXN7bZt28qkSZNk4cKFruc2btxYtm7dSpggyegzSSO0T+TIkSMyatSoe3qdAwcOSKZMmaR69ep3fF7p0qXjhZNWKHFDJ1euXHLx4sV7mhdkLIRJGjBmzBhZt26dTJ06VfLlyxdvJY+KipKwsLB4z9eq5HajORoKSeHj43PH+15eXtqfloylQEZHmKQiXVk1SHR4+LPPPpNCheKfnb18+fJmJd+8ebNrmg4jnzlzxgwjJ0abSNpk0pEiwJ3oM0nlps3SpUtlwoQJEhAQIOfPnzfTs2XLZioM7SvR/gx9XDtldfrYsWNNkNyu87VgwYLSunVrGTp0qBlC1g7Y06dPmyZL06ZN3byEyEgIk1Q0f/58c929e/d404cMGSJt2rQxt3VUxdvb24y8xN1p7U7eeust+fTTT01YhYaGmtGfF198MQWXBOC0jQAsoc8EgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQArCBMAVhAmAKwgTABYQZgAsIIwAWAFYQLACsIEgBWECQCx4f8BXctsqNmfZ6oAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Sección con la armadura adoptada\n",
+    "viga.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Resultados en tablas**\n",
+    "\n",
+    "`check_flexure()` y `check_shear()` devuelven un `DataFrame` de pandas con una fila por\n",
+    "combinación, cómodo para revisar varias vigas o exportar a Excel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:22.866847Z",
+     "iopub.status.busy": "2026-08-13T02:49:22.866847Z",
+     "iopub.status.idle": "2026-08-13T02:49:22.891353Z",
+     "shell.execute_reply": "2026-08-13T02:49:22.890849Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Label</th>\n",
+       "      <th>Comb.</th>\n",
+       "      <th>Position</th>\n",
+       "      <th>As,min</th>\n",
+       "      <th>As,req top</th>\n",
+       "      <th>As,req bot</th>\n",
+       "      <th>As</th>\n",
+       "      <th>Mu</th>\n",
+       "      <th>ØMn</th>\n",
+       "      <th>Mu≤ØMn</th>\n",
+       "      <th>DCR</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>cm²</td>\n",
+       "      <td>cm²</td>\n",
+       "      <td>cm²</td>\n",
+       "      <td>cm²</td>\n",
+       "      <td>kNm</td>\n",
+       "      <td>kNm</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>V101</td>\n",
+       "      <td>1.2D+1.6L</td>\n",
+       "      <td>Bottom</td>\n",
+       "      <td>3.08</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4.84</td>\n",
+       "      <td>5.15</td>\n",
+       "      <td>80</td>\n",
+       "      <td>84.91</td>\n",
+       "      <td>True</td>\n",
+       "      <td>0.942</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>V101</td>\n",
+       "      <td>1.2D+1.6L+W</td>\n",
+       "      <td>Top</td>\n",
+       "      <td>3.09</td>\n",
+       "      <td>2.72</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>3.05</td>\n",
+       "      <td>-35</td>\n",
+       "      <td>51.63</td>\n",
+       "      <td>True</td>\n",
+       "      <td>0.678</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Label        Comb. Position As,min As,req top As,req bot    As   Mu    ØMn  \\\n",
+       "0                                cm²        cm²        cm²   cm²  kNm    kNm   \n",
+       "1  V101    1.2D+1.6L   Bottom   3.08        0.0       4.84  5.15   80  84.91   \n",
+       "2  V101  1.2D+1.6L+W      Top   3.09       2.72        0.0  3.05  -35  51.63   \n",
+       "\n",
+       "  Mu≤ØMn    DCR  \n",
+       "0                \n",
+       "1   True  0.942  \n",
+       "2   True  0.678  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nodo.check_flexure()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:22.892354Z",
+     "iopub.status.busy": "2026-08-13T02:49:22.892354Z",
+     "iopub.status.idle": "2026-08-13T02:49:22.914272Z",
+     "shell.execute_reply": "2026-08-13T02:49:22.914272Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Label</th>\n",
+       "      <th>Comb.</th>\n",
+       "      <th>Av,min</th>\n",
+       "      <th>Av,req</th>\n",
+       "      <th>Av</th>\n",
+       "      <th>Vu</th>\n",
+       "      <th>Nu</th>\n",
+       "      <th>ØVc</th>\n",
+       "      <th>ØVs</th>\n",
+       "      <th>ØVn</th>\n",
+       "      <th>ØVmax</th>\n",
+       "      <th>Vu≤ØVmax</th>\n",
+       "      <th>Vu≤ØVn</th>\n",
+       "      <th>DCR</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>cm²/m</td>\n",
+       "      <td>cm²/m</td>\n",
+       "      <td>cm²/m</td>\n",
+       "      <td>kN</td>\n",
+       "      <td>kN</td>\n",
+       "      <td>kN</td>\n",
+       "      <td>kN</td>\n",
+       "      <td>kN</td>\n",
+       "      <td>kN</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>V101</td>\n",
+       "      <td>1.2D+1.6L</td>\n",
+       "      <td>1.67</td>\n",
+       "      <td>1.67</td>\n",
+       "      <td>2.57</td>\n",
+       "      <td>70</td>\n",
+       "      <td>0</td>\n",
+       "      <td>58.83</td>\n",
+       "      <td>37.36</td>\n",
+       "      <td>96.19</td>\n",
+       "      <td>287.25</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>0.728</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>V101</td>\n",
+       "      <td>1.2D+1.6L+W</td>\n",
+       "      <td>1.67</td>\n",
+       "      <td>1.67</td>\n",
+       "      <td>2.57</td>\n",
+       "      <td>45</td>\n",
+       "      <td>0</td>\n",
+       "      <td>58.83</td>\n",
+       "      <td>37.36</td>\n",
+       "      <td>96.19</td>\n",
+       "      <td>287.25</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>0.468</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Label        Comb. Av,min Av,req     Av  Vu  Nu    ØVc    ØVs    ØVn  \\\n",
+       "0                     cm²/m  cm²/m  cm²/m  kN  kN     kN     kN     kN   \n",
+       "1  V101    1.2D+1.6L   1.67   1.67   2.57  70   0  58.83  37.36  96.19   \n",
+       "2  V101  1.2D+1.6L+W   1.67   1.67   2.57  45   0  58.83  37.36  96.19   \n",
+       "\n",
+       "    ØVmax Vu≤ØVmax Vu≤ØVn    DCR  \n",
+       "0      kN                         \n",
+       "1  287.25     True   True  0.728  \n",
+       "2  287.25     True   True  0.468  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nodo.check_shear()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Leer la armadura adoptada desde el código**\n",
+    "\n",
+    "Cuando lo que necesitás no es la tabla sino los valores — por ejemplo para armar una planilla\n",
+    "de despiece o alimentar otro cálculo — usá `viga.flexure_design` y `viga.shear_design`. Son\n",
+    "objetos de datos, con unidades, que devuelven exactamente lo que el diseño adoptó.\n",
+    "\n",
+    "Cada cantidad es un `Quantity` de pint, así que se convierte a la unidad que prefieras con\n",
+    "`.to()`. Las áreas requeridas y los DCR son la envolvente de todos los estados de carga: el\n",
+    "DCR de una cara es el de la combinación que la gobierna."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:22.916275Z",
+     "iopub.status.busy": "2026-08-13T02:49:22.916275Z",
+     "iopub.status.idle": "2026-08-13T02:49:22.921069Z",
+     "shell.execute_reply": "2026-08-13T02:49:22.921069Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Armadura inferior: 2Ø16 mm + 1Ø12 mm\n",
+      "  As adoptada  = 5.15 cm²\n",
+      "  As requerida = 0.00 cm²\n",
+      "  As mínima    = 0.00 cm²\n",
+      "Armadura superior: 2Ø12 mm + 1Ø10 mm\n",
+      "Estribos: 1eØ6 mm/22 cm (2 ramas)\n",
+      "  Av adoptada  = 2.57 cm²/m\n",
+      "  Av requerida = 1.67 cm²/m\n",
+      "DCR flexión = 0.68 | DCR corte = 0.47\n"
+     ]
+    }
+   ],
+   "source": [
+    "flexion = viga.flexure_design\n",
+    "corte = viga.shear_design\n",
+    "\n",
+    "print(\"Armadura inferior:\", flexion.bottom)\n",
+    "print(f\"  As adoptada  = {flexion.bottom.A_s.to('cm**2'):.2f~P}\")\n",
+    "print(f\"  As requerida = {flexion.bottom.A_s_req.to('cm**2'):.2f~P}\")\n",
+    "print(f\"  As mínima    = {flexion.bottom.A_s_min.to('cm**2'):.2f~P}\")\n",
+    "print(\"Armadura superior:\", flexion.top)\n",
+    "print(\"Estribos:\", corte, f\"({corte.n_legs} ramas)\")\n",
+    "print(f\"  Av adoptada  = {corte.A_v.to('cm**2/m'):.2f~P}\")\n",
+    "print(f\"  Av requerida = {corte.A_v_req.to('cm**2/m'):.2f~P}\")\n",
+    "print(f\"DCR flexión = {flexion.DCR:.2f} | DCR corte = {corte.DCR:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Memoria de cálculo detallada**\n",
+    "\n",
+    "Para la combinación que gobierna, mento muestra el cálculo completo: propiedades de los\n",
+    "materiales, geometría, cada verificación del reglamento y la relación demanda-capacidad."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:22.923079Z",
+     "iopub.status.busy": "2026-08-13T02:49:22.922072Z",
+     "iopub.status.idle": "2026-08-13T02:49:22.927917Z",
+     "shell.execute_reply": "2026-08-13T02:49:22.927917Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "===== BEAM FLEXURE DETAILED RESULTS =====\n",
+      "Materials                            Variable     Value  Unit\n",
+      "----------------------------------  ----------  -------  ------\n",
+      "Section Label                                      V101\n",
+      "Concrete strength                       fc           25  MPa\n",
+      "Steel reinforcement yield strength      fy          420  MPa \n",
+      "\n",
+      "Geometry                  Variable     Value  Unit\n",
+      "-----------------------  ----------  -------  ------\n",
+      "Section height               h            50  cm\n",
+      "Section width                b            20  cm\n",
+      "Clear cover                  cc          2.5  cm\n",
+      "Mechanical top cover       cm,top       3.67  cm\n",
+      "Mechanical bottom cover    cm,bot       3.86  cm \n",
+      "\n",
+      "Design_forces       Variable     Value  Unit\n",
+      "-----------------  ----------  -------  ------\n",
+      "Top max moment       Mu,top        -35  kNm\n",
+      "Bottom max moment    Mu,bot         80  kNm \n",
+      "\n",
+      "Check                     Unit     Value  Min.      Max.  Ok?\n",
+      "-----------------------  ------  -------  ------  ------  -------\n",
+      "Min/Max As rebar top      cm²       3.05  3.09     14.76  9.6.1.3\n",
+      "Minimum spacing top        mm         52  30              ✅\n",
+      "Min/Max As rebar bottom   cm²       5.15  3.08      14.7  ✅\n",
+      "Minimum spacing bottom     mm         47  25              ✅ \n",
+      "\n",
+      "Top reinforcement check                    Variable       Value  Unit\n",
+      "----------------------------------------  ----------  ---------  ------\n",
+      "First layer bars                            n1+n2     2Ø12+1Ø10\n",
+      "Second layer bars                           n3+n4             -\n",
+      "Effective height                              d           46.33  cm\n",
+      "Depth of equivalent strength block ratio     c/d           0.05\n",
+      "Minimum rebar reinforcing                   As,min         3.09  cm²\n",
+      "Required rebar reinforcing top            As,req top       2.72  cm²\n",
+      "Required rebar reinforcing bottom         As,req bot          0  cm²\n",
+      "Defined rebar reinforcing top                 As           3.05  cm²\n",
+      "Longitudinal reinforcement ratio              ρl        0.55608\n",
+      "Total flexural strength                      ØMn          51.63  kNm\n",
+      "Demand Capacity Ratio                        DCR           0.68  ✅ \n",
+      "\n",
+      "Bottom reinforcement check                 Variable       Value  Unit\n",
+      "----------------------------------------  ----------  ---------  ------\n",
+      "First layer bars                            n1+n2     2Ø16+1Ø12\n",
+      "Second layer bars                           n3+n4             -\n",
+      "Effective height                              d           46.14  cm\n",
+      "Depth of equivalent strength block ratio     c/d           0.12\n",
+      "Minimum rebar reinforcing                   As,min         3.08  cm²\n",
+      "Required rebar reinforcing top            As,req top          0  cm²\n",
+      "Required rebar reinforcing bottom         As,req bot       4.84  cm²\n",
+      "Defined rebar reinforcing bottom              As           5.15  cm²\n",
+      "Longitudinal reinforcement ratio              ρl        0.55828\n",
+      "Total flexural strength                      ØMn          84.91  kNm\n",
+      "Demand Capacity Ratio                        DCR           0.94  ✅ \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "nodo.flexure_results_detailed()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:22.929921Z",
+     "iopub.status.busy": "2026-08-13T02:49:22.929921Z",
+     "iopub.status.idle": "2026-08-13T02:49:22.935026Z",
+     "shell.execute_reply": "2026-08-13T02:49:22.935026Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "===== BEAM SHEAR DETAILED RESULTS =====\n",
+      "Materials                            Variable     Value  Unit\n",
+      "----------------------------------  ----------  -------  ------\n",
+      "Section Label                                      V101\n",
+      "Concrete strength                       fc           25  MPa\n",
+      "Steel reinforcement yield strength      fy          420  MPa\n",
+      "Concrete density                        wc       2500.0  kg/m³\n",
+      "Normalweight concrete                   λ             1\n",
+      "Safety factor for shear                 Øv         0.75 \n",
+      "\n",
+      "Geometry                     Variable     Value  Unit\n",
+      "--------------------------  ----------  -------  ------\n",
+      "Section height                  h            50  cm\n",
+      "Section width                   b            20  cm\n",
+      "Clear cover                     cc          2.5  cm\n",
+      "Longitudinal tension rebar      As         3.05  cm² \n",
+      "\n",
+      "Design forces                     Variable     Value  Unit\n",
+      "-------------------------------  ----------  -------  ------\n",
+      "Axial, positive for compression      Nu            0  kN\n",
+      "Shear                                Vu           70  kN \n",
+      "\n",
+      "Shear reinforcement strength     Variable     Value  Unit\n",
+      "------------------------------  ----------  -------  ------\n",
+      "Number of stirrups                  ns            1\n",
+      "Stirrup diameter                    db            6  mm\n",
+      "Stirrup spacing                     s            22  cm\n",
+      "Effective height                    d         46.14  cm\n",
+      "Minimum shear reinforcing         Av,min       1.67  cm²/m\n",
+      "Required shear reinforcing        Av,req       1.67  cm²/m\n",
+      "Defined shear reinforcing           Av         2.57  cm²/m\n",
+      "Shear rebar strength               ØVs        37.36  kN \n",
+      "\n",
+      "Check                          Unit     Value  Min.      Max.  Ok?\n",
+      "----------------------------  ------  -------  ------  ------  -----\n",
+      "Stirrup spacing along length    cm         22           23.07  ✅\n",
+      "Stirrup spacing along width     cm       14.4           46.14  ✅\n",
+      "Minimum shear reinforcement   cm²/m      2.57  1.67            ✅\n",
+      "Minimum rebar diameter          mm          6  6               ✅ \n",
+      "\n",
+      "Shear strength                     Variable     Value  Unit\n",
+      "--------------------------------  ----------  -------  ------\n",
+      "Effective shear area                 Acv       922.88  cm²\n",
+      "Longitudinal reinforcement ratio      ρw      0.00558\n",
+      "Size modification factor              λs        0.838\n",
+      "Axial stress                         σNu          0.0  MPa\n",
+      "Concrete effective shear stress       kc         0.85  MPa\n",
+      "Concrete strength                    ØVc        58.83  kN\n",
+      "Maximum shear strength              ØVmax      287.25  kN\n",
+      "Total shear strength                 ØVn        96.19  kN\n",
+      "Max shear check                                    ✅\n",
+      "Demand Capacity Ratio                DCR         0.73  ✅ \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "nodo.shear_results_detailed()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Exportar a Word y a Excel**\n",
+    "\n",
+    "Las mismas memorias se exportan a un documento de Word, y las tablas a Excel. Los archivos se\n",
+    "escriben en el directorio de trabajo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:22.937030Z",
+     "iopub.status.busy": "2026-08-13T02:49:22.937030Z",
+     "iopub.status.idle": "2026-08-13T02:49:23.314379Z",
+     "shell.execute_reply": "2026-08-13T02:49:23.314379Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "nodo.flexure_results_detailed_doc()\n",
+    "nodo.shear_results_detailed_doc()\n",
+    "\n",
+    "nodo.check_flexure().to_excel(\"CIRSOC 201-25 resultados flexion.xlsx\")\n",
+    "nodo.check_shear().to_excel(\"CIRSOC 201-25 resultados corte.xlsx\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "rame-env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/source/examples/viga_rectangular_verificacion_CIRSOC_201-25.ipynb
+++ b/docs/source/examples/viga_rectangular_verificacion_CIRSOC_201-25.ipynb
@@ -1,0 +1,721 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mihdicaballero/mento/blob/main/docs/source/examples/viga_rectangular_verificacion_CIRSOC_201-25.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:25.213112Z",
+     "iopub.status.busy": "2026-08-13T02:49:25.213112Z",
+     "iopub.status.idle": "2026-08-13T02:49:25.217111Z",
+     "shell.execute_reply": "2026-08-13T02:49:25.217111Z"
+    },
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# Google Colab no trae mento instalado, así que lo instalamos sólo cuando el\n",
+    "# notebook corre allí. La guarda evita que la documentación llame a pip.\n",
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install mento"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Verificación de viga rectangular — CIRSOC 201-25\n",
+    "\n",
+    "Acá la armadura ya está definida — porque viene de un plano, de un cálculo anterior o de una\n",
+    "estructura existente — y lo que queremos saber es si verifica según el **CIRSOC 201-2025**.\n",
+    "\n",
+    "Es el camino inverso al del ejemplo de\n",
+    "[diseño](viga_rectangular_diseno_CIRSOC_201-25.ipynb): en lugar de pedirle a mento que elija\n",
+    "las barras, se las imponemos y le pedimos la relación demanda-capacidad.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Materiales y geometría de la sección**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:25.219121Z",
+     "iopub.status.busy": "2026-08-13T02:49:25.219121Z",
+     "iopub.status.idle": "2026-08-13T02:49:26.468810Z",
+     "shell.execute_reply": "2026-08-13T02:49:26.468810Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "Beam V201, $b$=20.00 cm, $h$=50.00 cm, $c_{c}$=2.50 cm,                             Concrete H-25, Rebar ADN 420."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from mento import Concrete_CIRSOC_201_25, SteelBar, RectangularBeam, cm, mm, kN, MPa, kNm\n",
+    "from mento import Forces, Node\n",
+    "\n",
+    "hormigon = Concrete_CIRSOC_201_25(name=\"H-25\", f_c=25 * MPa)\n",
+    "acero = SteelBar(name=\"ADN 420\", f_y=420 * MPa)\n",
+    "\n",
+    "viga = RectangularBeam(\n",
+    "    label=\"V201\",\n",
+    "    concrete=hormigon,\n",
+    "    steel_bar=acero,\n",
+    "    width=20 * cm,\n",
+    "    height=50 * cm,\n",
+    "    c_c=2.5 * cm,\n",
+    ")\n",
+    "viga.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Armadura existente**\n",
+    "\n",
+    "La armadura longitudinal se carga por cara y por capa; los estribos, con la cantidad de\n",
+    "estribos, el diámetro y la separación longitudinal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:26.470821Z",
+     "iopub.status.busy": "2026-08-13T02:49:26.470821Z",
+     "iopub.status.idle": "2026-08-13T02:49:26.530313Z",
+     "shell.execute_reply": "2026-08-13T02:49:26.530313Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAARMAAAGFCAYAAADelhfmAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAJZJJREFUeJzt3Ql4TOf+B/BvNllEkCD2NfYlqC0qtH/Evldpq62qorYW1Yvbcu1L0VJV+9JyL6WUqmtfY6ldULXEvsYSiezb/J/f686YkKikbyaZyffzPPMkc+Zk5sxkzvf83mXO2BkMBgOIiP4m+797B0REDBMi0oaVCRFpwTAhIi0YJkSkBcOEiLRgmBCRFgwTItKCYUJEWjBMiEgLhgkRacEwISItGCZEpAXDhIi0YJgQkRYMEyLSgmFCRFowTIhIC4YJEWnBMCEiLRgmRKQFw4SItGCYEJEWDBMi0oJhQkRaMEyISAuGCRFpwTAhIi0YJkSkBcOEiLRgmBCRFgwTItKCYUJEWjBMiEgLhgkRacEwISItGCZEpAXDhIi0YJgQkRYMEyLSgmFCRFowTIhIC4YJEWnBMCEiLRgmRKQFw4SItGCYEJEWDBMi0oJhQkRaMEyISAuGCRFpwTAhIi0YJkSkBcOEiLRgmBCRFgwTItKCYUJEWjBMiEgLhgkRacEwISItHJFNde3aFQ8fPszszaC/4OnpiRUrVvB1sgLZNkwkSOSSJ0+ezN4USsWjR4/42liRbBsmQoJkyZIlmb0ZlIru3bvztbEi7DMhIi1sIkxuhbAcJspsVh8mvwcFo3TzzzFx/obM3hSibM3qw2TKov+qn/NW70ZCQmJmbw5RtmXVYXLm4k38tidI/X77XhhWbjqU2ZtElG1ZdZhMmL8BRb3zqt9rVymFiQt+Y3VClEnsrbkq+XnrUfR/u7G63qV5bVy8FsLqhCiTWG2YTFq4ESUKe6FT01rqepliBdC6ka+qTojI8qw2TMqXLIhZI7rBydHBtGz8wI6oX90nU7eLKLuy2hmwX/Ruo37euR9mWla+VCHM+xdnTRJlBqsNk6wuPiER4ZExeBwZg8QkA2yNHQB3N2fkdneFcw6+jYhhos290AgEHg/G3uOXsP/kZdx/FKGWSzPMvClmK5KSkhATl6B+l1CpU7kEGtQojYY1fVCysGdmbx5lAh5S/qbLNx9g/MIt2HPsIqpXKI4Av8oY+G5zlC6WH3lzucHVJQdsVVx8AkLDo3ArJBS7Dp/D5n2nMGnxVvgUy48vejZDnSolMnsTyYIYJn/DkvW/Y9qPO/Be2/pYOrE3vL08kJ3kcHJUz1kuNSqWwKD3AhARFYO5q3bho7Er0KZhZYzu0xIODtbVzx8aGoq8eZ/MX6KXxzBJp/lr9mPuz/uxae4Q1K1WOtWmgM32mdgBudxc4PhME87dzQVD3m+ON5vVQZt+3+DzGesw5ZN2FguURYsWYefOnbhy5QqcnZ1RrVo1DBw4ECVLlky23vHjx7Fw4UKcOnUKcXFx6vYuXbogIiICJ06cwNSpU9V6sk5gYCDOnTsHJycn7N69O9n9nD9/Xp3G4sSJE+r8K4UKFUKnTp3w9ttvI7thmKSDNGlmrwrElnlD1BHZKDExCYHHL2DN1qPYsPsEbt8PQ5INBom5vB5uaOpXWc33Cahf2dSsK1bQE5vnfYbGH07B3J/3oe+b/hbZnmPHjqFz586oXLkyEhMTMWvWLPTr1w+rV6+Gq6urWmfbtm0YMWIEWrVqhblz56rlR44cwcyZM9Xt69atM91ffHw8mjRpgqpVqyZbbnT27FlVxYwdOxbe3t4ICgrCuHHj4ODgoMIpO2GYpFFsfALGzNuMMf3bJwuSw6cvo/Og7xD64A4K5HFF41drolyJwsjl7gJHe+sq819GksGAiKhYXL/7EDv2Hsavm3fBwTUvZo7ohrdb1VPrSPNn/ugP0Orjr9H+9WoonD93hm+XhIe50aNHqzCQnb5mzZqIjo7GhAkT0KBBA4waNcq0XmxsLJo3b441a9aoqqVhw4ZqeZ8+fdTP9evXp/h47dq1S3a9aNGiKlB27NjBMKEX27j3DFycndDrjdeSBUn73mNRMCkYXnYRQBhwattpVOjcGS2bdYadtAlskJT/6zcvgUN4OErbAQ6JLhg0MgTAYFOg+PmWQZvXfLHwlwP48qPmFt9GabYID48n/VkHDhxAWFgY3n//fdM6t2/fxuLFizFmzBjVbNmwYYMpTNL7mLlzZ3xwZjW2d8jMYLuPBaNjk1dMfQAXr91Fmz6TUTDuDOwSokzrSTt8+fLl+O0325zef+bMGdWvEB4eblqWGB+DoriEASO/xabAU6blnZvVVkPmliZ9VrKNvr6+8PF5MjP62rVr6mepUqXUT+nnkCbK0KFDVZ9I/vz5celS+rf15MmT2LJlCzp06IDshmGSBk/6RIIRUL+KadmPvx5AzoQQ2BkSYUhKeu5vfv75Z/WmtjW//PJLihWXvb0dSrmH4fuVO03LGtWqgOt3QtXFkiZNmoTg4GBMnDjxudskOKTJM2zYMAwYMECdBV88fvw43Y938eJFDB48GL169YKfnx+yG4ZJGpwOvq3mftaq/GRkwGAwYM3WIyju6ZhqU0bOgC9vWltz+fLlFENSlrnZRWP7wT8QGh6pluXK6aKaO3uPB1ts+yZPnqyaYdLBKh2jRsWLFzft+NIJKxVExYoVTdsuVUmxYsXS/HiXLl3Cxx9/jI4dO6Jnz57IjhgmaXDuSgiqVyhmGg49deEGLlwLQbkyqb/5XFxc1MXWeHl5pRigsqxokUJqOHz9zhOm5XK+mXNXpT8lY0nAS5DI8PCcOXNQpEiRZLdLxSD9GYMGDVJNnWbNmpluk+bJ3bt30bRp0zQ9plQ/vXv3RuvWrdXIUXbFMEmD8MhoeOV2N10/ee66+tmtSyf1Jk5px5IRAhkmtDUyrJrSc5Zl7dq2QZmi+RB0/snrI/Lmzqk+q2SJps3GjRsxfvx4uLm54f79++oSE/PksWUYuF69empi2p07d3D69GncvHlTNUdllKdRo0Zo0aJFss5ZmWMi60rlIr/LJSoqylThSJDUq1cP77zzjunx5P6zGw4Np0FYRAzyeLiZrj8Kj4KrsxNKlSyujnQyTyEhIQH29vbqjSdDkbY6ecnf31+V9mvXrjVVKBIkb7zxBurXr488v15QU+2N8uRyU69fRpP5JEL6LczJMHDbtm3VkO2NGzfU6M3SpUvRv39/FTQypNujRw9069YtWcUl1Y2M7hgZ/5/SfKpVqxa2b9+ugmPjxo3qYiST18z/LjtgmKRBTFw83HO6J7suw8RCjmg1atTAwYMHERkZiSpVqqBs2bKwVbLDyZdkSTNBJnyJOnXqmPonXJwdER0TZ1rfzSUHYmOffDAwIx09evSFt8uQr4SADBVPmzbtL+9P5qnIJTVSlciFGCZp9mw/gflVeYMGBARkq/eVHIHbtHlybhlzduokBWbXs8hcG0dHR9OcE9KLfSZEpAXDhIi0YJgQkRYMEyLSgmFCRFowTIhIC4YJEWnBMCEiLRgmRKQFw4SItGCYEJEWDBMi0oJhQkRaMEyISAuGCRFpwTAhIi0YJkSkBcOEiLRgmBCRFgwTItKCYUJEWjBMiEgLhgkRacEwISItGCZEpAXDhIi0YJgQkRYMEyLSgmFCRAwTIso6WJkQkRYMEyLSgmFCRFowTIhIC4YJEWnBMCEiLRgmRKQFw4SItGCYEJEWDBMi0oJhQkRaMEyISAuGCRFpwTAhIi0YJkSkBcOEiLRgmBCRFgwTItKCYUJEWjBMiEgLhgkRacEwISItGCZEpAXDhIi0YJgQkRYMEyLSgmFCRFowTIhIC4YJEWnBMCEiLRgmRKQFw4SItGCYEJEWDBMi0oJhQkRaMEyISAuGCRFpwTAhIi0YJkSkBcOEiLRgmBCRFgwTItKCYUJEWjBMiEgLhgkRacEwISItGCZEpAXDhIi0YJgQkRYMEyLSgmFCRFowTIhIC4YJEWnBMCEiLRgmRKSFIywoNjYWK1euxJEjR/Dw4UMkJSUlu/3f//63JTeHiKw1TMaMGYODBw+icePGqFy5Muzs7Cz58ERkK2Gyd+9ezJw5E9WrV7fkwxKRrfWZFChQADlz5rTkQxKRLYbJoEGDVGVy+/ZtSz4sEdlaM6dSpUqqE7Zt27ZwcXGBo2Pyh9+5c6clN4eIrDVMRowYgXv37qFfv37w9PRkByyRDbFomJw8eRJLlixBuXLlLPmwRGRrfSYlS5ZUzRwisj0WDZMBAwbg66+/VpPWHj16hIiIiGQXIrJejpYOE/Hxxx8nW24wGFT/yeHDhy25OURkrWEyd+5cSz4cEdlqmLzyyiuWfDgistU+k/Xr12Pr1q3PLZdlv/76qyU3hSjdHj9+jMTERL6CmRkmixcvRp48eZ5bLnNO5DYiHY4dO4ZPP/0UzZo1U9VweiZDJiQk4IcffsCbb74JPz8/vPbaaxg8eDBOnTql+v4CAwNN627cuBFdu3ZF/fr1ERAQgNGjR6sBhmfNmzcPX3zxBcLCwjBlyhR07NhR/U3Lli3VdQkpczJTfODAgWqdJk2a4JtvvlHblVVZNEzu3LmDIkWKPLe8UKFC6jYiHaKjo9Vcpn/84x/p+nsZEBg2bBgWLlyILl26YNWqVZg1axa8vLzQvXt3lC5dGo0aNVLrnjhxAqNGjUK7du3UepMnT8aZM2cwbty45+53165daNiwoZq4KRcJPDklx7/+9S8cOHAAY8eONa0rlc8nn3yiwkMOtBJQUr3PmTMHWZVF+0zy5s2LCxcuoHDhwsmWnz9/Hrlz57bkppANe/XVV9UlNXFxcfjuu++wefNmVQ2UKVNGVQC1atVSt8tyqWamTp2K119/XS0rWrQofv/9d7Rq1Qr79u1T95EjRw4EBQWpg+Fbb72l1pODpVQcS5cuTfaYcrC8dOmSqjLc3d3x1VdfmW4rVqwY+vbtiy+//FKFh3zMRE7VcfnyZXz//fcqxMqXL69GQeWzbb1794aTkxOydWXSvHlz9SLKELAkr1wOHTqk/mlSHhJZglQP0lyZOHEiVqxYoZoQ0nS5du2aun3Lli0oXry4KUjEmjVrVBO9V69euH//vtrZRbVq1XD37l3V7JGK5sGDB9i+fftzYbZnzx7V5JIgSYnMs5JP1Bs/ryYh5ePjo4LESJpbkZGRCA4OBrJ7ZSLJeuvWLfXTwcFBLZN/gKR9//79LbkplE1JP4Q0F3777Tfkz59fLXvvvfdUM0MGCOR9ePXqVZQqVSpZ80Qqamk2GWdwS9UgTRY5N480aYYPH65ukwOkLH+2iSX3If0uKQkNDcWCBQtURWMkoSR9ieaM1+U2ZPcwkdJs0qRJ6ghw7tw5ODs7o2zZsqpMJLKEixcvqh2+Q4cOyZZLs8W8qW2sEOTzZNIXIp2f4tlOUmm6SGX90UcfqcpB+kJmzJihqp6RI0eaqg7pFDZeNye3Sd+I9MNI1WPNLBomRlJCyoUoMzpnpSpetmyZqTo2cnV1Nb0/r1y5oqoPaRJJ56uxj8LYxJB+DiGdo76+vqq6EXJwlPvp2bOnqsCl+tm/f78Ki4IFCyZ7PGmySPNKmjcSSOb9INK8kY5cc3LeZONtWRHPTk/ZinRkSmUiTQsJBPNLvnz5TH17EhrS5JFOUfPmhgwXe3h4oF69eup6TEwM7O2T70bPhpQ0cYyjP+YViZyKQwJk+vTpqko3J30xUkUZA0RIB7AEjwRTVpQplQlRRoqKisL169dN16WfTprVEgIlSpRAixYtVJNDzvwn4SLBIgMBUlX4+/ujbt26qroIDw9XzRz5XfpD5NsTZPBA+kjc3NzUfcv6cn3VqlWqmSOds9OmTVMnTJeqREZnpDJ59913nwsSCSIZDpYKRS7GEU8JIwkr6beRMJNmkNzv7Nmz1bwXGUXKihgmZHP++OMPNXxqJEd+0bp1azVfQ+aFyBwS+QR7SEiIGqWpWrWqCgYh8z6k/yJXrlwqJKQPRCqIKlWqqKFa84+FyFkDJbx++ukndX/yN7Vr11ZDzUL6SiR4KlasaPqbP//8E6dPn1a/t2/fPtm2S+ewTJ2QQDH2vcjcFgk02f4+ffogq2KYkM2R+SJHjx5N9XYJBtkpU9sxJWykQhDPdtSmRGa/du3aNcXbpIljDKmX3T4jGZiQeSXWwqJhImks4+fGoS3pSJK2oSQ+UVZhDBIdfHx8VNWTHVgkTKQTaejQoar9KT3axg4tWS4lqPSGy2S2Z8fViaxdR7O5I7bOImEic0vkq0BXr16tTt1oTobg5Jv+ZB35sBMRWSeLDA3L7EKZEfhskAhZJlWLrENE1ssiYSIdXsahr5TIbVnxg0tElMXCRD7EJz3kO3bsSHbiaPldlslwnUwUIiLrZZE+EzmpjPSZyJdwyexDYxUSHx+vxtPlXBBybgcisl4WCROZsSdBIhN5zp49m2xoWCbzpPaxbCKyHhadZyKhIbMDicj2OGbWJzflJNLy+Qn5cJWcqzOlc8MSkfWwSAfsG2+8oU6iazx9XefOndWHoeRTkPJdOnL95s2bltgUIrLmMJGJacavBpBzQxQoUAAbNmxQH+eWn/JpTTknJxFZL4ufz0Q+m2P8RKaQT1TKJzzlLN9EZL0sFibyXcLG0+MZT0JjJJVKSt8zQkTWw2IdsPJxb5lTIrNd5YS98mlK85P88qsuiKybRcLk2RPlGs+1af41ADVq1LDEphCRLYXJszj7lcj68YTSRKQFw4SItGCYEJEWDBMi0oJhQkRaMEyISAuGCRFpwTAhIi0YJkSkBcOEiLRgmBCRFgwTItKCYUJEWjBMiEgLhgkRacEwISItGCZEpAXDhIi0YJgQkRYMEyLSgmFCRAwTIso6WJkQkRYMEyLSgmFCRFowTIhIC4YJEWnBMCEiLRgmRKQFw4SItGCYEJEWDBMi0oJhQkRaMEyISAuGCRFpwTAhIi0YJkSkBcOEiLRgmBCRFgwTItKCYUJEWjBMiEgLhgkRacEwISItGCZEpAXDhIi0YJgQkRYMEyLSgmFCRFowTIhIC4YJEWnBMCEiLRgmRKQFw4SItGCYEJEWDBMi0oJhQkRaMEyISAuGCRFpwTAhIi0YJkSkBcOEiLRgmBCRFgwTItKCYUJEWjBMiEgLhgkRacEwISItGCZEpAXDhIi0YJgQkRYMEyLSgmFCRFowTIhIC4YJEWnBMCEiLRgmRKQFw4SItGCYEJEWDBMi0sJRz92QkcFgwL179xATE4N8+fLBzc3NZl+c+Ph43L17F3Z2dihYsCAcHBwye5MoEzFMNNq/fz9WrlyJK1euqOtOTk547bXX0K1bN+TJkwe2FCI//fQTNm7ciIiICLXM09MT7du3R5s2bWBvb90Fb2hoKPLmzQtrFpoJz4FhosmGDRswf/58dZQ23+m2b9+OEydOYOrUqTYRKPKcxowZg1OnTqkqzOjhw4dYtGiRCtKBAwdm2vbJNuzcuVNth7OzM6pVq6a2p2TJksnWO378OBYuXKieR1xcnLq9S5cuKhyN/y8h6wQGBuLcuXPq4LB79+4UH3f9+vVYvnw5rl27hpw5c6JJkyYYNmxYup7DsWPH8MMPP+Ds2bO4f/++2pbXX3/9ufUuXLig3nNHjhxBVFQUChcujHbt2qFQoUL48ccf1X3I+3HNmjXYtGkT/vzzT0RGRmLXrl3IlSuX6X5u3bqFBQsW4PDhw3jw4IGqqFu2bIkPP/xQPeeXxTBJAwd7e8QnJCa7npCYpHYkedMJ8x1MJCUlqX/QsmXL0L9/f1i7bdu2ISgoKNXbd+zYAX9/f/W6yOtjJK+bvcPToM0osiN27twZlStXRmJiImbNmoV+/fph9erVcHV1NT2HESNGoFWrVpg7d65aLjvkzJkz1e3r1q17ut3x8SoYqlatmmy5OfnfLlu2DJ988gmqVKmimriyg6ZGgkcOPvPmzUvx9ujoaJQrVw5t27bF0KFDU1zn5MmT6Nu3L2rXro0ZM2aoA9WZM2fU8w0JCcHatWtNBzbZHj8/P3WR258lwSvvU3lNihUrhuDgYIwbN05tx6BBg/CyGCZp4JHTBbcfRj297u6Kx5Gx2Lp123MhYk7+UXI06NGjR4b1oTx69Ag3b95UzQ05MmUUadrImzS15ytNnP/+9794HFkAeTyePtewx1HIndMFGe3ZnWX06NEqDOQoX7NmTbWDTJgwAQ0aNMCoUaNM68XGxqJ58+bqKC5VS8OGDdXyPn36mAIgJeHh4Zg9eza++eYb1KlTx7S8bNmy6X4Or776qrqkRl57qQ6lmpo+fbqpWSlVRP369VX1tHfvXnTt2lUtf/vtt9VPCcyUyN/Ixaho0aK4evWqCmCGSQbxcHfBmcv3nr7o3nnVP/bPC8Ev3MGMRzgpWYsXL651m6REnzNnjirtJbSEHEUHDx6sgkU3OeL+VXBKqX8t3AkdCzxt1oWGR6kwtjRjn46Hh4f6eeDAAYSFheH99983rXP79m0sXrxY7aDnz59XVYMxTP7KwYMH1esREhKCTp06qeaGNK1kJ5RO6YwgTS6pJqR6MAaJhNq0adMwcuRIVYnIczCGSXpfN+Nr9rKsu6fMwrw9PXD5xtMwaVSrPNzdnBESGpWsryQ1Li76d6bvv/9eNS2MQSKk3JWjrvkyXXLkyPGX6yQa7BEeGYM2jaqblsnrVsDraTvdEuT5S3+Dr68vfHx81DIJOlGqVClTRTd27FjVnJAje/78+XHp0qWXfgypBuVxFi1ahCFDhmDKlClqx5YmiBxAMsKzz0Gqqi+//FI156QvRPo80vIcnnX9+nWsWLECHTt2TNPfsZmTBnWrlEDw9Xu4fuchihX0hKtLDrT0r4agE0fgkPi0L+VZEjRSksobVXePvVQkKfXTyBtO2tU1atTQ+phSfkuncmpBpUI1ZyGULeGNKmWLmLZn28EzmPl5J1jSpEmTVPvf2J9lToJDmjzSSSp9HcYq7vHjx2l6DHntExISVBhJn4SQZlRAQIDq0JTmg1Q+0o9jJH058jfS1DKSJrBc0kKeg7y2EiRy/8ZOZmM1lh5SYUnfnjQNGSYZ3MypUaEoth44gx4d/NWyzs1q46fNh/BqPm+Eh95LcSeTN5yMFLxM9ZIWN27ceGHfhbR7dYeJdApK/4887rOPLY+Zw9kFv18zYFD32qbnG3T+BqJj41G9fFFYyuTJk9UojIx2eHt7m5Ybm5kXL15U1USHDh1QsWJFtUz+d3JEL1++/Es/jlQBonTp0qZlMiQrHaJ37txR1+Ug8p///Md0u1SSEsjjx483LUtLk0I6ScXly5fVEL1sv3kwyXMzrpMWMj+qd+/eqpL74osv0vz3bOakkX+N0ti095TpeutGvvj03QAcvO8Nj7xPKg+ZvCU7lvHSq1cv01FLJy8vr1Rvkx3jRbenl+yM8kaTYVdhfI7C1S0nLsSXQYNalfF5jxamv9kUeAr1fUvByTHjJ7VJwEmQSMUmfUlFijypjozk/5A7d27VpyHNhGbNmplu27Jli5qE17Rp05d+PNnxxNWrV03LpE9Gmk/GjnBHR0e1cxsvEjbS5DVfJtv0sipUqKCqEKm8pJL64IMPTLfJSJtUpFIZpbUikfepBJM0kdMzV4jNnDRq3bAKWg+ci+Nnr6JGxRLq6Dvx0zfUbd/8uAUVvIujiEcsCuZ1Q/mypdUbMyM6QoXMK6hUqZKaP2BeEckbQeY61K1bN0Met3r16qrDUkYNTgSdxu374bgT6YwjNxPRuF5lrJreDy7OT+YnhIZH4tt/b8O4vq1hCbKDyZwKGeWQkTPp9Bbu7u5qB5Zh4Hr16mHz5s2qcjh9+rTauaUjVYZYGzVqhBYtngahNFGkD0TWlddYOj+FBIDcf4kSJdTfTJ06Ff/85z/V6y4jSrKz16pVK13PQTpxpd/CvNNbHleqFwkoec/JZMglS5ao0JLRJ+nslSCRTlgZFpeJkkbyGsj0BON9SuUi2y5/IyFmDBK5708//VQ1n5+tvF4GwySNShTyRPe2dTFgwnJsXzgUzjmcTIHSoGZZrNp8BL/tOYmIC7GwO3wek3+5CkfHjCsA7ZPc4QlnOCEa0uiQhkVCkj0uJ5ZGgw+fzJvICImJBkRExSIxKQmODs5oXK8Svv/wFXRpXscUJFIlDPt6NaqUKYQmdcvBEmQ4U8jOYU6OttJEkyaGNA8lDJcuXar6B2T0Q4ZDpc9CdkLz5qhUNzIyYmQcZpX5KcawkFGg6dOnq74XCXIZgv7222/TNOHL3B9//KGaG0Zy36J169ZqqFs62OV5yPbLjGvpr5EKRZpzMgNZJpsZK0fx888/J5vT0rNnz2SviQSpBI1czINUHD169KW3287wonE+K3DnfhhKBgzF2hn90cK/2kv/nZSBcqSRdE+rqJg4dPvnDyji7YUVU/uoQDEXHROH3UfO4WbIIzW/Qna4jCTP4871iwh7cBdu7rlRpHRFODqm7438smSHy+3uinx53dGoVgV45s6Z7HZ5W42ctRZL1+3DykndUaxg2qd2d+/eXe2c0vzQRTo+5cif1mHPrCY0C075Z2WSDm4uObBkdDd0H7UMjT/8Ct+OeEc1eYxklKd5g6rIrm7cDcXQqSux7/gFLBv3brqCJKNI/4W1B4nIakEiGCZ/Y2Rn+YT38f2qvfi/HlPQxK8SmjeohqZ+lVC8kP6Oz6zuwaMI7Pj9LDbvP421246had3y+GV6TxTwtOzcEso8DJO/wdXZCYO7/R86Na6O3/aewZK1ezBwwnKUKZYfJYvkU6W/TCnP4Wh7L7N89iY8IkrNbL0ZEqqGf8uX8EaD6qXww9hu8C2XfBSFbJ/tvcszqVO275v+6vI4Mga/n76Kuw8eIywiWs0EjY2Jhq2xgx28PJxRunAeBNQti1qV3oC3hWe4UtbCMNEsV04XNKn78pOeiGyF1U5aO3nuuprDYC4+PgH7T1zMtG0iys6sNkwGT1mBj0YlH9adsngT2vSbkWnbRJSdWW2Y9OjQABt2n8TpizfV9cioWHy7fBs+aP/0MwpEZDlWGyYy09KneAE1hV1s2HMSMXHxGNL96WctiMhyrDZMHB0dMLxnK2w78Ie6/uuuk+jZsSEK5bf+86wSWSOrDRNjdVKqyJMPIsUnJLAqIcpEVh0mUp0MfOfJx8UD6ldhVUKUiax+nknPTv44cPKi6TQARJQ5rD5MnJwc8cPEjzJ7M4iyPatu5hBR1mH1lcnfIWepknNmUNb9/2TUWepIv2wbJnyTWsf/iP8n62H1Z1ojoqyBfSZEpAXDhIi0YJgQkRYMEyLSgmFCRFowTIhIC4YJEWnBMCEiLRgmqbh97xE++2olPOv350mqNZOvTPV6dQDe+cdcnPnfaTfJ+nEGbAohMm3JZixYswcuOZww4J0m+PyD5urTyaTPj7/ux7i5v+LqrQfo1PQVjPioNSr78Iu7rBnD5H9u3g3FJ5P+jS37T8PJ0RFtX6+OVg2rIafr02+TJ70SEhOx69A5rNpyGCEPH6N+dR+MH9gRftV9+FJbIYbJ/7w7bB5WbTmSuf8NUicJP/3LOL4SVohhYvYFXgvW7MXMZVtx+eZ99UXkn3Zriipli2buf8iGyXcUf/efHVi1+bD6JsRenRup1zyPR87M3jRKB4bJMxISEvHT5sOYMH8DLl4LQetGvlgw5gPkyeWWnteXUpCUlITPpv6E+at3I7e7Kwa9F4Deb74GdzcXvl5WjGHyglBZuekQFv8SiGlDu8K3fDHL/mdsmHy5e/uB36Klf1WGiA1hmBCRFpxnQkRaMEyISAuGCRFpwTAhIi0YJkSkBcOEiLRgmBCRFgwTItKCn6vPRIsWLcLOnTtx5coVODs7o1q1ahg4cCBKlixpWic2NhZff/01tmzZgri4OPj5+WHYsGHw8vLKzE0neg4rk0x07NgxdO7cGUuWLMHs2bORkJCAfv36ITo62rTOtGnTsGfPHkyaNAnz58/HvXv3MHTo0MzcbKKUydeDUtbw8OFDQ82aNQ1Hjx5V18PDww116tQxbN261bTOpUuX1DpBQUGp3k9sbKxhxowZhhYtWhjq1q1raNu2rWHt2rXqtsOHD6u/37dvn+Gtt94y+Pn5GXr16mV48OCBITAw0NCxY0eDv7+/Yfjw4YaoqCgLPGuyFWzmZCERERHqp4eHh/p59uxZVa3UrVvXtE6pUqVQsGBBBAUFoWrVqinez8iRI9Xtn332GcqVK4dbt27h0aNHydaZN28ePv/8c7i4uKhmk1ycnJwwfvx4VRkNGTIEK1euRPfu3TP0OZPtYJhkoY/lT506Fb6+vvDxeXKmsQcPHqgdPFeuXMnWlf4SuS0lV69exdatW1WzyRhCRYs+f06Wvn37onr16ur3du3aYdasWVi3bp1p3SZNmuDIkSMME3pp7DPJIqRPJDg4GBMnTvxb93Pu3Dk4ODigZs2aL1yvbNmyycJJKhTz0PH09MTDhw//1rZQ9sIwyQImT56MwMBAzJ07F97e3sl28vj4eDx+/DjZ+lKVpDaaI6HwMhwdHV943c7OTvrT0vAsKLtjmGQi2VklSGR4eM6cOShSJPnZ2StWrKh28kOHDpmWyTDynTt31DBySqSJJE0mGSkisiT2mWRy02bTpk2YPn063NzccP/+fbXc3d1dVRjSVyL9GXK7dMrK8ilTpqggSa3ztXDhwmjdujVGjx6thpClA/b27duqyRIQEGDhZ0jZCcMkE61evVr97NWrV7Llo0aNQtu2bdXvMqpib2+vRl7MJ629yPDhw/Hdd9+psAoLC1OjPz169MjAZ0LE0zYSkSbsMyEiLRgmRKQFw4SItGCYEJEWDBMi0oJhQkRaMEyISAuGCRFpwTAhIi0YJkSkBcOEiLRgmBCRFgwTItKCYUJEWjBMiEgLhgkRacEwISItGCZEpAXDhIi0YJgQkRYMEyLSgmFCRFowTIhIC4YJEWnBMCEiLRgmRAQd/h9Ha1F1t5euUQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Armadura longitudinal inferior: 2Ø16 en la primera capa y 1Ø12 en la segunda\n",
+    "viga.set_longitudinal_rebar_bot(n1=2, d_b1=16 * mm, n2=1, d_b2=12 * mm)\n",
+    "\n",
+    "# Armadura longitudinal superior: 2Ø12\n",
+    "viga.set_longitudinal_rebar_top(n1=2, d_b1=12 * mm)\n",
+    "\n",
+    "# Estribos: 1 estribo (2 ramas) Ø8 cada 20 cm\n",
+    "viga.set_transverse_rebar(n_stirrups=1, d_b=8 * mm, s_l=20 * cm)\n",
+    "\n",
+    "viga.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Estados de carga y nodo**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:26.532316Z",
+     "iopub.status.busy": "2026-08-13T02:49:26.532316Z",
+     "iopub.status.idle": "2026-08-13T02:49:26.537323Z",
+     "shell.execute_reply": "2026-08-13T02:49:26.537323Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Node ID: 1 - Section label: V201\n",
+       "Forces Applied:\n",
+       "  - Force ID: 1, Label: 1.2D+1.6L, N_x: 0.00 kN, V_z: 50.00 kN, M_y: 80.00 kN·m\n",
+       "  - Force ID: 2, Label: 1.2D+1.6L+W, N_x: 0.00 kN, V_z: 55.00 kN, M_y: -30.00 kN·m"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f1 = Forces(label=\"1.2D+1.6L\", M_y=80 * kNm, V_z=50 * kN)\n",
+    "f2 = Forces(label=\"1.2D+1.6L+W\", M_y=-30 * kNm, V_z=55 * kN)\n",
+    "\n",
+    "nodo = Node(section=viga, forces=[f1, f2])\n",
+    "nodo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Verificación**\n",
+    "\n",
+    "`check()` corre flexión y corte para todas las combinaciones. La columna DCR es la relación\n",
+    "demanda-capacidad: verifica mientras sea menor o igual a 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:26.539199Z",
+     "iopub.status.busy": "2026-08-13T02:49:26.539199Z",
+     "iopub.status.idle": "2026-08-13T02:49:26.576066Z",
+     "shell.execute_reply": "2026-08-13T02:49:26.576066Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "Beam V201, $b$=20.00 cm, $h$=50.00 cm, $c_{c}$=2.50 cm,                             Concrete H-25, Rebar ADN 420."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "Top longitudinal rebar: 2Ø12, $A_{s,top}$ = 2.26 cm², $M_u$ = -30 kNm, $\\phi M_n$ = 38.46 kNm → $\\color{#439b00}{\\text{DCR}=0.78}$ \n",
+       "\n",
+       "Bottom longitudinal rebar: 2Ø16+1Ø12, $A_{s,bot}$ = 5.15 cm², $M_u$ = 80 kNm, $\\phi M_n$ = 84.52 kNm → $\\color{#efc200}{\\text{DCR}=0.95}$ "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "Shear reinforcing 1eØ8/20 cm, $A_v$=5.03 cm²/m, $V_u$=55 kN, $\\phi V_n$=131.32 kN → $\\color{#439b00}{\\text{DCR}=0.42}$ "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "nodo.check()\n",
+    "nodo.results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:26.578070Z",
+     "iopub.status.busy": "2026-08-13T02:49:26.578070Z",
+     "iopub.status.idle": "2026-08-13T02:49:26.602587Z",
+     "shell.execute_reply": "2026-08-13T02:49:26.602587Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Label</th>\n",
+       "      <th>Comb.</th>\n",
+       "      <th>Position</th>\n",
+       "      <th>As,min</th>\n",
+       "      <th>As,req top</th>\n",
+       "      <th>As,req bot</th>\n",
+       "      <th>As</th>\n",
+       "      <th>Mu</th>\n",
+       "      <th>ØMn</th>\n",
+       "      <th>Mu≤ØMn</th>\n",
+       "      <th>DCR</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>cm²</td>\n",
+       "      <td>cm²</td>\n",
+       "      <td>cm²</td>\n",
+       "      <td>cm²</td>\n",
+       "      <td>kNm</td>\n",
+       "      <td>kNm</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>V201</td>\n",
+       "      <td>1.2D+1.6L</td>\n",
+       "      <td>Bottom</td>\n",
+       "      <td>3.06</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>4.86</td>\n",
+       "      <td>5.15</td>\n",
+       "      <td>80</td>\n",
+       "      <td>84.52</td>\n",
+       "      <td>True</td>\n",
+       "      <td>0.947</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>V201</td>\n",
+       "      <td>1.2D+1.6L+W</td>\n",
+       "      <td>Top</td>\n",
+       "      <td>3.07</td>\n",
+       "      <td>2.34</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2.26</td>\n",
+       "      <td>-30</td>\n",
+       "      <td>38.46</td>\n",
+       "      <td>True</td>\n",
+       "      <td>0.78</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Label        Comb. Position As,min As,req top As,req bot    As   Mu    ØMn  \\\n",
+       "0                                cm²        cm²        cm²   cm²  kNm    kNm   \n",
+       "1  V201    1.2D+1.6L   Bottom   3.06        0.0       4.86  5.15   80  84.52   \n",
+       "2  V201  1.2D+1.6L+W      Top   3.07       2.34        0.0  2.26  -30  38.46   \n",
+       "\n",
+       "  Mu≤ØMn    DCR  \n",
+       "0                \n",
+       "1   True  0.947  \n",
+       "2   True   0.78  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nodo.check_flexure()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:26.604093Z",
+     "iopub.status.busy": "2026-08-13T02:49:26.604093Z",
+     "iopub.status.idle": "2026-08-13T02:49:26.625957Z",
+     "shell.execute_reply": "2026-08-13T02:49:26.625957Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Label</th>\n",
+       "      <th>Comb.</th>\n",
+       "      <th>Av,min</th>\n",
+       "      <th>Av,req</th>\n",
+       "      <th>Av</th>\n",
+       "      <th>Vu</th>\n",
+       "      <th>Nu</th>\n",
+       "      <th>ØVc</th>\n",
+       "      <th>ØVs</th>\n",
+       "      <th>ØVn</th>\n",
+       "      <th>ØVmax</th>\n",
+       "      <th>Vu≤ØVmax</th>\n",
+       "      <th>Vu≤ØVn</th>\n",
+       "      <th>DCR</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>cm²/m</td>\n",
+       "      <td>cm²/m</td>\n",
+       "      <td>cm²/m</td>\n",
+       "      <td>kN</td>\n",
+       "      <td>kN</td>\n",
+       "      <td>kN</td>\n",
+       "      <td>kN</td>\n",
+       "      <td>kN</td>\n",
+       "      <td>kN</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>V201</td>\n",
+       "      <td>1.2D+1.6L</td>\n",
+       "      <td>1.67</td>\n",
+       "      <td>1.67</td>\n",
+       "      <td>5.03</td>\n",
+       "      <td>50</td>\n",
+       "      <td>0</td>\n",
+       "      <td>58.58</td>\n",
+       "      <td>72.75</td>\n",
+       "      <td>131.32</td>\n",
+       "      <td>286.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>0.381</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>V201</td>\n",
+       "      <td>1.2D+1.6L+W</td>\n",
+       "      <td>1.67</td>\n",
+       "      <td>1.67</td>\n",
+       "      <td>5.03</td>\n",
+       "      <td>55</td>\n",
+       "      <td>0</td>\n",
+       "      <td>58.58</td>\n",
+       "      <td>72.75</td>\n",
+       "      <td>131.32</td>\n",
+       "      <td>286.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>True</td>\n",
+       "      <td>0.419</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  Label        Comb. Av,min Av,req     Av  Vu  Nu    ØVc    ØVs     ØVn  \\\n",
+       "0                     cm²/m  cm²/m  cm²/m  kN  kN     kN     kN      kN   \n",
+       "1  V201    1.2D+1.6L   1.67   1.67   5.03  50   0  58.58  72.75  131.32   \n",
+       "2  V201  1.2D+1.6L+W   1.67   1.67   5.03  55   0  58.58  72.75  131.32   \n",
+       "\n",
+       "   ØVmax Vu≤ØVmax Vu≤ØVn    DCR  \n",
+       "0     kN                         \n",
+       "1  286.0     True   True  0.381  \n",
+       "2  286.0     True   True  0.419  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nodo.check_shear()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Lectura de la verificación desde el código**\n",
+    "\n",
+    "Después de un `check()`, `flexure_design` y `shear_design` describen la armadura verificada y\n",
+    "su DCR, sin tener que leer la tabla. Los DCR son la envolvente de todos los estados de carga,\n",
+    "es decir, el de la combinación que gobierna cada cara."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:26.627961Z",
+     "iopub.status.busy": "2026-08-13T02:49:26.627961Z",
+     "iopub.status.idle": "2026-08-13T02:49:26.633465Z",
+     "shell.execute_reply": "2026-08-13T02:49:26.632961Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Armadura inferior: 2Ø16 mm + 1Ø12 mm → As = 5.15 cm²\n",
+      "Armadura superior: 2Ø12 mm → As = 2.26 cm²\n",
+      "Estribos: 1eØ8 mm/20 cm\n",
+      "DCR flexión = 0.78 | DCR corte = 0.42\n",
+      "Verifica\n"
+     ]
+    }
+   ],
+   "source": [
+    "flexion = viga.flexure_design\n",
+    "corte = viga.shear_design\n",
+    "\n",
+    "print(\"Armadura inferior:\", flexion.bottom, f\"→ As = {flexion.bottom.A_s.to('cm**2'):.2f~P}\")\n",
+    "print(\"Armadura superior:\", flexion.top, f\"→ As = {flexion.top.A_s.to('cm**2'):.2f~P}\")\n",
+    "print(\"Estribos:\", corte)\n",
+    "print(f\"DCR flexión = {flexion.DCR:.2f} | DCR corte = {corte.DCR:.2f}\")\n",
+    "print(\"Verifica\" if max(flexion.DCR, corte.DCR) <= 1 else \"No verifica\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Memoria de cálculo detallada**\n",
+    "\n",
+    "Para la combinación que gobierna, con cada verificación del reglamento paso a paso."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:26.634476Z",
+     "iopub.status.busy": "2026-08-13T02:49:26.634476Z",
+     "iopub.status.idle": "2026-08-13T02:49:26.640558Z",
+     "shell.execute_reply": "2026-08-13T02:49:26.640558Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "===== BEAM FLEXURE DETAILED RESULTS =====\n",
+      "Materials                            Variable     Value  Unit\n",
+      "----------------------------------  ----------  -------  ------\n",
+      "Section Label                                      V201\n",
+      "Concrete strength                       fc           25  MPa\n",
+      "Steel reinforcement yield strength      fy          420  MPa \n",
+      "\n",
+      "Geometry                  Variable     Value  Unit\n",
+      "-----------------------  ----------  -------  ------\n",
+      "Section height               h            50  cm\n",
+      "Section width                b            20  cm\n",
+      "Clear cover                  cc          2.5  cm\n",
+      "Mechanical top cover       cm,top        3.9  cm\n",
+      "Mechanical bottom cover    cm,bot       4.06  cm \n",
+      "\n",
+      "Design_forces       Variable     Value  Unit\n",
+      "-----------------  ----------  -------  ------\n",
+      "Top max moment       Mu,top        -30  kNm\n",
+      "Bottom max moment    Mu,bot         80  kNm \n",
+      "\n",
+      "Check                     Unit     Value  Min.      Max.  Ok?\n",
+      "-----------------------  ------  -------  ------  ------  -------\n",
+      "Min/Max As rebar top      cm²       2.26  3.07     14.69  9.6.1.3\n",
+      "Minimum spacing top        mm        110  30              ✅\n",
+      "Min/Max As rebar bottom   cm²       5.15  3.06     14.64  ✅\n",
+      "Minimum spacing bottom     mm         45  25              ✅ \n",
+      "\n",
+      "Top reinforcement check                    Variable     Value  Unit\n",
+      "----------------------------------------  ----------  -------  ------\n",
+      "First layer bars                            n1+n2        2Ø12\n",
+      "Second layer bars                           n3+n4           -\n",
+      "Effective height                              d          46.1  cm\n",
+      "Depth of equivalent strength block ratio     c/d         0.04\n",
+      "Minimum rebar reinforcing                   As,min       3.07  cm²\n",
+      "Required rebar reinforcing top            As,req top     2.34  cm²\n",
+      "Required rebar reinforcing bottom         As,req bot        0  cm²\n",
+      "Defined rebar reinforcing top                 As         2.26  cm²\n",
+      "Longitudinal reinforcement ratio              ρl      0.55881\n",
+      "Total flexural strength                      ØMn        38.46  kNm\n",
+      "Demand Capacity Ratio                        DCR         0.78  ✅ \n",
+      "\n",
+      "Bottom reinforcement check                 Variable       Value  Unit\n",
+      "----------------------------------------  ----------  ---------  ------\n",
+      "First layer bars                            n1+n2     2Ø16+1Ø12\n",
+      "Second layer bars                           n3+n4             -\n",
+      "Effective height                              d           45.94  cm\n",
+      "Depth of equivalent strength block ratio     c/d           0.12\n",
+      "Minimum rebar reinforcing                   As,min         3.06  cm²\n",
+      "Required rebar reinforcing top            As,req top          0  cm²\n",
+      "Required rebar reinforcing bottom         As,req bot       4.86  cm²\n",
+      "Defined rebar reinforcing bottom              As           5.15  cm²\n",
+      "Longitudinal reinforcement ratio              ρl        0.56071\n",
+      "Total flexural strength                      ØMn          84.52  kNm\n",
+      "Demand Capacity Ratio                        DCR           0.95  ✅ \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "nodo.flexure_results_detailed()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T02:49:26.642569Z",
+     "iopub.status.busy": "2026-08-13T02:49:26.642569Z",
+     "iopub.status.idle": "2026-08-13T02:49:26.647741Z",
+     "shell.execute_reply": "2026-08-13T02:49:26.647741Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "===== BEAM SHEAR DETAILED RESULTS =====\n",
+      "Materials                            Variable     Value  Unit\n",
+      "----------------------------------  ----------  -------  ------\n",
+      "Section Label                                      V201\n",
+      "Concrete strength                       fc           25  MPa\n",
+      "Steel reinforcement yield strength      fy          420  MPa\n",
+      "Concrete density                        wc       2500.0  kg/m³\n",
+      "Normalweight concrete                   λ             1\n",
+      "Safety factor for shear                 Øv         0.75 \n",
+      "\n",
+      "Geometry                     Variable     Value  Unit\n",
+      "--------------------------  ----------  -------  ------\n",
+      "Section height                  h            50  cm\n",
+      "Section width                   b            20  cm\n",
+      "Clear cover                     cc          2.5  cm\n",
+      "Longitudinal tension rebar      As         2.26  cm² \n",
+      "\n",
+      "Design forces                     Variable     Value  Unit\n",
+      "-------------------------------  ----------  -------  ------\n",
+      "Axial, positive for compression      Nu            0  kN\n",
+      "Shear                                Vu           55  kN \n",
+      "\n",
+      "Shear reinforcement strength     Variable     Value  Unit\n",
+      "------------------------------  ----------  -------  ------\n",
+      "Number of stirrups                  ns            1\n",
+      "Stirrup diameter                    db            8  mm\n",
+      "Stirrup spacing                     s            20  cm\n",
+      "Effective height                    d         45.94  cm\n",
+      "Minimum shear reinforcing         Av,min       1.67  cm²/m\n",
+      "Required shear reinforcing        Av,req       1.67  cm²/m\n",
+      "Defined shear reinforcing           Av         5.03  cm²/m\n",
+      "Shear rebar strength               ØVs        72.75  kN \n",
+      "\n",
+      "Check                          Unit     Value  Min.      Max.  Ok?\n",
+      "----------------------------  ------  -------  ------  ------  -----\n",
+      "Stirrup spacing along length    cm         20           22.97  ✅\n",
+      "Stirrup spacing along width     cm       14.2           45.94  ✅\n",
+      "Minimum shear reinforcement   cm²/m      5.03  1.67            ✅\n",
+      "Minimum rebar diameter          mm          8  6               ✅ \n",
+      "\n",
+      "Shear strength                     Variable     Value  Unit\n",
+      "--------------------------------  ----------  -------  ------\n",
+      "Effective shear area                 Acv       918.88  cm²\n",
+      "Longitudinal reinforcement ratio      ρw      0.00246\n",
+      "Size modification factor              λs         0.84\n",
+      "Axial stress                         σNu          0.0  MPa\n",
+      "Concrete effective shear stress       kc         0.85  MPa\n",
+      "Concrete strength                    ØVc        58.58  kN\n",
+      "Maximum shear strength              ØVmax       286.0  kN\n",
+      "Total shear strength                 ØVn       131.32  kN\n",
+      "Max shear check                                    ✅\n",
+      "Demand Capacity Ratio                DCR         0.42  ✅ \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "nodo.shear_results_detailed()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "rame-env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/source/getting_started/citing.rst
+++ b/docs/source/getting_started/citing.rst
@@ -1,0 +1,59 @@
+.. _getting_started/citing:
+
+Citing mento
+============
+
+If mento supported a paper, a thesis, a technical note or a design report, please cite it.
+Citations are what make an open source engineering tool visible to the people deciding
+whether to trust it, and they are the main way this project gets credit for the work.
+
+Which version to cite
+---------------------
+
+Always cite the version you actually ran. mento reports it:
+
+.. code-block:: python
+
+   import mento
+
+   print(mento.__version__)
+
+Calculations change between versions — a corrected clause or a new code edition can move a
+result — so the version is part of the reproducibility of whatever you report.
+
+Citation metadata
+-----------------
+
+The authoritative metadata lives in `CITATION.cff
+<https://github.com/mihdicaballero/mento/blob/main/CITATION.cff>`_ at the root of the
+repository. On GitHub, the **Cite this repository** button in the sidebar renders it as APA
+or BibTeX for you, so you rarely need to write the entry by hand.
+
+BibTeX
+------
+
+.. code-block:: bibtex
+
+   @software{mento,
+     author  = {Caballero, Mehdí and Romaris, Juan Pablo},
+     title   = {mento: an intuitive tool for structural engineers to design concrete
+                elements efficiently},
+     version = {0.5.0},
+     year    = {2026},
+     url     = {https://github.com/mihdicaballero/mento}
+   }
+
+Replace ``version`` and ``year`` with the release you used.
+
+.. note::
+
+   Releases are being archived on `Zenodo <https://zenodo.org/>`_, which issues a DOI for
+   each one. Once the first archived release is out, the DOI will be shown here and in
+   ``CITATION.cff``, and it is preferable to the plain repository URL in a formal citation.
+
+Citing a design code
+--------------------
+
+mento implements published standards; it does not replace them. When your work depends on a
+particular clause, cite the standard itself — ACI 318-19, EN 1992-2004 or CIRSOC 201-2025 —
+alongside mento, which is the implementation you used to apply it.

--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -8,6 +8,7 @@ Getting Started
    :maxdepth: 2
 
    what_is_mento
+   citing
 
 The getting started guide aims to get you using mento productively as quickly as possible.
 


### PR DESCRIPTION
# Description

Etapa 4 of the open source maturity plan: reach. Nothing here changes a calculation — it is
about mento being citable, installable the way conda users install things, and readable by
the audience that uses CIRSOC.

**Citation and Zenodo.** A [citing guide](docs/source/getting_started/citing.rst) covering
which version to cite (calculations change between versions, so the version is part of the
reproducibility of a report), a BibTeX entry, and the reminder to cite the standard itself
alongside the package. `CITATION.cff` was stale at 0.4.1 and is now 0.5.0 with
`date-released`. CONTRIBUTING gains an *Archiving on Zenodo* section with the one-time setup
and exactly where the DOI has to be written once it exists.

The repository is already linked to Zenodo, so the DOI will be minted with the next GitHub
Release. Nothing here fakes one: the two places it goes — `identifiers` in `CITATION.cff`
and a badge in the README — are documented rather than filled in.

**conda-forge.** The recipe lives in [`conda-recipe/`](conda-recipe/), pinned to mento 0.5.0
and the sha256 of its sdist on PyPI, so it stays in step with `pyproject.toml` instead of
being rewritten at submission time. Three dependency names differ from PyPI:
`matplotlib-base` and `seaborn-base` (mento only uses seaborn for plot theming) and
`ipython`. `conda_build_config.yaml` raises `python_min` to 3.10 so the noarch package does
not advertise versions the project does not test. CONTRIBUTING documents the submission to
staged-recipes and the per-release feedstock update by `regro-cf-autotick-bot`.

The submission itself is a PR to conda-forge/staged-recipes and has to come from a
maintainer's fork; it is not part of this branch.

**CIRSOC examples in Spanish.** Two notebooks on a rectangular beam — one designs the
reinforcement from the loads, the other verifies reinforcement that is already defined. They
cover the same ground as the ACI examples and additionally read results from code through
`flexure_design` / `shear_design`, converting with `.to()` so the units in the output are the
ones an engineer would write down. They carry the Open in Colab badge and the hidden install
cell added in #130, and ship with stored outputs so the build does not execute them.

Writing these is what surfaced the envelope bug in the results API, fixed separately in #131
and already on main; the outputs stored here were produced with that fix in place.

## Type of change

- [x] Documentation
- [x] Maintenance (tooling, CI, refactoring with no behaviour change)

## Checklist

- [x] Tests added or updated, and `pytest` passes locally — 595 passed, 1 skipped
- [x] `mypy mento/` passes
- [x] `pre-commit run --all-files` reports no changes
- [x] Documentation updated where the change is user facing
- [x] Public class and method names left unchanged, or the change was agreed beforehand

Documentation builds clean with `-W`, the bar set by #130.

## Notes for the reviewer

- `check-yaml` now skips `conda-recipe/meta.yaml`: a conda recipe is a Jinja template, and
  `{% set %}` on line 1 is not something a YAML parser can read.
- ruff lints and formats notebooks too. The Spanish notebooks were re-executed after ruff
  touched them, so source and stored outputs are in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)