### PR TITLE
Label flexure output with the symbols of the active design code

### DIFF
--- a/mento/beam.py
+++ b/mento/beam.py
@@ -958,6 +958,9 @@ class RectangularBeam(RectangularSection):
         # Formatter instance for DCR formatting
         markdown_content = ""
         formatter = Formatter()
+        symbols = self._flexure_symbols
+        md_demand = symbols["md_demand"]
+        md_capacity = symbols["md_capacity"]
 
         # Handle top result data
         if top_result_data:
@@ -972,8 +975,9 @@ class RectangularBeam(RectangularSection):
             formatted_DCR_top = formatter.DCR(DCR_top)
 
             markdown_content += (
-                f"Top longitudinal rebar: {rebar_top}, $A_{{s,top}}$ = {area_top} cm², $M_u$ = {Mu_top} kNm, "
-                f"$\\phi M_n$ = {Mn_top} kNm → {formatted_DCR_top} {warning_top}\n\n"
+                f"Top longitudinal rebar: {rebar_top}, $A_{{s,top}}$ = {area_top} cm², "
+                f"${md_demand}$ = {Mu_top} kNm, "
+                f"${md_capacity}$ = {Mn_top} kNm → {formatted_DCR_top} {warning_top}\n\n"
             )
         else:
             markdown_content += "No top moment to check.\n\n"
@@ -991,8 +995,9 @@ class RectangularBeam(RectangularSection):
             formatted_DCR_bot = formatter.DCR(DCR_bot)
 
             markdown_content += (
-                f"Bottom longitudinal rebar: {rebar_bot}, $A_{{s,bot}}$ = {area_bot} cm², $M_u$ = {Mu_bot} kNm, "
-                f"$\\phi M_n$ = {Mn_bot} kNm → {formatted_DCR_bot} {warning_bot}"
+                f"Bottom longitudinal rebar: {rebar_bot}, $A_{{s,bot}}$ = {area_bot} cm², "
+                f"${md_demand}$ = {Mu_bot} kNm, "
+                f"${md_capacity}$ = {Mn_bot} kNm → {formatted_DCR_bot} {warning_bot}"
             )
         else:
             markdown_content += "No bottom moment to check."
@@ -1064,6 +1069,34 @@ class RectangularBeam(RectangularSection):
         if self._shear_checked:
             self.shear_results  # This will generate _md_shear_results
         return None
+
+    @property
+    def _flexure_symbols(self) -> Dict[str, str]:
+        """Flexural symbols of the active design code.
+
+        ACI 318-19 and CIRSOC 201-25 work with a factored demand :math:`M_u` and a
+        reduced capacity :math:`\\phi M_n`; EN 1992-2004 works with :math:`M_{Ed}`
+        and :math:`M_{Rd}`. The per-code result dictionaries already carry the right
+        wording, but the limiting-case summaries assembled here have to pick it.
+
+        ``md_*`` entries are LaTeX for the Jupyter markdown line; the others are the
+        plain variable names used in the detailed tables and Word reports.
+        """
+        if self.concrete.design_code == "EN 1992-2004":
+            return {
+                "demand": "MEd",
+                "demand_top": "MEd,top",
+                "demand_bot": "MEd,bot",
+                "md_demand": "M_{Ed}",
+                "md_capacity": "M_{Rd}",
+            }
+        return {
+            "demand": "Mu",
+            "demand_top": "Mu,top",
+            "demand_bot": "Mu,bot",
+            "md_demand": "M_u",
+            "md_capacity": "\\phi M_n",
+        }
 
     @property
     def _report_text(self) -> Dict[str, str]:
@@ -1142,7 +1175,10 @@ class RectangularBeam(RectangularSection):
                     "Top max moment",
                     "Bottom max moment",
                 ],
-                "Variable": ["Mu,top", "Mu,bot"],
+                "Variable": [
+                    self._flexure_symbols["demand_top"],
+                    self._flexure_symbols["demand_bot"],
+                ],
                 "Value": [
                     round(self._limiting_case_flexure_top_details["forces"]["Value"][0], 2),
                     round(self._limiting_case_flexure_bot_details["forces"]["Value"][1], 2),
@@ -1258,7 +1294,10 @@ class RectangularBeam(RectangularSection):
                     "Top max moment",
                     "Bottom max moment",
                 ],
-                "Variable": ["Mu,top", "Mu,bot"],
+                "Variable": [
+                    self._flexure_symbols["demand_top"],
+                    self._flexure_symbols["demand_bot"],
+                ],
                 "Value": [
                     round(self._limiting_case_flexure_top_details["forces"]["Value"][0], 2),
                     round(self._limiting_case_flexure_bot_details["forces"]["Value"][1], 2),

--- a/mento/beam_summary.py
+++ b/mento/beam_summary.py
@@ -614,7 +614,10 @@ class BeamSummary:
         bot_result_data = beam._limiting_case_flexure_bot_details["flexure_capacity_bot"]
         forces_result = {
             "Design forces": ["Top max moment", "Bottom max moment"],
-            "Variable": ["Mu,top", "Mu,bot"],
+            "Variable": [
+                beam._flexure_symbols["demand_top"],
+                beam._flexure_symbols["demand_bot"],
+            ],
             "Value": [
                 round(beam._limiting_case_flexure_top_details["forces"]["Value"][0], 2),
                 round(beam._limiting_case_flexure_bot_details["forces"]["Value"][1], 2),

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -2710,6 +2710,104 @@ def test_flexure_results_detailed_after_check(capsys) -> None:
     assert "Materials" in captured.out
 
 
+def _designed_beam_for_code(concrete) -> RectangularBeam:
+    """A designed beam carrying a positive moment, for output-wording checks."""
+    steel = SteelBar(name="ADN420", f_y=420 * MPa)
+    beam = RectangularBeam(
+        label="SYM",
+        concrete=concrete,
+        steel_bar=steel,
+        width=20 * cm,
+        height=60 * cm,
+        c_c=25 * mm,
+    )
+    Node(beam, Forces(label="C1", M_y=100 * kNm, V_z=80 * kN)).design()
+    return beam
+
+
+@pytest.mark.parametrize(
+    "concrete_factory, demand, capacity, foreign_demand",
+    [
+        (
+            lambda: Concrete_EN_1992_2004(name="C25", f_c=25 * MPa),
+            "M_{Ed}",
+            "M_{Rd}",
+            "M_u",
+        ),
+        (
+            lambda: Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+            "M_u",
+            r"\phi M_n",
+            "M_{Ed}",
+        ),
+        (
+            lambda: Concrete_CIRSOC_201_25(name="H25", f_c=25 * MPa),
+            "M_u",
+            r"\phi M_n",
+            "M_{Ed}",
+        ),
+    ],
+    ids=["EN_1992_2004", "ACI_318_19", "CIRSOC_201_25"],
+)
+def test_flexure_markdown_uses_the_symbols_of_the_design_code(
+    concrete_factory, demand: str, capacity: str, foreign_demand: str
+) -> None:
+    """The Jupyter markdown line must not label a Eurocode result with ACI symbols.
+
+    EN 1992-2004 reports M_Ed against M_Rd; ACI 318-19 and CIRSOC 201-25 report
+    M_u against phi*M_n.
+    """
+    beam = _designed_beam_for_code(concrete_factory())
+    beam.flexure_results
+
+    markdown = beam._md_flexure_results
+    assert f"${demand}$" in markdown
+    assert f"${capacity}$" in markdown
+    assert f"${foreign_demand}$" not in markdown
+
+
+@pytest.mark.parametrize(
+    "concrete_factory, demand_top, demand_bot, foreign",
+    [
+        (
+            lambda: Concrete_EN_1992_2004(name="C25", f_c=25 * MPa),
+            "MEd,top",
+            "MEd,bot",
+            "Mu,",
+        ),
+        (
+            lambda: Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+            "Mu,top",
+            "Mu,bot",
+            "MEd,",
+        ),
+        (
+            lambda: Concrete_CIRSOC_201_25(name="H25", f_c=25 * MPa),
+            "Mu,top",
+            "Mu,bot",
+            "MEd,",
+        ),
+    ],
+    ids=["EN_1992_2004", "ACI_318_19", "CIRSOC_201_25"],
+)
+def test_flexure_detailed_forces_use_the_symbols_of_the_design_code(
+    capsys, concrete_factory, demand_top: str, demand_bot: str, foreign: str
+) -> None:
+    """The limiting-case design-forces table must follow the active code.
+
+    The per-code result dictionaries already carry the right wording; this pins
+    the summary that ``flexure_results_detailed`` assembles for the limiting case,
+    which used to be hard-coded to the ACI symbols whatever the code.
+    """
+    beam = _designed_beam_for_code(concrete_factory())
+    beam.flexure_results_detailed()
+
+    captured = capsys.readouterr()
+    assert demand_top in captured.out
+    assert demand_bot in captured.out
+    assert foreign not in captured.out
+
+
 def test_shear_results_detailed_not_checked(sample_beam) -> None:
     """Test shear_results_detailed when not checked."""
     with pytest.warns(UserWarning, match="Shear check has not been performed"):


### PR DESCRIPTION
# Description

A Eurocode flexure result was reported with ACI symbols. The Jupyter markdown line read `$M_u$ = 100 kNm, $\phi M_n$ = 115.02 kNm`, and the detailed table headed its design forces `Mu,top` / `Mu,bot` — where EN 1992-2004 calls them `M_Ed` and `M_Rd`.

The per-code result dictionaries were already correct: `EN_1992_2004_beam.py` builds `MEd,top` / `MEd,bot` and `MRd`, which is why the capacity row at the end of the table looked right. The wrong labels came from three summaries assembled *outside* the code modules, each with the ACI symbols written in by hand:

- `flexure_results` — the markdown line, `$M_u$` and `$\phi M_n$` hard-coded
- `flexure_results_detailed` and `flexure_results_detailed_doc` — limiting-case design-forces table with `["Mu,top", "Mu,bot"]` hard-coded
- `BeamSummary.results_detailed_doc` — the same fixed pair

All three sit on the **limiting-case branch**, taken whenever no explicit `force` is passed, which is the usual call. Passing a `force` reads the per-code dictionary and already produced the right wording — which is why the fault looked intermittent.

The fix adds a `_flexure_symbols` property next to `_report_text` returning the symbols of the active code, and has the three sites ask for it. This follows the pattern `shear_results` already used, which branched on `design_code` correctly.

Output after the fix:

| Code | Markdown | Detailed table | Capacity |
|---|---|---|---|
| EN 1992-2004 | `$M_{Ed}$` / `$M_{Rd}$` | `MEd,top` / `MEd,bot` | `MRd` |
| ACI 318-19 | `$M_u$` / `$\phi M_n$` | `Mu,top` / `Mu,bot` | `ØMn` |
| CIRSOC 201-25 | `$M_u$` / `$\phi M_n$` | `Mu,top` / `Mu,bot` | `ØMn` |

`BeamSummary.check(capacity_check=True)` already branched correctly and is untouched.

## Type of change

- [x] Bug fix
- [ ] New feature or design code implementation
- [ ] Documentation
- [ ] Maintenance (tooling, CI, refactoring with no behaviour change)

## Checklist

- [x] Tests added or updated, and `pytest` passes locally — 659 passed, 1 skipped
- [x] `mypy mento/` passes — no issues in 26 source files
- [x] `pre-commit run --all-files` reports no changes — all hooks passed on the commit
- [x] Documentation updated where the change is user facing — no doc change needed; the theory pages already use each code's own symbols
- [x] Public class and method names left unchanged — `_flexure_symbols` is private, added alongside the existing `_report_text`

## Calculation validation

N/A — no design calculation added or modified. This changes how results are *labelled*; the numbers are untouched, and the existing calculation tests all still pass unchanged.

## Testing

Two parametrised tests over EN 1992-2004, ACI 318-19 and CIRSOC 201-25 (6 cases) pin the symbol wording — one for the markdown line, one for the detailed forces table. Verified they pinch the actual regression: with the fix reverted the two EN cases fail while the ACI and CIRSOC ones keep passing.

## Note on provenance

This commit was written against `docs-theory` and pushed a few minutes after #138 had already merged, so it missed that PR despite appearing in its final description. #138's body has been corrected to describe only the documentation work it actually contains. This branch carries the single commit, unchanged, on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
