### PR TITLE
Fix the Colab install and prepare the 0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ from the release history and are summaries rather than complete lists.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-15
+
 ### Added
 
 - Public design results API: `beam.flexure_design` and `beam.shear_design` return plain,
@@ -130,7 +132,8 @@ First public release on PyPI: rectangular concrete beam check and design for fle
 shear under ACI 318-19 and CIRSOC 201-25, unit aware calculations, results as pandas
 DataFrames, and Word calculation reports.
 
-[Unreleased]: https://github.com/mihdicaballero/mento/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/mihdicaballero/mento/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/mihdicaballero/mento/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/mihdicaballero/mento/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/mihdicaballero/mento/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/mihdicaballero/mento/compare/v0.3.6...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ from the release history and are summaries rather than complete lists.
   The old module still works and emits a `DeprecationWarning`; `from mento import
   BeamSummary` is unaffected.
 
+### Fixed
+
+- **`pip install mento` on Google Colab.** The IPython requirement was `>=8.0`, while Colab
+  pins ipython to 7.34.0, so installing mento there could not resolve without upgrading
+  IPython out from under the running session. The floor is now `>=7.34`; mento only uses
+  `IPython.display.Markdown` and `display`, which both bounds cover.
+
 ## [0.5.0] - 2026-08-01
 
 Infrastructure release. No changes to the design calculations, and no changes to the public

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,5 +26,5 @@ keywords:
   - CIRSOC 201
   - Python
 license: MIT
-version: 0.5.0
-date-released: "2026-08-02"
+version: 0.5.1
+date-released: "2026-08-15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,11 @@ dependencies = [
     "python-docx>=1.1",
     "openpyxl>=3.1",
     "jinja2>=3.1",
-    "IPython>=8.0",
+    # Google Colab pins ipython to 7.34.0, so a >=8.0 floor made `pip install mento`
+    # there either fail to resolve or force an upgrade that breaks the session. mento
+    # only uses IPython.display.Markdown and display, which have been stable for far
+    # longer than either bound.
+    "IPython>=7.34",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mento"
-version = "0.5.0"
+version = "0.5.1"
 description = "An intuitive tool for structural engineers to design concrete elements efficiently."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
# Description

Every example notebook carries an "Open in Colab" badge, and following it led to a broken
install: `pip install mento` on Colab reports an error and leaves the session in a bad state.

The cause is mento's own metadata, not Colab. `pyproject.toml` asked for `IPython>=8.0`,
while Colab pins ipython to 7.34.0. With that pin present pip cannot resolve at all:

```
The conflict is caused by:
    mento 0.5.0 depends on IPython>=8.0
    The user requested (constraint) ipython==7.34.0
ERROR: ResolutionImpossible
```

On Colab the pin is not a hard constraint but a requirement of the `google-colab` package, so
pip resolves upwards instead — it upgrades IPython underneath the session that is already
running, which is what produces the error and the half-working install.

Nothing needed the 8.0 floor. mento imports `IPython.display.Markdown` and `display`, and
nothing else; both have been stable far longer than either bound. The floor is now `>=7.34`,
which is what Colab ships.

**Release preparation.** Colab installs from PyPI, so the fix does not reach anyone until it
ships. The second commit bumps the version in `pyproject.toml` and `CITATION.cff` and closes
the changelog's Unreleased section, per the release procedure in CONTRIBUTING. Merging this
leaves `main` ready for the `v0.5.1` tag.

0.5.1 therefore carries everything merged since 0.5.0: the design results API (#129), the
envelope fix in that API (#131), the citation and conda work and the Spanish CIRSOC examples
(#132), and this Colab fix.

## Type of change

- [x] Bug fix
- [ ] New feature or design code implementation
- [ ] Documentation
- [x] Maintenance (tooling, CI, refactoring with no behaviour change)

## Checklist

- [x] Tests added or updated, and `pytest` passes locally — 595 passed, 1 skipped
- [x] `mypy mento/` passes
- [x] `pre-commit run --all-files` reports no changes
- [x] Documentation updated where the change is user facing — CHANGELOG entry under Fixed
- [x] Public class and method names left unchanged, or the change was agreed beforehand

## How this was verified

A clean virtual environment pinned to `ipython==7.34.0`, the way Colab is:

- the wheel built from this branch installs **without touching IPython** — it stays at
  7.34.0, so there is no upgrade, no session restart and no conflict with `google-colab`
- a full CIRSOC 201-25 design runs there: both checks, `beam.plot()`, the detailed flexure
  and shear reports, and the results read through `flexure_design` / `shear_design`

The other suspect was ruled out rather than assumed: the install cell added in #130 puts
`%pip install mento` indented inside an `if`, so it was worth confirming that IPython 7.34
(not just 8.x) transforms it. It does — `get_ipython().run_line_magic('pip', 'install mento')`,
valid Python.

For the release commit, `python -m build` produces `mento-0.5.1`, `twine check` passes on
both the wheel and the sdist, and the wheel metadata reads `Version: 0.5.1` and
`Requires-Dist: IPython>=7.34`.

## Notes for the reviewer

- **Version number.** 0.5.1 is a patch bump, but this release also adds a public API
  (`flexure_design` / `shear_design`) and renames a module behind a deprecation shim, which
  under semver would be a minor bump. Below 1.0 the changelog already says the public API can
  move between minor releases, so this is a judgement call rather than a mistake — say the
  word and it becomes 0.6.0 instead.
- `conda-recipe/meta.yaml` stays pinned to 0.5.0 on purpose: it points at a released sdist and
  its sha256, and 0.5.1 does not exist on PyPI yet. It should be re-pinned after the release,
  before the recipe is submitted to staged-recipes.
- Publishing this release is also what mints the Zenodo DOI left pending in #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)