### PR TITLE
Release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ from the release history and are summaries rather than complete lists.
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-08-25
+
 ### Added
 
 - Spanish detailed reports. `mento.set_language("es")` switches
@@ -26,13 +28,42 @@ from the release history and are summaries rather than complete lists.
 - A DOI. Releases are archived on Zenodo, and
   [10.5281/zenodo.21956634](https://doi.org/10.5281/zenodo.21956634) always resolves to the
   latest one. It is in `CITATION.cff`, in the README badge and in the citing guide.
+- A [Theory section](https://mento-docs.readthedocs.io/en/latest/theory/index.html) in the
+  documentation, with one page per element and design code, so the tool can be audited
+  against the codes it implements. Each page names what is out of scope, the places where
+  mento takes a position the code leaves open, and a table mapping every check to the test
+  that pins it and the external source it was verified against.
 
 ### Changed
 
+- Flexure output is labelled with the symbols of the active design code. An EN 1992-2004
+  result was reported with ACI symbols — `M_u` and `\phi M_n` in the markdown line, and
+  `Mu,top` / `Mu,bot` heading the design forces of the detailed table — where the Eurocode
+  writes `M_Ed` and `M_Rd`. Only the limiting-case branch was affected, which is the one
+  taken when no explicit force is passed. ACI 318-19 and CIRSOC 201-25 are unchanged.
 - The conda recipe is pinned to 0.5.1 and its checksum.
 
 ### Fixed
 
+- **EN 1992-2004 flexural design produced layouts that its own check then rejected.** Over
+  a sweep of 288 combinations, 29 designs came back with DCR > 1. Several independent
+  defects: the lever arm applied `lambda` twice, under-sizing the tension steel by about
+  2%; the ductility limits mixed the neutral-axis and block-depth conventions, leaving
+  `M_lim` about 20% too high; the redistribution limit ignored `k_3`/`k_4` above C50/60;
+  `M_Rd` counted compression steel the section did not need, which made capacity
+  non-monotonic; and the top face was sized with the bottom face's effective depth.
+  Cross-checked against the Concise Eurocode 2 closed form and plain equilibrium. Flexural
+  design is now driven by one shared strategy for both codes.
+- **The ACI size effect factor was not capped at 1.0.** ACI 318-19 Eq. 22.5.5.1.3 writes
+  `lambda_s = sqrt(2/(1 + d/10in)) <= 1.0`. Without the cap, sections with `d` below about
+  250 mm got a factor above 1, inflating `V_c` instead of reducing it — the opposite of
+  what the provision is for, and on the unsafe side. It only applies in the
+  `A_v < A_v_min` branch, so in practice this moves slabs; beams under test are unaffected.
+- Checking a section with no reinforcement for ACI shear raised `ZeroDivisionError`
+  instead of reporting an insufficient section. With `rho_w` at zero, Table 22.5.5.1 puts
+  `phi*V_n` at exactly zero and the DCR division blew up. It now reports `DCR = inf`,
+  matching the guard already in the wall module. EN is unaffected, since `V_Rd,c` carries
+  the `v_min` floor of 6.2.2(2).
 - A one-way slab is no longer reported as a beam. `OneWaySlab` inherited the titles of
   `RectangularBeam`, so its detailed reports were headed `BEAM FLEXURE DETAILED RESULTS`
   and its Word file named `Beam S1 flexure check ACI 318-19.docx`. Slabs now use their own
@@ -164,7 +195,8 @@ First public release on PyPI: rectangular concrete beam check and design for fle
 shear under ACI 318-19 and CIRSOC 201-25, unit aware calculations, results as pandas
 DataFrames, and Word calculation reports.
 
-[Unreleased]: https://github.com/mihdicaballero/mento/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/mihdicaballero/mento/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/mihdicaballero/mento/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/mihdicaballero/mento/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/mihdicaballero/mento/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/mihdicaballero/mento/compare/v0.4.0...v0.4.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,8 +26,8 @@ keywords:
   - CIRSOC 201
   - Python
 license: MIT
-version: 0.5.1
-date-released: "2026-08-15"
+version: 0.5.2
+date-released: "2026-08-25"
 identifiers:
   # Concept DOI: always resolves to the latest release, so it never has to change here.
   # The DOI of one specific release is on its own Zenodo record.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mento"
-version = "0.5.1"
+version = "0.5.2"
 description = "An intuitive tool for structural engineers to design concrete elements efficiently."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Bumps the version in `pyproject.toml` and `CITATION.cff`, and moves the `Unreleased` entries of the changelog under `0.5.2`.

The v0.5.2 GitHub Release was published against `main` while `pyproject.toml` still read `0.5.1`, so [`publish.yml`](.github/workflows/publish.yml) stopped at the tag check and nothing reached PyPI:

```
Release tag: 0.5.2 / built version: 0.5.1
##[error]Tag v0.5.2 does not match the version in pyproject.toml (0.5.1)
```

This is the bump that step was asking for. Once merged, the release has to be deleted and recreated so the `release: published` event fires again against the new `main`.

## Changelog gaps filled

The `Unreleased` section did not mention several changes that ship in this release:

- The EN 1992-2004 flexural design fix (#137)
- The missing cap on the ACI size effect factor `lambda_s` (#137)
- The `ZeroDivisionError` on an ACI shear check with no reinforcement (#137)
- Flexure symbols now following the active design code (#139)
- The new Theory section in the documentation (#137)

## Verification

- `python -m build` produces `mento-0.5.2.tar.gz` / `.whl`, so the tag check now passes
- `twine check` PASSED on both distributions
- `ruff check` and `ruff format --check` clean
- 659 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)