### PR TITLE
Drop Python 3.10, 3.11 and Ubuntu from CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13"]
-        os: ["ubuntu-latest", "windows-latest"]
+        python: ["3.12", "3.13"]
+        os: ["windows-latest"]
 
     env:
       FORCE_COLOR: "1"
@@ -39,7 +39,7 @@ jobs:
         run: pytest --cov=mento --cov-config=.coveragerc --cov-report=xml
 
       - name: Upload results to Codecov
-        if: matrix.python == '3.12' && matrix.os == 'ubuntu-latest'
+        if: matrix.python == '3.12'
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ from the release history and are summaries rather than complete lists.
 
 ## [Unreleased]
 
+### Removed
+
+- **Support for Python 3.10 and 3.11.** `requires-python` is now `>=3.12`, so pip refuses
+  to install mento on the older interpreters instead of installing it and failing later.
+  The classifiers and the conda recipe's `python_min` follow. Stay on 0.5.2 if you are
+  pinned to 3.10 or 3.11.
+- Ubuntu from the test matrix. Tests run on windows-latest against Python 3.12 and 3.13,
+  down from eight jobs to two. mento is pure Python and nothing in it is
+  platform-specific, but Linux is no longer verified on every pull request. The lint and
+  docs jobs still run on ubuntu-latest, and the PyPI distributions are still built there.
+
 ## [0.5.2] - 2026-08-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,11 +259,17 @@ Always set `$env:PYTHONIOENCODING="utf-8"` before running to avoid codec errors 
 
 Workflow: `.github/workflows/tests.yml`
 - Runs on push/PR to `main`
-- Matrix: Python 3.10, 3.11, 3.12 on ubuntu-latest and windows-latest
-- Steps: `pip install pytest pytest-cov`, `pip install -r requirements_dev.txt`
-- Lint: `ruff check .` (no auto-fix in CI)
-- Tests: `pytest --cov=mento --cov-config=.coveragerc --cov-report=xml`
-- Coverage uploaded to Codecov
+- `tests` job: Python 3.12 and 3.13 on windows-latest, installing `-e ".[test]"`.
+  Runs `pytest --cov=mento --cov-config=.coveragerc --cov-report=xml`; the 3.12 job
+  uploads coverage to Codecov.
+- `lint` job: ubuntu-latest, `ruff check .`, `ruff format --check .` and `mypy mento/`
+  (no auto-fix in CI).
+- `docs` job: ubuntu-latest, installs pandoc via apt, then
+  `sphinx-build -b html -W --keep-going` so warnings fail the build.
+
+The lint and docs jobs stay on ubuntu-latest because they are build infrastructure, not
+platform coverage — and the docs job installs pandoc with apt. Only the test matrix
+describes the platforms mento is verified on.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ the tests and validation should cover.
 
 ## Setting up your environment
 
-mento requires Python 3.10 or newer.
+mento requires Python 3.12 or newer.
 
 ```bash
 git clone https://github.com/mihdicaballero/mento.git

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository provides a comprehensive package for the design and structural a
 pip install mento
 ```
 
-Requires Python 3.10 or newer.
+Requires Python 3.12 or newer.
 
 #### Features
 - Check and design for flexure and shear of:

--- a/conda-recipe/README.md
+++ b/conda-recipe/README.md
@@ -6,7 +6,7 @@ keep in step with `pyproject.toml` so that submitting or updating the recipe is 
 rewrite.
 
 - `meta.yaml` — the recipe itself, pinned to a released version on PyPI and its sha256.
-- `conda_build_config.yaml` — raises `python_min` to 3.10, mento's minimum.
+- `conda_build_config.yaml` — raises `python_min` to 3.12, mento's minimum.
 
 The submission and update procedure is in
 [CONTRIBUTING.md](../CONTRIBUTING.md#publishing-on-conda-forge).

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
-# mento requires Python 3.10 or newer (requires-python in pyproject.toml), which is
+# mento requires Python 3.12 or newer (requires-python in pyproject.toml), which is
 # higher than the python_min conda-forge pins globally. Overriding it here keeps the
 # noarch package from advertising support for versions the project does not test.
 python_min:
-  - "3.10"
+  - "3.12"

--- a/docs/source/dev/contributing.rst
+++ b/docs/source/dev/contributing.rst
@@ -44,7 +44,7 @@ approach before you write code.
 Setting up your environment
 ---------------------------
 
-Mento requires Python 3.10 or newer.
+Mento requires Python 3.12 or newer.
 
 .. code-block:: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,15 +19,13 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Physics",
     "Typing :: Typed",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 keywords = [
     "concrete design",
     "structural engineering",
@@ -106,8 +104,7 @@ select = ["E4", "E7", "E9", "F"]
 
 [tool.mypy]
 packages = ["mento"]
-# 3.12 rather than the minimum supported 3.10: numpy 2.x ships stubs that use
-# PEP 695 `type` statements, which mypy cannot parse under an older target.
+# Matches the minimum supported version.
 python_version = "3.12"
 strict = true
 allow_any_generics = true


### PR DESCRIPTION
The test matrix was eight jobs: four Python versions across ubuntu and windows. It is now two — 3.12 and 3.13 on `windows-latest`.

## Compatibility, not just CI

Dropping the interpreters is a compatibility change, so the declared floor moves with it:

| | before | after |
|---|---|---|
| `requires-python` | `>=3.10` | `>=3.12` |
| classifiers | 3.10–3.13 | 3.12, 3.13 |
| `conda_build_config.yaml` `python_min` | `3.10` | `3.12` |

pip now refuses to install mento on 3.10 and 3.11 rather than installing it and failing somewhere less obvious. `conda-recipe/meta.yaml` templates on `{{ python_min }}`, so it follows on its own.

README, CONTRIBUTING and `docs/source/dev/contributing.rst` all said "Python 3.10 or newer"; updated.

**This is breaking, so it belongs in 0.6.0, not a patch.** The changelog entry is under `Unreleased` with a note to stay on 0.5.2 if pinned to 3.10 or 3.11.

## One thing worth catching

The Codecov upload step was gated on `matrix.python == '3.12' && matrix.os == 'ubuntu-latest'`. With ubuntu gone from the matrix that condition can never be true, so coverage would have stopped uploading without failing anything. It is now gated on the Python version alone.

## What stays on Linux

`lint` and `docs` keep running on `ubuntu-latest` — they are build infrastructure rather than platform coverage, and the docs job installs pandoc with apt. `publish.yml` still builds the PyPI distributions on Linux, and Read the Docs only offers Linux runners.

The tradeoff to be aware of: mento is pure Python and nothing in it is platform-specific, but Linux is no longer verified on every pull request, while the wheel that ships to PyPI is still built there.

Also refreshes the CI section of `CLAUDE.md`, which still described a 3.10–3.12 matrix and an install from `requirements_dev.txt`.

## Verification

- `ruff check`, `ruff format --check`, `mypy mento/` all clean
- 659 passed, 1 skipped
- `python -m build` → `Requires-Python: >=3.12`, classifiers 3.12 and 3.13 only
- workflow YAML parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)