### PR TITLE
Correct slab width and validation sources in the documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,10 @@ Reinforced concrete design Python package. Covers beams, slabs, sections, materi
 
 ## Python environment
 
-**Always use the `py312` or `rame-env` conda environment.** The base `anaconda3` env should never be used for mento.
+**Always use the `rame-env` conda environment.** The base `anaconda3` env should never be used for mento. (The old `py312` env no longer exists.)
 
 ```
-C:\Users\mihdi\anaconda3\envs\py312\python.exe
+C:\Users\mihdi\anaconda3\envs\rame-env\python.exe
 ```
 
 This is also set in `.vscode/settings.json` as `python.defaultInterpreterPath` so the VS Code test runner and IntelliSense use it automatically.
@@ -24,16 +24,16 @@ This is also set in `.vscode/settings.json` as `python.defaultInterpreterPath` s
 
 ```powershell
 # Full suite (uses pyproject.toml addopts: --cov, --cov-report=html, --cov-report=term-missing)
-& "C:\Users\mihdi\anaconda3\envs\py312\python.exe" -m pytest tests/
+& "C:\Users\mihdi\anaconda3\envs\rame-env\python.exe" -m pytest tests/
 
 # Single file, fast iteration (strip addopts to avoid --cov conflicts)
-& "C:\Users\mihdi\anaconda3\envs\py312\python.exe" -m pytest tests/test_beam.py --override-ini="addopts=" -v
+& "C:\Users\mihdi\anaconda3\envs\rame-env\python.exe" -m pytest tests/test_beam.py --override-ini="addopts=" -v
 
 # Single file with coverage
-& "C:\Users\mihdi\anaconda3\envs\py312\python.exe" -m pytest tests/test_beam.py --override-ini="addopts=" --cov=mento --cov-report=term-missing -q
+& "C:\Users\mihdi\anaconda3\envs\rame-env\python.exe" -m pytest tests/test_beam.py --override-ini="addopts=" --cov=mento --cov-report=term-missing -q
 
 # Check coverage for a specific module only
-& "C:\Users\mihdi\anaconda3\envs\py312\python.exe" -m pytest tests/ --override-ini="addopts=" --cov=mento --cov-report=term-missing -q 2>&1 | Select-String "beam|slab|rebar"
+& "C:\Users\mihdi\anaconda3\envs\rame-env\python.exe" -m pytest tests/ --override-ini="addopts=" --cov=mento --cov-report=term-missing -q 2>&1 | Select-String "beam|slab|rebar"
 ```
 
 > `--override-ini="addopts="` strips the default `--cov` flags from pyproject.toml. Required when running single files or adding custom `--cov` arguments to avoid argument conflicts.
@@ -44,13 +44,13 @@ This is also set in `.vscode/settings.json` as `python.defaultInterpreterPath` s
 
 ```powershell
 # Ruff lint (auto-fix)
-& "C:\Users\mihdi\anaconda3\envs\py312\python.exe" -m ruff check . --fix
+& "C:\Users\mihdi\anaconda3\envs\rame-env\python.exe" -m ruff check . --fix
 
 # Ruff format
-& "C:\Users\mihdi\anaconda3\envs\py312\python.exe" -m ruff format .
+& "C:\Users\mihdi\anaconda3\envs\rame-env\python.exe" -m ruff format .
 
 # MyPy (strict)
-& "C:\Users\mihdi\anaconda3\envs\py312\python.exe" -m mypy mento/
+& "C:\Users\mihdi\anaconda3\envs\rame-env\python.exe" -m mypy mento/
 ```
 
 Ruff config: 120-char line limit. MyPy config: `strict = true`, `allow_any_generics = true`. Package checked: `mento/`.
@@ -176,7 +176,7 @@ When asked to design or check a beam with mento, run a script via PowerShell wit
 
 ```powershell
 $env:PYTHONIOENCODING="utf-8"
-C:\Users\mihdi\anaconda3\envs\py312\python.exe -c "..."
+C:\Users\mihdi\anaconda3\envs\rame-env\python.exe -c "..."
 ```
 
 ### Correct API pattern — RectangularBeam design
@@ -278,10 +278,10 @@ obj.some_method()
 
 **Checking coverage for one file:**
 ```powershell
-& "C:\Users\mihdi\anaconda3\envs\py312\python.exe" -m pytest tests/ --override-ini="addopts=" --cov=mento --cov-report=term-missing -q 2>&1 | Select-String "filename_or_module"
+& "C:\Users\mihdi\anaconda3\envs\rame-env\python.exe" -m pytest tests/ --override-ini="addopts=" --cov=mento --cov-report=term-missing -q 2>&1 | Select-String "filename_or_module"
 ```
 
 **Running a single test by name:**
 ```powershell
-& "C:\Users\mihdi\anaconda3\envs\py312\python.exe" -m pytest tests/test_beam.py::test_my_function --override-ini="addopts=" -v
+& "C:\Users\mihdi\anaconda3\envs\rame-env\python.exe" -m pytest tests/test_beam.py::test_my_function --override-ini="addopts=" -v
 ```

--- a/docs/source/theory/beam_aci_318_19.rst
+++ b/docs/source/theory/beam_aci_318_19.rst
@@ -388,7 +388,7 @@ both faces carry steel.
 Validation
 ----------
 
-Every row is pinned by a test in ``tests/test_beam.py`` and was verified against the
+Every row is pinned by a test in ``tests/test_beam.py`` and is verified against the
 external source named.
 
 .. list-table::
@@ -400,13 +400,13 @@ external source named.
      - Verified against
    * - :math:`M_n`, singly reinforced
      - ``test_determine_nominal_moment_simple_reinf_ACI_318_19_Test_Etabs_03``
-     - ETABS + Excel *BEAM-01-Flexure-Rectangle ACI 318-19-v6*
+     - Calcpad *BEAM-01-Flexure-Rectangle ACI 318-19-v6*
    * - :math:`M_n`, doubly reinforced (steel not yielding)
      - ``test_determine_nominal_moment_double_reinf_ACI_318_19_Test_Etabs_01``
-     - ETABS + Excel, same workbook
+     - Calcpad, same sheet
    * - :math:`M_n`, doubly reinforced (steel yielding)
      - ``test_determine_nominal_moment_double_reinf_ACI_318_19_Test_Etabs_23_yielding``
-     - ETABS + Excel, same workbook
+     - Calcpad, same sheet
    * - :math:`A_{s,req}`, :math:`A_{s,min}` governing
      - ``test_calculate_flexural_reinforcement_ACI_318_19_Test_Etabs_05``
      - ETABS, :math:`A_{s,req} = 1.7041\ \text{in}^2`
@@ -421,7 +421,7 @@ external source named.
      - §9.6.1.2
    * - Flexure check, full section
      - ``test_check_flexure_ACI_318_19_1`` … ``_3``
-     - Excel workbook
+     - Calcpad, same sheet
    * - Flexure design, doubly reinforced
      - ``test_design_flexure_ACI_318_19_Test_Etabs_01``
      - ETABS, verified through :math:`\phi M_n \ge M_u`

--- a/docs/source/theory/beam_en_1992_2004.rst
+++ b/docs/source/theory/beam_en_1992_2004.rst
@@ -367,8 +367,8 @@ Inverting :math:`K` yields the **block depth**, so the lever arm is
 C25 200×600 section at 150 kN·m that is 518.3 mm instead of 507.9 mm — a 2%
 overestimate of the lever arm, hence a 2% **under-estimate** of the required steel.
 
-mento previously carried this error, inherited from its reference spreadsheet. It is
-now pinned by a test that recomputes the Concise Eurocode 2 closed form from scratch.
+The single application is pinned by a test that recomputes the Concise Eurocode 2
+closed form from scratch.
 
 Ductility limits live on the neutral axis
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/theory/index.rst
+++ b/docs/source/theory/index.rst
@@ -12,7 +12,7 @@ The intent is auditability. A structural engineer signing off on a design needs 
 verify that the tool agrees with the code, and to know exactly where it does not
 follow the most common interpretation. Every page therefore ends with a
 **Validation** table mapping each check to the test that pins it and to the external
-source that test was verified against.
+source that test is verified against.
 
 .. toctree::
    :hidden:

--- a/docs/source/theory/one_way_slab.rst
+++ b/docs/source/theory/one_way_slab.rst
@@ -2,7 +2,7 @@ One-Way Slab
 ============
 
 ``OneWaySlab`` subclasses ``RectangularBeam``. **The code provisions are identical** —
-a one-way slab strip is analysed as a wide, shallow beam, and every equation on the
+a one-way slab is analysed as a wide, shallow beam, and every equation on the
 :doc:`ACI <beam_aci_318_19>` and :doc:`EN <beam_en_1992_2004>` pages applies
 unchanged.
 
@@ -11,18 +11,27 @@ This page covers only what differs.
 Model
 -----
 
-The slab is a strip of unit width — typically 1 m or 12 in — spanning one way. The
-strip width becomes :math:`b` (or :math:`b_w`) in every formula, and the slab
-thickness becomes :math:`h`. Results are therefore *per strip*, so a 1 m strip gives
-areas in cm²/m directly.
+A one-way slab spans in one direction and is designed over a chosen width. That
+``width`` becomes :math:`b` (or :math:`b_w`) in every formula, and the slab thickness
+becomes :math:`h`.
 
 .. math::
 
-   b = \text{strip width}
+   b = \text{design width}
    \qquad
    h = \text{slab thickness}
    \qquad
    d = h - c_c - \frac{d_b}{2}
+
+The width is a free parameter, not fixed at unity. A 1 m or 12 in width is the usual
+choice for a floor or roof slab, and it is convenient because the reported areas then
+read directly as cm²/m. Any other width is equally valid — a 150 cm width is a
+reasonable model for a strip footing, for example — and the section is solved at that
+width rather than scaled up from a unit strip.
+
+Results are therefore absolute for the width given: :math:`A_s` is the total steel
+across :math:`b`, not a per-metre intensity. Divide by the width to convert to cm²/m
+when that is the more useful form.
 
 Note the absence of a stirrup diameter in :math:`d`: slabs carry no transverse
 reinforcement by default, so ``_stirrup_d_b`` starts at zero and the mechanical cover
@@ -36,7 +45,7 @@ Reinforcement is specified by spacing, not count
 
 ``set_slab_longitudinal_rebar_bot(d_b1, s_b1, d_b3, s_b3)`` takes a **bar diameter
 and a spacing** per layer, matching slab detailing practice, instead of the beam's
-bar count. Internally the bar count over the strip is derived from the spacing, and
+bar count. Internally the bar count across the width is derived from the spacing, and
 from there the section behaves exactly as a beam:
 
 .. math::
@@ -61,8 +70,9 @@ Two ``BeamSettings`` values are overridden on construction:
      - Why
    * - ``max_bars_per_layer``
      - ≥ 200
-     - A 1 m strip at 10 cm spacing already needs 10 bars, and narrow spacings can
-       need far more. The beam default would reject valid slab layouts.
+     - A 1 m width at 10 cm spacing already needs 10 bars, and wider slabs or
+       narrower spacings need far more. The beam default would reject valid slab
+       layouts.
    * - ``max_diameter_diff``
      - 0
      - All bars within a layer must share a diameter — mixing diameters in a slab
@@ -100,12 +110,12 @@ Consequences for flexure
 
 Nothing changes mechanically. The geometric minimum of :math:`1.8\text{‰}\,b\,h` that
 mento applies under ACI (see :ref:`aci-decisions`) is expressed on the gross section,
-so for a slab strip it scales with the strip width as expected.
+so it scales with the design width as expected.
 
 .. note::
 
    Shrinkage and temperature reinforcement in the transverse direction (ACI §24.4,
-   EN §9.3.1.1) is **not** computed. mento designs the one-way strip only; the
+   EN §9.3.1.1) is **not** computed. mento designs the spanning direction only; the
    distribution steel perpendicular to the span is the engineer's responsibility.
 
 Validation

--- a/docs/source/user_guide/slabs.rst
+++ b/docs/source/user_guide/slabs.rst
@@ -1,14 +1,16 @@
 Slab
 ====
 
-The `OneWaySlab` class models a one-way slab strip for flexure and shear analysis and design.
+The `OneWaySlab` class models a one-way spanning slab for flexure and shear analysis and design.
 It inherits all check and design logic from `RectangularBeam`, but uses bar **diameter + spacing**
 instead of bar count for longitudinal reinforcement — consistent with standard slab detailing practice.
 
 Key Concepts
 ------------
 
-- **Geometry**: Defined by a strip `width` (typically 1 m or 100 cm) and slab `height` (thickness).
+- **Geometry**: Defined by a `width` and a slab `height` (thickness). The width is free:
+  1 m is the usual choice for a floor slab, but any width works — a footing might use 150 cm.
+  Results are the totals across that width, not per-metre values.
 - **Material Properties**: Requires a `Concrete` object and a `SteelBar` object.
 - **Reinforcement**: Specified by bar diameter and spacing, not bar count.
 - **Checks and design**: Performed through a `Node` object, exactly as for beams.
@@ -21,8 +23,8 @@ Below is a step-by-step guide on how to use the `OneWaySlab` class.
 1. Creating a Slab Object
 *************************
 
-To define a slab strip, specify its geometry, material properties, and clear cover.
-The `width` represents the analysis strip width; `height` is the slab thickness.
+To define a slab, specify its geometry, material properties, and clear cover.
+The `width` is the width being designed; `height` is the slab thickness.
 
 .. code-block:: python
 
@@ -33,7 +35,7 @@ The `width` represents the analysis strip width; `height` is the slab thickness.
     concrete = Concrete_ACI_318_19(name="C25", f_c=25 * MPa)
     steel = SteelBar(name="ADN 420", f_y=420 * MPa)
 
-    # Define slab strip geometry (1 m wide strip, 20 cm thick)
+    # Define slab geometry (1 m wide, 20 cm thick)
     slab = OneWaySlab(label="S101", concrete=concrete, steel_bar=steel,
                       width=100 * cm, height=20 * cm, c_c=25 * mm)
 


### PR DESCRIPTION
# Description

Documentation-only corrections in three places where the prose did not match the code or the validation record. No changes to `mento/` or `tests/`.

**1. The one-way slab is not a unit-width strip.** Both the theory page and the user guide described the model as "a strip of unit width — typically 1 m or 12 in" whose results are *per strip*, "so a 1 m strip gives areas in cm²/m directly."

`OneWaySlab` accepts any `width`, and solves the section at that width rather than scaling from a unit strip. Confirmed by running both cases at 150 kN·m:

| width | designed | A_s provided | A_s required |
|---|---|---|---|
| 100 cm | 2Ø12 | 16.96 cm² | 16.71 cm² |
| 150 cm | 2Ø16 | 16.08 cm² | 16.45 cm² |

Different sections, not one scaled to the other. `A_s` is the total across `b`, so the "cm²/m directly" reading held only by coincidence when the width happened to be 1 m. The old framing also ruled out a legitimate use — a 150 cm width models a strip footing — which is how this surfaced.

**2. Removed a changelog entry from the Eurocode theory page.** The lever-arm decision narrated that mento "previously carried this error, inherited from its reference spreadsheet. It is now pinned by a test…". Theory pages should state what the implementation does, not how it arrived there. The technical content — why λ is applied once, and the 518.3 vs 507.9 mm illustration — is kept; only the history is dropped.

**3. Excel → Calcpad in the ACI validation table.** Three rows credited `ETABS + Excel *BEAM-01-Flexure-Rectangle ACI 318-19-v6*` / `Excel workbook`. No Excel was used for validation; these are Calcpad sheets, matching the convention the EN and slab tables already follow.

Also swept the theory pages for other retrospective phrasing (`previously`, `no longer`, `has been fixed`, `originally`, `legacy`) — item 2 was the only instance. Two "was verified against" in the validation-table intros became "is verified against" so the tables read as a standing property.

Separately, a second commit points the `CLAUDE.md` contributor commands at `rame-env`. The `py312` env named throughout no longer exists — the directory is present but holds no `python.exe`, so the documented commands fail with a confusing "not recognized as the name of a cmdlet" instead of a missing-interpreter error.

## Type of change

- [ ] Bug fix
- [ ] New feature or design code implementation
- [x] Documentation
- [x] Maintenance (tooling, CI, refactoring with no behaviour change)

## Checklist

- [ ] Tests added or updated, and `pytest` passes locally — N/A, no code changed
- [ ] `mypy mento/` passes — N/A, no code changed
- [x] `pre-commit run --all-files` reports no changes — ran on both commits, all hooks passed
- [x] Documentation updated where the change is user facing
- [x] Public class and method names left unchanged

## Calculation validation

N/A — no design calculation added or modified. The slab runs above were used to establish what the existing code does, not to change it.

## Notes for the reviewer

Three ACI validation rows still credit **ETABS on its own** (`ETABS, A_s,req = 1.7041 in²`; `ETABS`; `ETABS, verified through φMn ≥ Mu`). ETABS is a distinct tool from Excel so I left those, but if those checks actually came from Calcpad too, say so and I will switch them.

Docs build clean under Sphinx 8.1.3. The only warnings are pre-existing nbsphinx image-path noise from the example notebooks, unrelated to these pages.

**Correction:** an earlier revision of this description also claimed a flexure-symbols fix. That commit was pushed a few minutes after this PR merged and is not part of it — it is in #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
