### PR TITLE
fix: resolve audit findings M-003, M-004 and M-005

### DIFF
--- a/mento/beam.py
+++ b/mento/beam.py
@@ -533,11 +533,14 @@ class RectangularBeam(RectangularSection):
         # Calculate the centroid as a weighted average
         total_area_b = area_1_b + area_2_b + area_3_b + area_4_b
         if total_area_b == 0:
-            return 0 * mm  # Avoid division by zero if no bars are present
-
-        self._bot_rebar_centroid = (
-            area_1_b * y1_b + area_2_b * y2_b + area_3_b * y3_b + area_4_b * y4_b
-        ) / total_area_b
+            self._bot_rebar_centroid = 0 * mm
+        else:
+            self._bot_rebar_centroid = (
+                area_1_b * y1_b
+                + area_2_b * y2_b
+                + area_3_b * y3_b
+                + area_4_b * y4_b
+            ) / total_area_b
         # TOP BARS CENTROID
         # Calculate the vertical positions of the bar layers
         y1_t = self._d_b1_t / 2
@@ -554,11 +557,14 @@ class RectangularBeam(RectangularSection):
         # Calculate the centroid as a weighted average
         total_area_t = area_1_t + area_2_t + area_3_t + area_4_t
         if total_area_t == 0:
-            return 0 * mm  # Avoid division by zero if no bars are present
-
-        self._top_rebar_centroid = (
-            area_1_t * y1_t + area_2_t * y2_t + area_3_t * y3_t + area_4_t * y4_t
-        ) / total_area_t
+            self._top_rebar_centroid = 0 * mm
+        else:
+            self._top_rebar_centroid = (
+                area_1_t * y1_t
+                + area_2_t * y2_t
+                + area_3_t * y3_t
+                + area_4_t * y4_t
+            ) / total_area_t
 
     def _update_longitudinal_rebar_attributes(self) -> None:
         """Recalculate attributes dependent on rebar configuration for both top and bottom reinforcing."""

--- a/mento/beam.py
+++ b/mento/beam.py
@@ -536,10 +536,7 @@ class RectangularBeam(RectangularSection):
             self._bot_rebar_centroid = 0 * mm
         else:
             self._bot_rebar_centroid = (
-                area_1_b * y1_b
-                + area_2_b * y2_b
-                + area_3_b * y3_b
-                + area_4_b * y4_b
+                area_1_b * y1_b + area_2_b * y2_b + area_3_b * y3_b + area_4_b * y4_b
             ) / total_area_b
         # TOP BARS CENTROID
         # Calculate the vertical positions of the bar layers
@@ -560,10 +557,7 @@ class RectangularBeam(RectangularSection):
             self._top_rebar_centroid = 0 * mm
         else:
             self._top_rebar_centroid = (
-                area_1_t * y1_t
-                + area_2_t * y2_t
-                + area_3_t * y3_t
-                + area_4_t * y4_t
+                area_1_t * y1_t + area_2_t * y2_t + area_3_t * y3_t + area_4_t * y4_t
             ) / total_area_t
 
     def _update_longitudinal_rebar_attributes(self) -> None:

--- a/mento/beam_summary.py
+++ b/mento/beam_summary.py
@@ -71,7 +71,7 @@ class BeamSummary:
         # print("Processed Data: Ok")
 
     def validate_units(self, units_row: List) -> None:
-        valid_units = {"m", "mm", "cm", "inch", "ft", "kN", "kNm", ""}
+        valid_units = {"m", "mm", "cm", "in", "inch", "ft", "kN", "kNm", "MPa", ""}
         for unit_str in units_row:
             if unit_str and unit_str not in valid_units:
                 raise ValueError(f"Invalid unit '{unit_str}' detected. Allowed units: {valid_units}")
@@ -84,6 +84,7 @@ class BeamSummary:
             "cm": cm,
             "m": m,
             "in": inch,
+            "inch": inch,
             "ft": ft,
             "kN": kN,
             "kNm": kNm,

--- a/mento/forces.py
+++ b/mento/forces.py
@@ -149,7 +149,7 @@ class Forces:
         """
         if by not in ["N_x", "V_z", "M_y", "M_x"]:
             raise ValueError("Comparison attribute must be one of 'N_x', 'V_z', 'M_y', or 'M_x'")
-        return getattr(self, by).magnitude > getattr(other, by).magnitude
+        return getattr(self, by) > getattr(other, by)
 
     def __str__(self) -> str:
         base = f"Force ID: {self.id}, Label: {self.label}, N_x: {self.N_x}, V_z: {self.V_z}, M_y: {self.M_y}"

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -3542,6 +3542,35 @@ def test_clear_top_longitudinal_imperial(beam_example_imperial: RectangularBeam)
     assert beam_example_imperial.reinforcement.top.n_bars == 0
 
 
+def test_clearing_bottom_rebar_resets_centroid(
+    beam_example_EN_1992_2004_01: RectangularBeam,
+) -> None:
+    """Clearing the bottom reinforcement must also clear its centroid."""
+    beam = beam_example_EN_1992_2004_01
+
+    beam.set_longitudinal_rebar_bot(n1=4, d_b1=20 * mm)
+    assert beam._bot_rebar_centroid.to("mm").magnitude > 0
+
+    beam.set_longitudinal_rebar_bot(n1=0, d_b1=0 * mm)
+
+    assert beam._A_s_bot.to("mm**2").magnitude == pytest.approx(0)
+    assert beam._bot_rebar_centroid.to("mm").magnitude == pytest.approx(0)
+
+
+def test_clearing_top_rebar_resets_centroid(
+    beam_example_EN_1992_2004_01: RectangularBeam,
+) -> None:
+    """Clearing the top reinforcement must also clear its centroid."""
+    beam = beam_example_EN_1992_2004_01
+
+    beam.set_longitudinal_rebar_top(n1=4, d_b1=20 * mm)
+    assert beam._top_rebar_centroid.to("mm").magnitude > 0
+
+    beam.set_longitudinal_rebar_top(n1=0, d_b1=0 * mm)
+
+    assert beam._A_s_top.to("mm**2").magnitude == pytest.approx(0)
+    assert beam._top_rebar_centroid.to("mm").magnitude == pytest.approx(0)
+
 def test_longitudinal_rebar_area_ignores_none_diameters() -> None:
     """Diameters forced to None (not through the setters) count as zero area."""
     beam = build_metric_beam()

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -3571,6 +3571,7 @@ def test_clearing_top_rebar_resets_centroid(
     assert beam._A_s_top.to("mm**2").magnitude == pytest.approx(0)
     assert beam._top_rebar_centroid.to("mm").magnitude == pytest.approx(0)
 
+
 def test_longitudinal_rebar_area_ignores_none_diameters() -> None:
     """Diameters forced to None (not through the setters) count as zero area."""
     beam = build_metric_beam()

--- a/tests/test_beam_summary.py
+++ b/tests/test_beam_summary.py
@@ -15,7 +15,7 @@ from docx.oxml.ns import qn
 from docx.shared import Cm, Emu
 from pathlib import Path
 
-from mento import MPa, mm, cm, kN, kNm, m
+from mento import MPa, mm, cm, kN, kNm, m, inch
 from mento.beam_summary import BeamSummary
 from mento.reports.summaries import (
     BEAM_DATA_COLUMNS,
@@ -174,7 +174,7 @@ def test_beam_summary_with_en_1992_concrete(
 
 def test_validate_units_valid(beam_summary: BeamSummary) -> None:
     """Test validation with all valid units."""
-    valid_units = ["m", "mm", "cm", "inch", "ft", "kN", "kNm", ""]
+    valid_units = ["m", "mm", "cm", "in", "inch", "ft", "kN", "kNm", "MPa", ""]
     # Should not raise any exception
     beam_summary.validate_units(valid_units)
 
@@ -203,6 +203,8 @@ def test_get_unit_variable_valid_units(beam_summary: BeamSummary) -> None:
     assert beam_summary.get_unit_variable("mm") == mm
     assert beam_summary.get_unit_variable("cm") == cm
     assert beam_summary.get_unit_variable("m") == m
+    assert beam_summary.get_unit_variable("in") == inch
+    assert beam_summary.get_unit_variable("inch") == inch
     assert beam_summary.get_unit_variable("kN") == kN
     assert beam_summary.get_unit_variable("kNm") == kNm
     assert beam_summary.get_unit_variable("MPa") == MPa

--- a/tests/test_forces.py
+++ b/tests/test_forces.py
@@ -217,11 +217,13 @@ def test_compare_to_M_y(custom_metric_forces: Forces) -> None:
     assert custom_metric_forces.compare_to(other_forces_larger, by="M_y") is False
 
 
-def test_compare_to_different_units(custom_metric_forces: Forces) -> None:
-    """Test compare_to with Forces objects having different internal units."""
-    # custom_metric_forces.V_z is 50 kN
-    other_forces_imperial = Forces(V_z=10 * kip)  # 10 kip = 44.48 kN
-    assert custom_metric_forces.compare_to(other_forces_imperial, by="V_z") is True  # 50 kN > 44.48 kN
+def test_compare_to_different_unit_systems() -> None:
+    """Comparison must account for different force units."""
+    metric_force = Forces(V_z=20 * kN, unit_system="metric")
+    imperial_force = Forces(V_z=5 * kip, unit_system="imperial")
+
+    assert metric_force.compare_to(imperial_force, by="V_z") is False
+    assert imperial_force.compare_to(metric_force, by="V_z") is True
 
 
 def test_compare_to_invalid_attribute(custom_metric_forces: Forces) -> None:


### PR DESCRIPTION
fix: resolve force comparison, unit aliases, and rebar centroids

# Description

<!-- What does this change do, and why? -->

Closes #

## Type of change

- [x] Bug fix
- [ ] New feature or design code implementation
- [ ] Documentation
- [ ] Maintenance (tooling, CI, refactoring with no behaviour change)

## Checklist

- [ ] Tests added or updated, and `pytest` passes locally
- [ ] `mypy mento/` passes
- [ ] `pre-commit run --all-files` reports no changes
- [ ] Documentation updated where the change is user facing
- [ ] Public class and method names left unchanged, or the change was agreed beforehand

## Calculation validation

<!-- Required when this PR adds or modifies a design calculation. Delete this section if it
     does not apply. -->

- [ ] Validated in CalcPad, and the file is included in this PR
- **Reference example:** <!-- standard, clause, example number and page, or textbook -->
- **Result comparison:** <!-- expected vs. mento, and the tolerance used in the test -->
