### PR TITLE
fix(slab): a one-way slab is designed without stirrups when its concrete carries the shear

### DIFF
--- a/mento/beam.py
+++ b/mento/beam.py
@@ -36,8 +36,91 @@ from mento.design_results import (
 )
 
 
+class _DesignCodeAttributes:
+    """Attributes the design codes write onto a section, declared for type checkers.
+
+    Kept off ``RectangularBeam`` itself: that class is a dataclass, so an
+    annotation in its body -- even one guarded by ``TYPE_CHECKING`` -- counts as a
+    field to a type checker, and every private name below showed up in the editor
+    as a required constructor argument. A plain base class contributes no fields,
+    so the synthesized signature stays the handful the caller actually passes.
+    """
+
+    # ------------------------------------------------------------------
+    # The ADR-0001 compatibility layer: declared, never assigned here.
+    #
+    # A check no longer writes its results to the section. These exist because
+    # the report tables still read them off the element, and each design code
+    # zeroes its own set through ``DesignCode.initialize_attributes``, so a
+    # table asked for before any check has run finds a number instead of an
+    # AttributeError.
+    #
+    # Declared under TYPE_CHECKING so the type checker knows they exist and
+    # what they hold, without adding anything at runtime.
+    #
+    # They leave with the compatibility layer. A new design code should not add
+    # to this list -- its report tables should read the check state instead.
+    # ------------------------------------------------------------------
+    if TYPE_CHECKING:
+        # ACI 318-19 and CIRSOC 201-25
+        _phi_V_n: Quantity
+        _phi_V_s: Quantity
+        _phi_V_c: Quantity
+        _phi_V_max: Quantity
+        _V_u: Quantity
+        _M_u: Quantity
+        _M_u_bot: Quantity
+        _M_u_top: Quantity
+        _N_u: Quantity
+        _A_cv: Quantity
+        _k_c_min: Quantity
+        _sigma_Nu: Quantity
+        V_c: Quantity
+        _rho_w: Quantity
+        f_yt: Quantity
+        _phi_M_n_bot: Quantity
+        _phi_M_n_top: Quantity
+        _d_b_max_bot: Quantity
+        _d_b_max_top: Quantity
+        _lambda_s: float
+        _max_shear_ok: bool
+        _A_s_bool_bot: bool
+        _A_s_bool_top: bool
+        # EN 1992-2004
+        _V_Ed_1: Quantity
+        _V_Ed_2: Quantity
+        _N_Ed: Quantity
+        _M_Ed: Quantity
+        _M_Ed_bot: Quantity
+        _M_Ed_top: Quantity
+        _M_Rd_bot: Quantity
+        _M_Rd_top: Quantity
+        _sigma_cd: Quantity
+        _sigma_cp: Quantity
+        _V_Rd_c: Quantity
+        _V_Rd_s: Quantity
+        _V_Rd_max: Quantity
+        _V_Rd: Quantity
+        _f_ywk: Quantity
+        _f_ywd: Quantity
+        _f_cd: Quantity
+        _f_cd_shear: Quantity
+        _A_p: Quantity
+        _z: Quantity
+        _k_value: float
+        _theta: float
+        _cot_theta: float
+        # Both
+        _A_s_min_bot: Quantity
+        _A_s_min_top: Quantity
+        _A_s_max_bot: Quantity
+        _A_s_max_top: Quantity
+        flexure_design_results_bot: Any
+        flexure_design_results_top: Any
+
+
 @dataclass
-class RectangularBeam(RectangularSection):
+class RectangularBeam(RectangularSection, _DesignCodeAttributes):
     """
     Represents a reinforced concrete rectangular beam section with methods for design, checking,
     and visualization of longitudinal and transverse reinforcement according to various design codes.
@@ -177,79 +260,6 @@ class RectangularBeam(RectangularSection):
         self._flexure_capacity_bot: Dict = {}
         self._flexure_capacity_top: Dict = {}
         self._flexure_all_checks: bool = False
-
-    # ------------------------------------------------------------------
-    # The ADR-0001 compatibility layer: declared, never assigned here.
-    #
-    # A check no longer writes its results to the section. These exist because
-    # the report tables still read them off the element, and each design code
-    # zeroes its own set through ``DesignCode.initialize_attributes``, so a
-    # table asked for before any check has run finds a number instead of an
-    # AttributeError.
-    #
-    # Declared under TYPE_CHECKING for two reasons: the type checker needs to
-    # know they exist and what they hold, and ``RectangularBeam`` is a
-    # dataclass, so a plain annotation here would become a constructor field.
-    #
-    # They leave with the compatibility layer. A new design code should not add
-    # to this list -- its report tables should read the check state instead.
-    # ------------------------------------------------------------------
-    if TYPE_CHECKING:
-        # ACI 318-19 and CIRSOC 201-25
-        _phi_V_n: Quantity
-        _phi_V_s: Quantity
-        _phi_V_c: Quantity
-        _phi_V_max: Quantity
-        _V_u: Quantity
-        _M_u: Quantity
-        _M_u_bot: Quantity
-        _M_u_top: Quantity
-        _N_u: Quantity
-        _A_cv: Quantity
-        _k_c_min: Quantity
-        _sigma_Nu: Quantity
-        V_c: Quantity
-        _rho_w: Quantity
-        f_yt: Quantity
-        _phi_M_n_bot: Quantity
-        _phi_M_n_top: Quantity
-        _d_b_max_bot: Quantity
-        _d_b_max_top: Quantity
-        _lambda_s: float
-        _max_shear_ok: bool
-        _A_s_bool_bot: bool
-        _A_s_bool_top: bool
-        # EN 1992-2004
-        _V_Ed_1: Quantity
-        _V_Ed_2: Quantity
-        _N_Ed: Quantity
-        _M_Ed: Quantity
-        _M_Ed_bot: Quantity
-        _M_Ed_top: Quantity
-        _M_Rd_bot: Quantity
-        _M_Rd_top: Quantity
-        _sigma_cd: Quantity
-        _sigma_cp: Quantity
-        _V_Rd_c: Quantity
-        _V_Rd_s: Quantity
-        _V_Rd_max: Quantity
-        _V_Rd: Quantity
-        _f_ywk: Quantity
-        _f_ywd: Quantity
-        _f_cd: Quantity
-        _f_cd_shear: Quantity
-        _A_p: Quantity
-        _z: Quantity
-        _k_value: float
-        _theta: float
-        _cot_theta: float
-        # Both
-        _A_s_min_bot: Quantity
-        _A_s_min_top: Quantity
-        _A_s_max_bot: Quantity
-        _A_s_max_top: Quantity
-        flexure_design_results_bot: Any
-        flexure_design_results_top: Any
 
     def _initialize_code_attributes(self) -> None:
         design_code(self.concrete).initialize_attributes(self)
@@ -767,10 +777,55 @@ class RectangularBeam(RectangularSection):
     # CHECK & DESIGN SHEAR
     ##########################################################
 
+    def _clear_transverse_rebar_design(self) -> None:
+        """Record a shear design that places no stirrups.
+
+        Mirrors what the stirrup designer leaves behind for a real cage, so the
+        report tables and ``BeamSummary`` read the same keys either way -- they
+        just read zeros.
+        """
+        length_unit = "cm" if self.concrete.unit_system == "metric" else "inch"
+        area_unit = "cm**2/m" if self.concrete.unit_system == "metric" else "inch**2/ft"
+        empty = {
+            "n_stir": 0,
+            "d_b": (0 * mm).to(length_unit),
+            "s_l": (0 * mm).to(length_unit),
+            "s_w": (0 * mm).to(length_unit),
+            "A_v": (0 * cm**2 / m).to(area_unit),
+            "s_max_l": (0 * mm).to(length_unit),
+            "s_max_w": (0 * mm).to(length_unit),
+        }
+        self.shear_design_results = pd.DataFrame([empty])
+        self._best_rebar_design = self.shear_design_results.iloc[0]
+        self._stirrup_s_w = empty["s_w"]
+        self._stirrup_s_max_l = empty["s_max_l"]
+        self._stirrup_s_max_w = empty["s_max_w"]
+        self.set_transverse_rebar(0, 0 * mm, 0 * cm)
+
+    @property
+    def _stirrups_optional(self) -> bool:
+        """Whether this element may be built with no transverse reinforcement at all.
+
+        A beam never may. Stirrups run the whole length of a beam whatever the
+        shear diagram says, so designing one always places at least the minimum
+        area -- ACI 318-19 Table 9.6.3.4, EN 1992-1-1 Eq. (9.5N) -- even where
+        the concrete alone would carry Vu. ACI 9.6.3.1 waives that minimum below
+        a threshold and the check reports the waiver, but the design does not
+        follow it down.
+
+        A one-way slab is the exception both codes name: ACI 318-19 7.6.3.1 only
+        calls for shear reinforcement where Vu exceeds phi*Vc, and EN 1992-1-1
+        6.2.1(4) drops the minimum in members where the load can redistribute
+        transversally. So a slab the concrete alone carries is designed with no
+        stirrups at all, rather than given a cage it does not need.
+        """
+        return self.mode == "slab"
+
     # Factory method to select the shear design method
     def design_shear(self, forces: list[Forces]) -> DataFrame:
         # Track the maximum A_v_req to identify the limiting case
         max_A_v_req = 0 * cm**2 / m
+        max_V_s_req = 0 * kN
 
         # Step 1: Identify the worst-case force
         for force in forces:
@@ -782,6 +837,13 @@ class RectangularBeam(RectangularSection):
                 max_V_s_req = self._V_s_req
 
         # Step 2: Perform rebar design for the worst-case force
+        if self._stirrups_optional and max_A_v_req <= 0 * cm**2 / m:
+            # No combination asks for shear reinforcement and the code does not
+            # impose a minimum here, so the section is built without stirrups.
+            self._clear_transverse_rebar_design()
+            self._update_longitudinal_rebar_attributes()
+            return self.check_shear(forces)
+
         section_rebar = Rebar(self)
         self.shear_design_results = section_rebar.transverse_rebar(max_A_v_req, max_V_s_req, self._alpha)
         self._best_rebar_design = section_rebar.transverse_rebar_design

--- a/mento/beam.py
+++ b/mento/beam.py
@@ -395,6 +395,36 @@ class RectangularBeam(RectangularSection, _DesignCodeAttributes):
         # Recalculate effective depths using the new stirrup diameter.
         self._update_effective_heights()
 
+    def _leg_spacing_across_width(self) -> Quantity:
+        """Distance between adjacent stirrup legs, measured across the section.
+
+        A beam's legs are the sides of its stirrup cage, so their spacing is not
+        detailed directly: it falls out of how many legs are spread between the
+        centres of the outermost pair. A slab's is a detailing decision of its
+        own, which is why the two sections answer this differently and the shear
+        checks ask the section instead of assuming the cage.
+
+        Zero when the section carries no stirrups, so that a section without
+        shear reinforcement reports no spacing rather than a negative one.
+        """
+        n_legs = self._stirrup_n * 2
+        if n_legs < 2:
+            return 0 * self._len_unit()
+        return max(
+            (self.width - 2 * self.c_c - self._stirrup_d_b) / (n_legs - 1),
+            0 * self._len_unit(),
+        )
+
+    def _apply_transverse_design(self, design: Any) -> None:
+        """Store the row the transverse rebar search chose.
+
+        A hook rather than a call inlined in :meth:`design_shear`, because a
+        section is detailed the way it is reinforced: a beam by a stirrup count
+        and a spacing, a slab by a spacing in each direction. Only the section
+        knows which of the two the row means.
+        """
+        self.set_transverse_rebar(design["n_stir"], design["d_b"], design["s_l"])
+
     def _len_unit(self) -> Quantity:
         # Base length unit for this section
         return 1 * mm if getattr(self.concrete, "unit_system", "metric") == "metric" else 1 * inch
@@ -851,11 +881,7 @@ class RectangularBeam(RectangularSection, _DesignCodeAttributes):
         self._stirrup_s_w = self._best_rebar_design["s_w"]
         self._stirrup_s_max_l = self._best_rebar_design["s_max_l"]
         self._stirrup_s_max_w = self._best_rebar_design["s_max_w"]
-        self.set_transverse_rebar(
-            self._best_rebar_design["n_stir"],
-            self._best_rebar_design["d_b"],
-            self._best_rebar_design["s_l"],
-        )
+        self._apply_transverse_design(self._best_rebar_design)
 
         # Update longitudinal rebar attributes
         self._update_longitudinal_rebar_attributes()

--- a/mento/codes/ACI_318_19_beam.py
+++ b/mento/codes/ACI_318_19_beam.py
@@ -115,6 +115,13 @@ def _calculate_A_v_min_ACI(self: "RectangularBeam", st: ShearCheckState, f_c: fl
     # 'Minimum reinforcement should be placed if the factored shear Vu
     # is greater than half the shear capacity of the concrete,
     # reduced by 0.5phi*Vc. It is assumed that minimum reinforcement is required.
+    if self._stirrups_optional:
+        # 7.6.3.1: a one-way slab carries no minimum shear reinforcement, so the
+        # 9.6.3.1 floor above does not apply. A_v_req then falls out of
+        # _calculate_V_s_req as max(Vu - phi*Vc, 0), which is the threshold the
+        # slab clause actually sets.
+        st.A_v_min = 0.0
+        return
     sec = section_floats(self)
     st.A_v_min = shear_eq.min_shear_reinforcement_ratio(
         f_c, _calculate_f_yt_aci(self), sec.width, is_imperial=sec.is_imperial
@@ -269,6 +276,15 @@ def _design_shear_ACI_318_19(self: "RectangularBeam", force: Forces) -> None:
     _check_minimum_reinforcement_requirement_aci(self, st)
     # Calculate required shear reinforcement
     _calculate_V_s_req(self, st)
+    # 9.6.3.1 waives A_v,min below its threshold and the check reports that
+    # faithfully, but designing does not follow the waiver down: a beam is built
+    # with stirrups over its whole length, so the cage asked of the designer
+    # never drops below Table 9.6.3.4. Without this floor a lightly loaded beam
+    # came back under the minimum -- 1eO6/28cm = 2.02 cm2/m on a 30x60 against
+    # the 2.50 cm2/m the table asks for. _calculate_A_v_min_ACI returns zero for
+    # a section that may go without stirrups at all, so a slab is unaffected.
+    _calculate_A_v_min_ACI(self, st, sec.f_c)
+    st.A_v_req = max(st.A_v_req, st.A_v_min)
     apply_shear_state(self, st)
     # Update spacing of longitudinal reinforcement calculation
     self._update_longitudinal_rebar_attributes()

--- a/mento/codes/ACI_318_19_beam.py
+++ b/mento/codes/ACI_318_19_beam.py
@@ -179,8 +179,7 @@ def _calculate_total_shear_strength_aci(self: "RectangularBeam", st: ShearCheckS
 
 def _calculate_rebar_spacing_aci(self: "RectangularBeam", st: ShearCheckState) -> None:
     sec = section_floats(self)
-    n_legs_actual = sec.stirrup_n * 2  # Ensure legs are even
-    st.stirrup_s_w = max((sec.width - 2 * sec.c_c - sec.stirrup_d_b) / (n_legs_actual - 1), 0.0)
+    st.stirrup_s_w = sec.stirrup_s_w
     (
         st.stirrup_s_max_l,
         st.stirrup_s_max_w,

--- a/mento/codes/EN_1992_2004_beam.py
+++ b/mento/codes/EN_1992_2004_beam.py
@@ -215,9 +215,7 @@ def _check_shear_EN_1992_2004(self: "RectangularBeam", force: Forces) -> ENShear
         _calculate_required_shear_reinforcement_EN_1992_2004(self, st)
 
         # Rebar spacing checks
-        sec = section_floats(self)
-        n_legs_actual = sec.stirrup_n * 2  # Ensure legs are even
-        st.stirrup_s_w = (sec.width - 2 * sec.c_c - sec.stirrup_d_b) / (n_legs_actual - 1)
+        st.stirrup_s_w = section_floats(self).stirrup_s_w
         (
             st.stirrup_s_max_l,
             st.stirrup_s_max_w,

--- a/mento/codes/EN_1992_2004_beam.py
+++ b/mento/codes/EN_1992_2004_beam.py
@@ -64,11 +64,17 @@ def _initialize_shear_variables_EN_1992_2004(self: "RectangularBeam", st: ENShea
 
         # Minimum shear reinforcement calculation. Eq. (9.5N) gives the ratio;
         # §9.2.2(5) defines it as A_sw/(s*b_w*sin(alpha)), hence the geometry here.
-        rho_min = shear_eq.min_shear_reinforcement_ratio(
-            sec.f_c,
-            self._f_ywk.to(MPa).magnitude,
-        )
-        st.A_v_min = rho_min * sec.width * math.sin(self._alpha)
+        # §6.2.1(4) waives that minimum in members where the load can redistribute
+        # transversally -- slabs are the example the clause names -- so there it is
+        # zero and V_Rd,c alone decides whether stirrups are needed at all.
+        if self._stirrups_optional:
+            st.A_v_min = 0.0
+        else:
+            rho_min = shear_eq.min_shear_reinforcement_ratio(
+                sec.f_c,
+                self._f_ywk.to(MPa).magnitude,
+            )
+            st.A_v_min = rho_min * sec.width * math.sin(self._alpha)
 
         # Consider bottom or top tension reinforcement
         st.A_s_tension = sec.A_s_bot if force._M_y >= 0 * kNm else sec.A_s_top
@@ -241,6 +247,21 @@ def _design_shear_EN_1992_2004(self: "RectangularBeam", force: Forces) -> None:
         st.f_cd_shear = self._f_cd_shear.to(MPa).magnitude
         st.f_cd = self._f_cd.to(MPa).magnitude
         _initialize_shear_variables_EN_1992_2004(self, st, force)
+
+        if self._stirrups_optional:
+            # §6.2.2(1): a member that needs no minimum stirrups needs none at all
+            # while V_Ed stays within V_Rd,c. Sizing from the truss model regardless
+            # would hand a slab a cage for a shear its concrete already carries.
+            st.V_Rd_c = _shear_without_rebar_EN_1992_2004(self, st)
+            if st.V_Ed_2 <= st.V_Rd_c:
+                st.A_v_req = 0.0
+                st.V_s_req = 0.0
+                st.V_Rd = st.V_Rd_c
+                st.V_Rd_max = st.V_Rd
+                st.max_shear_ok = st.V_Ed_1 <= st.V_Rd_max
+                apply_en_shear_state(self, st)
+                return None
+
         # Calculate maximum shear strength
         _calculate_max_shear_strength_EN_1992_2004(self, st)
         # Calculate required shear reinforcement area

--- a/mento/design_results.py
+++ b/mento/design_results.py
@@ -190,14 +190,47 @@ class FaceReinforcement:
         return " + ".join(str(layer) for layer in self.layers)
 
 
+#: How a section carries its transverse reinforcement. A beam carries closed
+#: stirrups; a slab strip carries a grid of legs, with no cage to count.
+STIRRUPS = "stirrups"
+GRID = "grid"
+
+
+def format_transverse_rebar(layout: str, n_stirrups: int, d_b: str, s_l: str, s_w: str) -> str:
+    """Label the transverse reinforcement in the notation of its element.
+
+    A beam is a number of closed stirrups of one diameter at one spacing along
+    the length, so the count leads: ``2eØ10/15cm``. A slab strip has no cage --
+    the same bar sits on a grid -- so what identifies it is the diameter once
+    and a spacing each way, longitudinal first: ``Ø10/15cm×20cm``. The diameter
+    is not repeated: both directions are the same bar.
+
+    Takes the numbers already formatted, so each caller keeps its own precision
+    and units while the shape of the label is decided in one place.
+    """
+    if n_stirrups == 0:
+        return "no stirrups"
+    if layout == GRID:
+        return f"Ø{d_b}/{s_l}×{s_w}"
+    return f"{n_stirrups}eØ{d_b}/{s_l}"
+
+
 @dataclass(frozen=True)
 class TransverseReinforcement:
-    """The stirrups a section carries, as configured."""
+    """The transverse reinforcement a section carries, as configured.
+
+    ``s_l`` is the spacing along the length and ``s_w`` the spacing across the
+    width. On a beam the second is not detailed but implied -- it is where the
+    legs of the cage fall -- while on a slab strip both are chosen, which is
+    what ``layout`` distinguishes.
+    """
 
     n_stirrups: int
     d_b: Quantity
     s_l: Quantity
     A_v: Quantity
+    s_w: Quantity
+    layout: str = STIRRUPS
 
     @property
     def n_legs(self) -> int:
@@ -205,9 +238,13 @@ class TransverseReinforcement:
         return self.n_stirrups * 2
 
     def __str__(self) -> str:
-        if self.n_stirrups == 0:
-            return "no stirrups"
-        return f"{self.n_stirrups}eØ{self.d_b:.4g~P}/{self.s_l:.4g~P}"
+        return format_transverse_rebar(
+            self.layout,
+            self.n_stirrups,
+            f"{self.d_b:.4g~P}",
+            f"{self.s_l:.4g~P}",
+            f"{self.s_w:.4g~P}",
+        )
 
 
 @dataclass(frozen=True)
@@ -286,6 +323,8 @@ class ShearDesign:
     A_v_req: Quantity
     A_v_min: Quantity
     DCR: float
+    s_w: Quantity
+    layout: str = STIRRUPS
 
     @property
     def n_legs(self) -> int:
@@ -293,9 +332,18 @@ class ShearDesign:
         return self.n_stirrups * 2
 
     def __str__(self) -> str:
-        if self.n_stirrups == 0:
-            return "no stirrups"
-        return f"{self.n_stirrups}eØ{self.d_b:.4g~P}/{self.s_l:.4g~P}"
+        return format_transverse_rebar(
+            self.layout,
+            self.n_stirrups,
+            f"{self.d_b:.4g~P}",
+            f"{self.s_l:.4g~P}",
+            f"{self.s_w:.4g~P}",
+        )
+
+
+def transverse_layout(beam: RectangularBeam) -> str:
+    """Which notation the section's transverse reinforcement is written in."""
+    return GRID if getattr(beam, "mode", "beam") == "slab" else STIRRUPS
 
 
 def _layers(beam: RectangularBeam, face: str) -> Tuple[RebarLayer, ...]:
@@ -348,6 +396,8 @@ def build_reinforcement(beam: RectangularBeam) -> SectionReinforcement:
             d_b=beam._stirrup_d_b,
             s_l=beam._stirrup_s_l,
             A_v=beam._A_v,
+            s_w=beam._leg_spacing_across_width(),
+            layout=transverse_layout(beam),
         ),
     )
 
@@ -389,4 +439,6 @@ def build_shear_design(beam: RectangularBeam) -> ShearDesign:
         A_v_req=zero if worst.A_v_req is None else worst.A_v_req,
         A_v_min=zero if worst.A_v_min is None else worst.A_v_min,
         DCR=worst.DCR,
+        s_w=beam._leg_spacing_across_width(),
+        layout=transverse_layout(beam),
     )

--- a/mento/plots/sections.py
+++ b/mento/plots/sections.py
@@ -19,6 +19,7 @@ from matplotlib.figure import Figure
 from matplotlib.patches import Circle, FancyBboxPatch, Rectangle
 from pint import Quantity
 
+from mento.design_results import format_transverse_rebar
 from mento.results import CUSTOM_COLORS
 
 if TYPE_CHECKING:
@@ -265,15 +266,22 @@ def _annotate_stirrups_text(
 ) -> None:
     """
     Escribe la leyenda de estribos a la derecha, a media altura.
-    Ejemplo: '1eØ6/20' o '2eØ6/20'.
+    Ejemplo: '1eØ6/20' en una viga, 'Ø10/8×15' en una losa.
     """
     if self._stirrup_n == 0:
         return  # nothing to show
 
-    phi_mm = self._stirrup_d_b.to("mm").magnitude
-    s_cm = self._stirrup_s_l.to("cm").magnitude
-
-    text = f"{self._stirrup_n:.0f}eØ{phi_mm:.0f}/{s_cm:.0f}"
+    transverse = self.reinforcement.transverse
+    # Bare magnitudes, as the drawing has always shown them: mm for the bar,
+    # cm for the spacings, no unit suffix. The shape of the label is the
+    # element's, which is what format_transverse_rebar decides.
+    text = format_transverse_rebar(
+        transverse.layout,
+        transverse.n_stirrups,
+        f"{self._stirrup_d_b.to('mm').magnitude:.0f}",
+        f"{self._stirrup_s_l.to('cm').magnitude:.0f}",
+        f"{transverse.s_w.to('cm').magnitude:.0f}",
+    )
 
     x_text = width_cm + 0.1 * width_cm
     y_text = height_cm / 2.0

--- a/mento/precompute.py
+++ b/mento/precompute.py
@@ -78,6 +78,7 @@ class SectionFloats:
     A_v: float
     stirrup_d_b: float
     stirrup_n: int
+    stirrup_s_w: float
     f_c: float
     f_y: float
     E_s: float
@@ -129,6 +130,9 @@ def refresh_section_floats(section: "RectangularBeam") -> SectionFloats:
         A_v=section._A_v.to(length).magnitude,
         stirrup_d_b=section._stirrup_d_b.to(length).magnitude,
         stirrup_n=section._stirrup_n,
+        # Asked of the section rather than derived here: a beam and a slab space
+        # their legs across the width by different rules.
+        stirrup_s_w=section._leg_spacing_across_width().to(length).magnitude,
         f_c=section.concrete.f_c.to(stress).magnitude,
         f_y=section.steel_bar.f_y.to(stress).magnitude,
         E_s=section.steel_bar._E_s.to(stress).magnitude,

--- a/mento/rebar.py
+++ b/mento/rebar.py
@@ -120,6 +120,12 @@ class Rebar:
 
     @property
     def transverse_rebar_design(self) -> DataFrame:
+        if self._trans_combos_df.empty:
+            raise RebarDesignInfeasibleError(
+                "No valid transverse rebar combination found — no bar the code "
+                "allows, at any spacing within its limits, provides the required "
+                "A_v. The section is too shallow for the shear it carries."
+            )
         return self._trans_combos_df.iloc[0]
 
     ##########################################################
@@ -232,15 +238,31 @@ class Rebar:
         return n_legs + (n_legs % 2)
 
     def transverse_rebar(self, A_v_req: Quantity, V_s_req: Quantity, alpha: float) -> DataFrame:
-        """
-        Computes the required transverse reinforcement based on ACI 318-19.
+        """Select the transverse reinforcement that covers ``A_v_req``.
+
+        A beam and a slab strip are reinforced differently, so they are searched
+        differently. A beam carries closed stirrups, so the free variables are
+        the bar diameter, the number of legs across the width and the spacing
+        along the length. A slab strip carries a grid of legs, and both spacings
+        are free -- the parameterisation
+        :meth:`~mento.slab.OneWaySlab.set_slab_transverse_rebar` already takes.
 
         Args:
-            A_v_req: Required area for transverse reinforcement.
+            A_v_req: Required area of transverse reinforcement per unit length.
+            V_s_req: Shear the reinforcement must carry, which sets the spacing
+                limits.
+            alpha: Inclination of the shear reinforcement, for EN.
 
         Returns:
-            A dictionary containing the transverse rebar design.
+            Every valid combination, best first; ``transverse_rebar_design``
+            reads the first row.
         """
+        if self.mode == "slab":
+            return self._transverse_rebar_slab(A_v_req, V_s_req, alpha)
+        return self._transverse_rebar_beam(A_v_req, V_s_req, alpha)
+
+    def _transverse_rebar_beam(self, A_v_req: Quantity, V_s_req: Quantity, alpha: float) -> DataFrame:
+        """Closed stirrups: (d_b, n_legs, s_l), the legs spread across the width."""
 
         # Prepare the list for valid combinations
         valid_combinations = []
@@ -331,6 +353,121 @@ class Rebar:
         # Sort by 'A_v' first, then by 'n_stir' to prioritize fewer bars
         df_combinations.sort_values(by=["n_stir", "A_v"], inplace=True)
         df_combinations.reset_index(drop=True, inplace=True)
+        self._trans_combos_df = df_combinations
+        return df_combinations
+
+    def _slab_spacing_limits(self, d_b: Quantity, V_s_req: Quantity, alpha: float) -> Tuple[Quantity, Quantity]:
+        """The code's spacing limits for a section carrying stirrups of diameter ``d_b``.
+
+        Both limits are written on the effective depth, and the effective depth
+        moves with the stirrup diameter. A beam starts from the diameter its
+        settings assume, so the shift is small; a slab starts from no stirrup at
+        all, so assigning a 10 mm bar takes a whole centimetre off ``d`` and with
+        it off ``s_max_l``. Evaluating the limits against the diameter actually
+        being tried is what keeps the chosen spacing inside the limit the
+        finished section is later checked against.
+        """
+        d_b_before = self.beam._stirrup_d_b
+        try:
+            self.beam._stirrup_d_b = d_b
+            self.beam._update_effective_heights()
+            _, s_max_l, s_max_w = design_code(self.beam.concrete).transverse_rebar(self, V_s_req, alpha)
+        finally:
+            self.beam._stirrup_d_b = d_b_before
+            self.beam._update_effective_heights()
+        return s_max_l, s_max_w
+
+    def _transverse_rebar_slab(self, A_v_req: Quantity, V_s_req: Quantity, alpha: float) -> DataFrame:
+        """A grid of legs: (d_b, s_l, s_w), with both spacings free.
+
+        A slab strip is a metre cut out of a wider member, so its legs are not
+        the two faces of a stirrup cage the way a beam's are: the transverse
+        spacing is a free variable and the strip catches whatever number of legs
+        that spacing gives -- 6.7 of them at 15 cm across a metre. The beam
+        search cannot say that. It spreads an even number of legs between the
+        outermost bar centres, so a wide strip starts from far more legs than
+        the shear asks for and never comes back down.
+
+        With ``A_v = A_db * (width / s_w) / s_l``, the least steel that still
+        covers ``A_v_req`` is the largest product ``s_l * s_w`` that both limits
+        allow, so that is what the loop below maximises, on the whole-unit grid
+        the two spacings are detailed on.
+
+        The spacing limits usually bind long before ``A_v_req`` does: a shallow
+        slab has ``s_max_l = d/2``, which can put the provided ``A_v`` well above
+        what the shear demands however the search is written. That is the
+        detailing rule speaking, not slack left in the search.
+        """
+        metric = self.beam.concrete.unit_system == "metric"
+        unit = cm if metric else inch
+        # The floors the beam search stops at: closer than this no bar can be
+        # placed, let alone vibrated around.
+        s_min = 5 if metric else 2
+        area_unit = "cm**2/m" if metric else "inch**2/ft"
+        width = self.beam.width
+
+        valid_diameters = design_code(self.beam.concrete).transverse_rebar(self, V_s_req, alpha)[0]
+
+        valid_combinations = []
+        for d_b in valid_diameters:
+            s_max_l, s_max_w = self._slab_spacing_limits(d_b, V_s_req, alpha)
+            # Whole units, so the spacing is one a drawing can carry. The strip
+            # caps the transverse spacing as well: a leg spacing wider than the
+            # strip would put less than one leg in it.
+            s_l_max = int(math.floor(s_max_l.to(unit).magnitude))
+            s_w_max = int(math.floor(min(s_max_w, width).to(unit).magnitude))
+            # High shear halves both limits, and half of a shallow slab's d is
+            # already tighter than the floor. The limit wins when the two
+            # disagree, exactly as the beam search ends up doing: its floor only
+            # adds legs, it never stops the spacing going below it. One whole
+            # unit is the hard floor, so that a limit rounding down to nothing
+            # leaves an empty search rather than a division by zero.
+            s_l_lo = max(1, min(s_min, s_l_max))
+            s_w_lo = max(1, min(s_min, s_w_max))
+
+            A_db = self.rebar_areas[d_b]
+            # A_v >= A_v_req  <=>  s_l * s_w <= A_db * width / A_v_req.
+            if A_v_req > 0 * A_v_req.units:
+                product_max = (A_db * width / A_v_req).to(unit**2).magnitude
+            else:
+                product_max = math.inf
+
+            best: Tuple[int, int] | None = None
+            for s_l in range(s_l_max, s_l_lo - 1, -1):
+                s_w = s_w_max if math.isinf(product_max) else min(s_w_max, int(product_max // s_l))
+                if s_w < s_w_lo:
+                    continue
+                # Descending s_l with a strict comparison keeps the widest
+                # longitudinal spacing among the products that tie.
+                if best is None or s_l * s_w > best[0] * best[1]:
+                    best = (s_l, s_w)
+            if best is None:
+                continue
+
+            s_l_q, s_w_q = best[0] * unit, best[1] * unit
+            n_legs = (width / s_w_q).to("dimensionless").magnitude
+            valid_combinations.append(
+                {
+                    # A slab has no closed stirrup to count. This is the
+                    # equivalent number of rows across the width, which is what
+                    # the section stores the reinforcement as; A_v is computed
+                    # from the spacing itself and is the value that governs.
+                    "n_stir": max(1, round(n_legs / 2)),
+                    "d_b": d_b,
+                    "s_l": s_l_q,
+                    "s_w": s_w_q,
+                    "A_v": (A_db * n_legs / s_l_q).to(area_unit),
+                    "s_max_l": s_max_l.to(unit),
+                    "s_max_w": s_max_w.to(unit),
+                }
+            )
+
+        df_combinations = pd.DataFrame(valid_combinations)
+        if not df_combinations.empty:
+            # Least steel first. Unlike a beam, a slab gains nothing from a
+            # heavier bar: the spacing limits already fix how close the legs go.
+            df_combinations.sort_values(by=["A_v", "s_l"], ascending=[True, False], inplace=True)
+            df_combinations.reset_index(drop=True, inplace=True)
         self._trans_combos_df = df_combinations
         return df_combinations
 

--- a/mento/reports/tables.py
+++ b/mento/reports/tables.py
@@ -22,12 +22,47 @@ from pint import Quantity
 from mento.units import inch, kN, kNm, mm
 
 from mento.codes.registry import design_code
+from mento.design_results import GRID, transverse_layout
 
 if TYPE_CHECKING:
     from mento.beam import RectangularBeam
     from mento.material import Concrete_ACI_318_19, Concrete_EN_1992_2004
     from mento.forces import Forces
     from mento.settings import BeamSettings
+
+
+def _transverse_rebar_rows(
+    self: "RectangularBeam",
+    d_b_shown: Quantity,
+    round_to: int | None = 3,
+) -> tuple[list[str], list[str], list[Any], list[str]]:
+    """The three rows that identify the transverse reinforcement of a section.
+
+    A beam is a stirrup count, a diameter and a spacing along the length. A slab
+    strip has no cage to count, so the count gives way to the spacing across the
+    width, which is what actually detailed it and had no row of its own. Three
+    rows either way, so every column of the table stays the same length.
+    """
+
+    def shown(value: Quantity, unit: str) -> Any:
+        magnitude = value.to(unit).magnitude
+        return magnitude if round_to is None else round(magnitude, round_to)
+
+    diameter = shown(d_b_shown, "mm")
+    s_l = shown(self._stirrup_s_l, "cm")
+    if transverse_layout(self) == GRID:
+        return (
+            ["Stirrup diameter", "Stirrup spacing along length", "Stirrup spacing along width"],
+            ["db", "sl", "sw"],
+            [diameter, s_l, shown(self._leg_spacing_across_width(), "cm")],
+            ["mm", "cm", "cm"],
+        )
+    return (
+        ["Number of stirrups", "Stirrup diameter", "Stirrup spacing"],
+        ["ns", "db", "s"],
+        [self._stirrup_n, diameter, s_l],
+        ["", "mm", "cm"],
+    )
 
 
 def _settings(beam: RectangularBeam) -> BeamSettings:
@@ -275,29 +310,29 @@ def _initialize_dicts_ACI_318_19_shear(self: "RectangularBeam") -> None:
         ],
         "Ok?": checks,
     }
+    # A slab strip has no cage to count: the same bar sits on a grid, so the row
+    # that names a stirrup count gives way to the second spacing that actually
+    # detailed it. Same three rows either way, so the columns stay aligned.
+    rebar_rows, rebar_vars, rebar_values, rebar_units = _transverse_rebar_rows(self, d_b_shown)
     self._shear_reinforcement = {
         "Shear reinforcement strength": [
-            "Number of stirrups",
-            "Stirrup diameter",
-            "Stirrup spacing",
+            *rebar_rows,
             "Effective height",
             "Minimum shear reinforcing",
             "Required shear reinforcing",
             "Defined shear reinforcing",
             "Shear rebar strength",
         ],
-        "Variable": ["ns", "db", "s", "d", "Av,min", "Av,req", "Av", "ØVs"],
+        "Variable": [*rebar_vars, "d", "Av,min", "Av,req", "Av", "ØVs"],
         "Value": [
-            self._stirrup_n,
-            round(d_b_shown.to("mm").magnitude, 3),
-            round(self._stirrup_s_l.to("cm").magnitude, 3),
+            *rebar_values,
             round(self._d_shear.to("cm").magnitude, 2),
             round(self._A_v_min.to("cm**2/m").magnitude, 2),
             round(self._A_v_req.to("cm**2/m").magnitude, 2),
             round(self._A_v.to("cm**2/m").magnitude, 2),
             round(self._phi_V_s.to("kN").magnitude, 2),
         ],
-        "Unit": ["", "mm", "cm", "cm", "cm²/m", "cm²/m", "cm²/m", "kN"],
+        "Unit": [*rebar_units, "cm", "cm²/m", "cm²/m", "cm²/m", "kN"],
     }
     check_max = "✅" if self._max_shear_ok else "❌"
     check_FU = "✅" if self._DCRv < 1 else "❌"
@@ -724,29 +759,26 @@ def _initialize_dicts_EN_1992_2004_shear(self: "RectangularBeam") -> None:
         ],
         "Ok?": checks,
     }
+    rebar_rows, rebar_vars, rebar_values, rebar_units = _transverse_rebar_rows(self, d_b_shown, round_to=None)
     self._shear_reinforcement = {
         "Shear reinforcement strength": [
-            "Number of stirrups",
-            "Stirrup diameter",
-            "Stirrup spacing",
+            *rebar_rows,
             "Effective height",
             "Minimum shear reinforcing",
             "Required shear reinforcing",
             "Defined shear reinforcing",
             "Shear rebar strength",
         ],
-        "Variable": ["ns", "db", "s", "d", "Asw,min", "Asw,req", "Asw", "VRd,s"],
+        "Variable": [*rebar_vars, "d", "Asw,min", "Asw,req", "Asw", "VRd,s"],
         "Value": [
-            self._stirrup_n,
-            d_b_shown.to("mm").magnitude,
-            self._stirrup_s_l.to("cm").magnitude,
+            *rebar_values,
             round(self._d_shear.to("cm").magnitude, 2),
             round(self._A_v_min.to("cm**2/m").magnitude, 2),
             round(self._A_v_req.to("cm**2/m").magnitude, 2),
             round(self._A_v.to("cm**2/m").magnitude, 2),
             round(self._V_Rd_s.to("kN").magnitude, 2),
         ],
-        "Unit": ["", "mm", "cm", "cm", "cm²/m", "cm²/m", "cm²/m", "kN"],
+        "Unit": [*rebar_units, "cm", "cm²/m", "cm²/m", "cm²/m", "kN"],
     }
     check_max = "✅" if self._max_shear_ok else "❌"
     check_DCR = "✅" if self._DCRv < 1 else "❌"

--- a/mento/slab.py
+++ b/mento/slab.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from dataclasses import dataclass
 import math
 import numpy as np
@@ -74,19 +74,51 @@ class OneWaySlab(RectangularBeam):
     ) -> None:
         """Sets the transverse rebar in the slab section.
 
-        A zero spacing means no stirrups, which clears the transverse reinforcement.
+        A zero diameter or a zero spacing in either direction means no stirrups,
+        which clears the transverse reinforcement.
         """
         self._stirrup_s_l = s_long
-        if s_long == 0 * cm or s_trans == 0 * cm:
+        if d_b == 0 * mm or s_long == 0 * cm or s_trans == 0 * cm:
             # No stirrups: same state as a section without transverse rebar
             self._A_v = 0 * mm**2 / m
+            self._stirrup_n = 0
+            self._stirrup_d_b = 0 * mm
+            self._stirrup_s_w = 0 * mm
         else:
             n_legs_per_unit_width = self.width / s_trans
             A_db = (d_b**2) * math.pi / 4  # Area of one stirrup leg per unit width
             self._A_v = A_db * n_legs_per_unit_width / s_long  # Legs area per unit length
+            self._stirrup_d_b = d_b
+            self._stirrup_s_w = s_trans
+            # Both shear checks read _stirrup_n to decide whether the section
+            # carries shear reinforcement at all, and the drawings read it as a
+            # number of stirrups. Leaving it at zero was why a slab given
+            # transverse rebar was still checked as if it had none. A strip has
+            # no closed stirrup to count -- the legs at s_trans need not divide
+            # into it a whole number of times -- so this is the equivalent
+            # number of rows; _A_v above is what the capacity is computed from.
+            self._stirrup_n = max(1, round(n_legs_per_unit_width.to("dimensionless").magnitude / 2))
 
         # Update effective heights
         self._update_effective_heights()
+
+    def _leg_spacing_across_width(self) -> Quantity:
+        """The transverse spacing the strip was detailed with.
+
+        A beam derives this from the geometry of its stirrup cage. A slab does
+        not have one: the legs sit on a grid, and how far apart they are across
+        the strip is chosen, not implied. Deriving it the beam's way put the
+        legs of a designed slab at a spacing it had never been given.
+        """
+        return self._stirrup_s_w
+
+    def _apply_transverse_design(self, design: Any) -> None:
+        """A slab is detailed by a spacing in each direction, not by a stirrup count."""
+        self.set_slab_transverse_rebar(
+            d_b=design["d_b"],
+            s_long=design["s_l"],
+            s_trans=design["s_w"],
+        )
 
     def set_slab_longitudinal_rebar_bot(
         self,

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -357,3 +357,60 @@ def test_a_code_registered_without_report_tables_says_so() -> None:
             beam.check_shear([Forces(label="C1", V_z=80 * kN)])
     finally:
         _REGISTRY.pop(invented.title, None)
+
+
+##########################################################
+# DATACLASS BODIES: WHAT THE EDITOR SHOWS THE CALLER
+##########################################################
+
+PACKAGE_MODULES = sorted(MENTO_ROOT.rglob("*.py"))
+
+
+def _is_dataclass_decorated(node: ast.ClassDef) -> bool:
+    for decorator in node.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        name = target.attr if isinstance(target, ast.Attribute) else getattr(target, "id", None)
+        if name == "dataclass":
+            return True
+    return False
+
+
+def _conditionally_annotated_names(body: list[ast.stmt]) -> list[str]:
+    """Names annotated inside an ``if`` / ``try`` in a class body, not at its top level."""
+    found: list[str] = []
+    for node in body:
+        nested: list[ast.stmt] = []
+        if isinstance(node, ast.If):
+            nested = [*node.body, *node.orelse]
+        elif isinstance(node, ast.Try):
+            nested = [*node.body, *node.orelse, *node.finalbody]
+        for inner in ast.walk(ast.Module(body=nested, type_ignores=[])):
+            if isinstance(inner, ast.AnnAssign) and isinstance(inner.target, ast.Name):
+                found.append(inner.target.id)
+    return found
+
+
+def test_package_modules_are_discovered() -> None:
+    """Guards the test below: an empty glob would make it vacuously pass."""
+    assert len(PACKAGE_MODULES) > 20, f"only {len(PACKAGE_MODULES)} modules found under {MENTO_ROOT}"
+
+
+@pytest.mark.parametrize("path", PACKAGE_MODULES, ids=lambda p: p.name)
+def test_dataclass_bodies_declare_no_conditional_annotations(path: Path) -> None:
+    """Every annotation in a dataclass body is a constructor argument to the editor.
+
+    A type checker reads ``if TYPE_CHECKING:`` as taken, so a name declared
+    under it counts as a field even though ``dataclasses`` never sees it at
+    runtime. That is how the fifty-odd compatibility-layer attributes on
+    ``RectangularBeam`` became required keyword arguments in IntelliSense while
+    the runtime signature stayed clean -- a defect no test that imports the
+    class can catch. Declarations that are not fields belong on a plain base
+    class such as ``_DesignCodeAttributes``, which contributes none.
+    """
+    for node in ast.walk(_parse(path)):
+        if isinstance(node, ast.ClassDef) and _is_dataclass_decorated(node):
+            offenders = _conditionally_annotated_names(node.body)
+            assert not offenders, (
+                f"{path.name}: {node.name} is a dataclass, so {offenders} read as "
+                f"constructor fields to a type checker. Move them to a plain base class."
+            )

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -718,6 +718,81 @@ def test_shear_design_spacing_along_width_wide_beam() -> None:
     assert float(results.iloc[1]["DCR"]) <= 1.0
 
 
+@pytest.mark.parametrize(
+    "code",
+    ["ACI 318-19", "EN 1992-2004", "CIRSOC 201-25"],
+)
+def test_shear_design_always_gives_a_beam_stirrups(code: str) -> None:
+    """A beam keeps its minimum cage even with no shear on it.
+
+    The counterpart of the slab rule: ACI 318-19 9.6.3.1 and EN 1992-1-1 9.2.2
+    only waive the minimum for members that can redistribute the load
+    transversally, which a beam cannot. Only ``OneWaySlab`` opts out, so this
+    guards the slab fix from being generalised to every section.
+    """
+    concretes = {
+        "ACI 318-19": Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        "EN 1992-2004": Concrete_EN_1992_2004(name="C25", f_c=25 * MPa),
+        "CIRSOC 201-25": Concrete_CIRSOC_201_25(name="H25", f_c=25 * MPa),
+    }
+    beam = RectangularBeam(
+        label="B1",
+        concrete=concretes[code],
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=20 * cm,
+        height=50 * cm,
+        c_c=25 * mm,
+    )
+    Node(section=beam, forces=Forces(label="ELU_01", M_y=30 * kNm, V_z=0 * kN)).design_shear()
+
+    assert beam._stirrups_optional is False
+    assert beam.shear_design.n_stirrups > 0
+    assert beam.shear_design.A_v.to("cm**2/m").magnitude > 0
+
+
+def _A_v_min_table_9_6_3_4(width_cm: float, f_c: float = 25.0, f_yt: float = 420.0) -> float:
+    """ACI 318-19 Table 9.6.3.4, as an area per unit length in cm2/m."""
+    b_w = width_cm * 10  # mm
+    return max(0.062 * math.sqrt(f_c) * b_w / f_yt, 0.35 * b_w / f_yt) * 10
+
+
+@pytest.mark.parametrize("width_cm, height_cm", [(20, 40), (20, 50), (30, 60), (40, 70), (50, 80)])
+@pytest.mark.parametrize("V_z_kN", [0, 10, 25])
+@pytest.mark.parametrize("code", ["ACI 318-19", "EN 1992-2004", "CIRSOC 201-25"])
+def test_shear_design_never_puts_a_beam_below_the_minimum_area(
+    code: str, V_z_kN: int, width_cm: int, height_cm: int
+) -> None:
+    """A lightly loaded beam still gets the minimum cage, not merely some cage.
+
+    ACI 318-19 9.6.3.1 waives A_v,min where Vu falls under its threshold, and the
+    design used to hand that zero straight to the stirrup designer -- which then
+    sized off the spacing limits alone. With the 6 mm bars CIRSOC 201-25 allows,
+    a 30x60 came back with 1eO6/28cm = 2.02 cm2/m against the 2.50 cm2/m of
+    Table 9.6.3.4. A beam carries stirrups over its whole length, so the minimum
+    holds whatever the shear diagram says.
+    """
+    concretes = {
+        "ACI 318-19": Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        "EN 1992-2004": Concrete_EN_1992_2004(name="C25", f_c=25 * MPa),
+        "CIRSOC 201-25": Concrete_CIRSOC_201_25(name="H25", f_c=25 * MPa),
+    }
+    beam = RectangularBeam(
+        label="B1",
+        concrete=concretes[code],
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=width_cm * cm,
+        height=height_cm * cm,
+        c_c=25 * mm,
+    )
+    Node(section=beam, forces=Forces(label="ELU_01", M_y=30 * kNm, V_z=V_z_kN * kN)).design()
+
+    A_v = beam.shear_design.A_v.to("cm**2/m").magnitude
+    A_v_min = _A_v_min_table_9_6_3_4(width_cm)
+    assert A_v >= A_v_min - 1e-9, (
+        f"{code}, {width_cm}x{height_cm} cm, V_z {V_z_kN} kN: designed {A_v:.2f} cm2/m, minimum {A_v_min:.2f} cm2/m"
+    )
+
+
 @pytest.mark.parametrize("width_cm", [20, 30, 40, 50, 60, 80, 100, 120])
 @pytest.mark.parametrize("V_z_kN", [100, 250, 450])
 @pytest.mark.parametrize("code", ["ACI 318-19", "EN 1992-2004", "CIRSOC 201-25"])

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -750,6 +750,24 @@ def test_shear_design_always_gives_a_beam_stirrups(code: str) -> None:
     assert beam.shear_design.A_v.to("cm**2/m").magnitude > 0
 
 
+def test_a_designed_beam_is_labelled_by_its_stirrup_count() -> None:
+    """The beam notation is unchanged by the slab one: count, diameter, spacing."""
+    beam = RectangularBeam(
+        label="B1",
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=20 * cm,
+        height=50 * cm,
+        c_c=25 * mm,
+    )
+    Node(section=beam, forces=Forces(label="ELU_01", M_y=30 * kNm, V_z=150 * kN)).design()
+
+    transverse = beam.reinforcement.transverse
+    assert transverse.layout == "stirrups"
+    assert str(transverse) == f"{transverse.n_stirrups}eØ{transverse.d_b:.4g~P}/{transverse.s_l:.4g~P}"
+    assert beam._shear_reinforcement["Variable"][:3] == ["ns", "db", "s"]
+
+
 def _A_v_min_table_9_6_3_4(width_cm: float, f_c: float = 25.0, f_yt: float = 420.0) -> float:
     """ACI 318-19 Table 9.6.3.4, as an area per unit length in cm2/m."""
     b_w = width_cm * 10  # mm

--- a/tests/test_rebar.py
+++ b/tests/test_rebar.py
@@ -918,3 +918,32 @@ def test_slab_transverse_search_drops_a_diameter_it_cannot_place() -> None:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def test_slab_transverse_search_with_no_required_area_opens_the_spacing_fully() -> None:
+    """Asked for nothing, the search returns the widest grid the limits allow.
+
+    Not reachable through ``design_shear``: a slab that needs no shear
+    reinforcement is designed with none and never gets here. It is reachable by
+    driving ``Rebar`` directly, which is how the rest of this module tests the
+    search, and it is the case that decides what "no area required" means --
+    the spacing limits alone, rather than a division by a zero demand.
+    """
+    slab = OneWaySlab(
+        label="slab-no-demand",
+        concrete=Concrete_ACI_318_19(name="C25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=20 * cm,
+        c_c=25 * mm,
+    )
+    slab.set_slab_longitudinal_rebar_bot(d_b1=12 * mm, s_b1=20 * cm)
+
+    combos = Rebar(slab).transverse_rebar(A_v_req=0 * cm**2 / m, V_s_req=0 * kN, alpha=math.radians(90))
+
+    assert not combos.empty
+    for _, row in combos.iterrows():
+        # Nothing required, so each diameter is placed at the loosest grid its
+        # own limits permit -- and no looser.
+        assert row["s_l"] == row["s_max_l"].to("cm").magnitude // 1 * cm
+        assert row["s_w"] == min(row["s_max_w"], 100 * cm).to("cm").magnitude // 1 * cm

--- a/tests/test_rebar.py
+++ b/tests/test_rebar.py
@@ -1,8 +1,10 @@
+import math
+
 import pytest
 from mento.rebar import Rebar, RebarDesignInfeasibleError
 from mento.beam import RectangularBeam
 from mento.material import Concrete_ACI_318_19, SteelBar, Concrete_EN_1992_2004
-from mento.units import psi, kip, mm, inch, ksi, cm, MPa, kN
+from mento.units import psi, kip, m, mm, inch, ksi, cm, MPa, kN
 from mento.forces import Forces
 from mento.node import Node
 from mento.settings import BeamSettings
@@ -825,6 +827,93 @@ def test_longitudinal_rebar_design_raises_infeasible_when_no_combo_fits() -> Non
     beam_rebar.longitudinal_rebar_ACI_318_19(A_s_req=100 * cm**2)
     with pytest.raises(RebarDesignInfeasibleError):
         _ = beam_rebar.longitudinal_rebar_design
+
+
+def test_transverse_rebar_design_raises_infeasible_when_no_combo_fits() -> None:
+    """The transverse counterpart of the test above.
+
+    ``iloc[0]`` on an empty search raised a bare ``IndexError`` from inside
+    pandas, several frames below anything a caller could act on. The search can
+    come back empty -- no bar the code allows, at any spacing inside its limits,
+    reaches A_v_req -- and that is a statement about the section, so it should
+    read as one.
+    """
+    slab = OneWaySlab(
+        label="infeasible-shear",
+        concrete=Concrete_ACI_318_19(name="C25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=20 * cm,
+        c_c=25 * mm,
+    )
+    slab_rebar = Rebar(slab)
+    slab_rebar._trans_combos_df = pd.DataFrame()
+    with pytest.raises(RebarDesignInfeasibleError):
+        _ = slab_rebar.transverse_rebar_design
+
+
+def test_transverse_rebar_searches_a_slab_by_spacing_not_by_leg_count() -> None:
+    """Slab mode reaches the slab search, and the slab search is grid-shaped.
+
+    The beam search derives the transverse spacing from an even number of legs
+    spread between the outermost bar centres, so on a metre-wide strip it lands
+    on a fraction of a centimetre -- 13.43 cm for eight legs -- and starts from
+    far more steel than the shear asks for. The slab search chooses both
+    spacings on the whole-centimetre grid the strip is actually detailed on.
+    """
+    slab = OneWaySlab(
+        label="slab-search",
+        concrete=Concrete_ACI_318_19(name="C25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=20 * cm,
+        c_c=25 * mm,
+    )
+    slab.set_slab_longitudinal_rebar_bot(d_b1=12 * mm, s_b1=20 * cm)
+    slab_rebar = Rebar(slab)
+    assert slab_rebar.mode == "slab"
+
+    combos = slab_rebar.transverse_rebar(A_v_req=8 * cm**2 / m, V_s_req=30 * kN, alpha=math.radians(90))
+
+    assert not combos.empty
+    for _, row in combos.iterrows():
+        assert row["s_l"].to("cm").magnitude == int(row["s_l"].to("cm").magnitude)
+        assert row["s_w"].to("cm").magnitude == int(row["s_w"].to("cm").magnitude)
+        assert row["s_l"] <= row["s_max_l"]
+        assert row["s_w"] <= row["s_max_w"]
+        assert row["A_v"] >= 8 * cm**2 / m
+    # Least steel first, so the row the design reads is the cheapest one.
+    assert combos.iloc[0]["A_v"] == min(combos["A_v"])
+
+
+def test_slab_transverse_search_drops_a_diameter_it_cannot_place() -> None:
+    """A bar too thin for the demand is dropped, not squeezed below the floor.
+
+    Driven directly, with an A_v_req far past anything a 20 cm slab would ever
+    see, because that is the only way to reach the branch: the spacing limits
+    are so much tighter than A_v_req in real slabs that the limits are what
+    bind. The smallest bar ACI allows runs out of grid first -- every spacing
+    that would cover A_v_req is below the floor -- so the search moves on to the
+    next diameter instead of returning a spacing nobody can build.
+    """
+    slab = OneWaySlab(
+        label="slab-extreme-shear",
+        concrete=Concrete_ACI_318_19(name="C25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=20 * cm,
+        c_c=25 * mm,
+    )
+    slab.set_slab_longitudinal_rebar_bot(d_b1=12 * mm, s_b1=20 * cm)
+
+    combos = Rebar(slab).transverse_rebar(A_v_req=400 * cm**2 / m, V_s_req=30 * kN, alpha=math.radians(90))
+
+    assert not combos.empty
+    assert 10 * mm not in list(combos["d_b"])  # no grid point at the thinnest bar
+    for _, row in combos.iterrows():
+        assert row["A_v"] >= 400 * cm**2 / m
+        assert row["s_l"] >= 1 * cm
+        assert row["s_w"] >= 1 * cm
 
 
 if __name__ == "__main__":

--- a/tests/test_slab.py
+++ b/tests/test_slab.py
@@ -553,3 +553,55 @@ def test_slab_shear_design_is_the_least_steel_the_spacing_limits_allow() -> None
                     assert A_v.to("cm**2/m").magnitude >= chosen * (1 - 1e-9), (
                         f"Ø{row['d_b']} at {s_l} cm x {s_w} cm covers A_v_req with less steel"
                     )
+
+
+##########################################################
+# HOW THE TRANSVERSE REINFORCEMENT IS LABELLED
+##########################################################
+
+
+def test_a_designed_slab_is_labelled_by_its_two_spacings() -> None:
+    """A slab strip has no cage, so the beam's stirrup count says nothing.
+
+    The design chooses a spacing each way and the label used to report only the
+    longitudinal one, prefixed by a stirrup count that does not exist -- a
+    100 cm strip came out as "7eO10 mm/3 cm" with the 7 cm across the width
+    nowhere to be seen. The diameter is written once: both directions are the
+    same bar.
+    """
+    slab = _designed_slab(Concrete_ACI_318_19(name="H25", f_c=25 * MPa), V_z=150 * kN)
+
+    transverse = slab.reinforcement.transverse
+    assert transverse.layout == "grid"
+    assert transverse.s_w.to("cm").magnitude > 0
+    label = str(transverse)
+    assert label.startswith("Ø")
+    assert "e Ø" not in label and "eØ" not in label
+    assert label.count("Ø") == 1
+    assert f"{transverse.s_l:.4g~P}" in label
+    assert f"{transverse.s_w:.4g~P}" in label
+    # The shear result carries the same notation as the section does.
+    assert str(slab.shear_design) == label
+
+
+def test_a_slab_without_stirrups_says_so() -> None:
+    slab = _designed_slab(Concrete_ACI_318_19(name="H25", f_c=25 * MPa), V_z=0 * kN)
+
+    assert str(slab.reinforcement.transverse) == "no stirrups"
+
+
+def test_the_shear_report_of_a_slab_names_both_spacings() -> None:
+    """The count row gives way to the spacing that actually detailed the strip."""
+    slab = _designed_slab(Concrete_ACI_318_19(name="H25", f_c=25 * MPa), V_z=150 * kN)
+
+    rows = slab._shear_reinforcement
+    assert rows["Variable"][:3] == ["db", "sl", "sw"]
+    assert rows["Shear reinforcement strength"][:3] == [
+        "Stirrup diameter",
+        "Stirrup spacing along length",
+        "Stirrup spacing along width",
+    ]
+    assert rows["Unit"][:3] == ["mm", "cm", "cm"]
+    assert rows["Value"][2] == pytest.approx(slab._stirrup_s_w.to("cm").magnitude, rel=1e-9)
+    # Every column of the table still has one entry per row.
+    assert len({len(column) for column in rows.values()}) == 1

--- a/tests/test_slab.py
+++ b/tests/test_slab.py
@@ -371,3 +371,185 @@ def test_slab_shear_design_places_stirrups_once_the_demand_exceeds_the_concrete(
     assert transverse.n_stirrups > 0
     assert transverse.A_v >= slab.shear_design.A_v_req
     assert slab.shear_design.DCR <= 1
+
+
+# ---------------------------------------------------------------------------
+# Shear design, where the demand passes what the concrete alone carries
+# ---------------------------------------------------------------------------
+
+
+def _slab_needing_stirrups(concrete_cls) -> OneWaySlab:
+    """A 100 x 20 cm strip, which is too shallow for 100 kN of shear on its own."""
+    return OneWaySlab(
+        label="Slab shear",
+        concrete=concrete_cls(name="C25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="B500S", f_y=420 * MPa),
+        width=100 * cm,
+        height=20 * cm,
+        c_c=25 * mm,
+    )
+
+
+@pytest.mark.parametrize(
+    ("concrete_cls", "d_b", "s_l", "s_w", "A_v"),
+    [
+        pytest.param(Concrete_ACI_318_19, 10 * mm, 7 * cm, 15 * cm, 74.80, id="ACI-318-19"),
+        pytest.param(Concrete_EN_1992_2004, 6 * mm, 12 * cm, 12 * cm, 19.63, id="EN-1992-2004"),
+    ],
+)
+def test_shear_design_of_a_slab_that_needs_stirrups(concrete_cls, d_b, s_l, s_w, A_v) -> None:
+    """A strip carrying more shear than its concrete does gets a buildable grid of legs.
+
+    The forces are the same in both codes; what differs is the detailing rules,
+    so the expected bar and spacings are per code.
+
+    The number this pins is the one the beam-shaped search got wrong. That
+    search spreads an even number of legs between the outermost bar centres,
+    which on a metre-wide strip starts at eight legs and never comes back down:
+    it returned 78.54 cm2/m under ACI and 23.56 cm2/m under EN, and its ACI
+    answer sat at 8 cm along the span against a 7.95 cm limit. Neither figure
+    is anywhere near A_v_req, and neither can be -- see the second half of the
+    test, which is the part worth reading.
+    """
+    # The premise: with no shear reinforcement the strip does not pass.
+    bare = _slab_needing_stirrups(concrete_cls)
+    bare.set_slab_longitudinal_rebar_bot(d_b1=12 * mm, s_b1=20 * cm)
+    forces = Forces(label="C1", M_y=30 * kNm, V_z=100 * kN)
+    Node(section=bare, forces=forces).check_shear()
+    assert bare.shear_design.DCR > 1
+
+    slab = _slab_needing_stirrups(concrete_cls)
+    Node(section=slab, forces=Forces(label="C1", M_y=30 * kNm, V_z=100 * kN)).design()
+
+    shear = slab.shear_design
+    assert shear.d_b == d_b
+    assert shear.s_l == s_l
+    # The transverse spacing has no equivalent on the public shear result yet.
+    assert slab._stirrup_s_w == s_w
+    assert shear.A_v.to("cm**2/m").magnitude == pytest.approx(A_v, rel=1e-3)
+
+    # The design is inside the limits it will be checked against. It was not
+    # before: the limits are written on d, and d moves by the whole diameter of
+    # a stirrup a slab did not have until the design assigned one.
+    assert slab._stirrup_s_l <= slab._stirrup_s_max_l
+    assert slab._stirrup_s_w <= slab._stirrup_s_max_w
+
+    # And it covers the demand, with room to spare that no search can remove:
+    # s_max_l is d/2 on a 20 cm slab, so the least steel the detailing rules
+    # allow is already several times what the shear asks for.
+    assert shear.A_v >= shear.A_v_req
+    assert shear.DCR <= 1
+
+
+def test_designed_slab_is_reinforced_in_both_directions() -> None:
+    """The design speaks the slab's own parameterisation, not the beam's.
+
+    ``design_shear`` used to hand the row to ``set_transverse_rebar``, which
+    reads it as a number of closed stirrups. A slab has none: it is detailed by
+    a bar diameter and a spacing each way, which is what
+    ``set_slab_transverse_rebar`` takes.
+    """
+    slab = _slab_needing_stirrups(Concrete_ACI_318_19)
+    Node(section=slab, forces=Forces(label="C1", M_y=30 * kNm, V_z=100 * kN)).design()
+
+    A_db = math.pi * slab._stirrup_d_b**2 / 4
+    n_legs = slab.width / slab._stirrup_s_w
+    assert slab._A_v.to("cm**2/m").magnitude == pytest.approx(
+        (A_db * n_legs / slab._stirrup_s_l).to("cm**2/m").magnitude, rel=1e-9
+    )
+
+
+def test_shear_design_of_an_imperial_slab_strip() -> None:
+    """The imperial branch of the slab search, on its own whole-inch grid."""
+    slab = OneWaySlab(
+        label="Slab shear imperial",
+        concrete=Concrete_ACI_318_19(name="C4", f_c=4 * ksi),
+        steel_bar=SteelBar(name="G60", f_y=60 * ksi),
+        width=12 * inch,
+        height=10 * inch,
+        c_c=0.75 * inch,
+    )
+    bare = OneWaySlab(
+        label="Slab shear imperial",
+        concrete=Concrete_ACI_318_19(name="C4", f_c=4 * ksi),
+        steel_bar=SteelBar(name="G60", f_y=60 * ksi),
+        width=12 * inch,
+        height=10 * inch,
+        c_c=0.75 * inch,
+    )
+    bare.set_slab_longitudinal_rebar_bot(d_b1=0.5 * inch, s_b1=8 * inch)
+    Node(section=bare, forces=Forces(label="C1", V_z=12 * kip)).check_shear()
+    assert bare.shear_design.DCR > 1
+
+    Node(section=slab, forces=Forces(label="C1", M_y=10 * kNm, V_z=12 * kip)).design()
+
+    shear = slab.shear_design
+    assert shear.d_b == 0.375 * inch
+    assert shear.s_l == 4 * inch
+    assert slab._stirrup_s_w == 8 * inch
+    assert slab._stirrup_s_l <= slab._stirrup_s_max_l
+    assert slab._stirrup_s_w <= slab._stirrup_s_max_w
+    assert shear.A_v >= shear.A_v_req
+    assert shear.DCR <= 1
+
+
+def test_transverse_rebar_set_on_a_slab_is_credited_by_the_shear_check() -> None:
+    """Both codes read ``_stirrup_n`` to decide whether a section carries stirrups.
+
+    ``set_slab_transverse_rebar`` left it at zero, so a slab given a full grid
+    of legs was checked as a section with none: it reported phi*V_s = 0 and a
+    zero stirrup diameter, and the report's minimum-diameter row had nothing to
+    compare against.
+    """
+    slab = _slab_needing_stirrups(Concrete_ACI_318_19)
+    slab.set_slab_longitudinal_rebar_bot(d_b1=12 * mm, s_b1=20 * cm)
+    slab.set_slab_transverse_rebar(d_b=10 * mm, s_long=7 * cm, s_trans=15 * cm)
+
+    transverse = slab.reinforcement.transverse
+    assert transverse.d_b == 10 * mm
+    assert transverse.n_stirrups > 0
+
+    Node(section=slab, forces=Forces(label="C1", M_y=30 * kNm, V_z=100 * kN)).check_shear()
+    assert slab._phi_V_s > 0 * kN
+
+
+def test_clearing_slab_transverse_rebar_leaves_no_stirrup_behind() -> None:
+    """The zero state has to clear the diameter and the count as well as A_v."""
+    slab = _slab_needing_stirrups(Concrete_ACI_318_19)
+    slab.set_slab_transverse_rebar(d_b=10 * mm, s_long=7 * cm, s_trans=15 * cm)
+
+    slab.set_slab_transverse_rebar()
+
+    transverse = slab.reinforcement.transverse
+    assert transverse.n_stirrups == 0
+    assert transverse.d_b.magnitude == 0
+    assert transverse.A_v.to("cm**2/m").magnitude == 0
+    assert slab._stirrup_s_w.magnitude == 0
+
+
+def test_slab_shear_design_is_the_least_steel_the_spacing_limits_allow() -> None:
+    """No bar, at any spacing the code allows, covers A_v_req with less steel.
+
+    Written against the whole grid rather than against a number, because the
+    point of the slab branch is that it finds the optimum, not that it happens
+    to return 74.8 cm2/m. The grid starts at 1 cm, below the floor the search
+    stops at: a tighter spacing only ever adds steel, so including it makes the
+    claim stronger rather than unfair.
+    """
+    slab = _slab_needing_stirrups(Concrete_ACI_318_19)
+    Node(section=slab, forces=Forces(label="C1", M_y=30 * kNm, V_z=100 * kN)).design()
+
+    A_v_req = slab.shear_design.A_v_req
+    chosen = slab.shear_design.A_v.to("cm**2/m").magnitude
+
+    for _, row in slab.shear_design_results.iterrows():
+        A_db = math.pi * row["d_b"] ** 2 / 4
+        s_l_max = int(row["s_max_l"].to("cm").magnitude)
+        s_w_max = int(min(row["s_max_w"], slab.width).to("cm").magnitude)
+        for s_l in range(1, s_l_max + 1):
+            for s_w in range(1, s_w_max + 1):
+                A_v = A_db * (slab.width / (s_w * cm)) / (s_l * cm)
+                if A_v >= A_v_req:
+                    assert A_v.to("cm**2/m").magnitude >= chosen * (1 - 1e-9), (
+                        f"Ø{row['d_b']} at {s_l} cm x {s_w} cm covers A_v_req with less steel"
+                    )

--- a/tests/test_slab.py
+++ b/tests/test_slab.py
@@ -1,6 +1,7 @@
 import math
 
 import pytest
+from pint import Quantity
 
 from mento.node import Node
 from mento.slab import OneWaySlab
@@ -302,3 +303,71 @@ def test_flexure_check_with_no_bottom_reinforcement_floors_phi_Mn() -> None:
     assert slab.flexure_design.bottom.DCR == 0
     assert results.iloc[1]["Position"] == "Bottom"
     assert results.iloc[1]["As"] == 0
+
+
+##########################################################
+# SHEAR DESIGN: A SLAB MAY BE BUILT WITHOUT STIRRUPS
+##########################################################
+
+
+def _designed_slab(concrete: Concrete_ACI_318_19 | Concrete_EN_1992_2004, V_z: Quantity) -> OneWaySlab:
+    """A 100x20 slab strip designed for one combination, bending plus shear."""
+    slab = OneWaySlab(
+        label="Slab shear",
+        concrete=concrete,
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=20 * cm,
+        c_c=20 * mm,
+    )
+    Node(section=slab, forces=Forces(label="C1", M_y=30 * kNm, V_z=V_z)).design()
+    return slab
+
+
+@pytest.mark.parametrize(
+    "concrete",
+    [
+        Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        Concrete_EN_1992_2004(name="C25", f_c=25 * MPa),
+    ],
+    ids=["ACI_318_19", "EN_1992_2004"],
+)
+def test_slab_shear_design_places_no_stirrups_when_concrete_carries_the_shear(
+    concrete: Concrete_ACI_318_19 | Concrete_EN_1992_2004,
+) -> None:
+    """ACI 318-19 7.6.3.1 and EN 1992-1-1 6.2.1(4) both let a slab go without.
+
+    Designing for a moment and no shear used to hand the slab a full stirrup
+    cage anyway, because the beam minimum was applied to it: A_v_min came out
+    positive, the stirrup designer was always run, and the result was a
+    reinforcement the demand never asked for and the code does not require.
+    """
+    slab = _designed_slab(concrete, V_z=0 * kN)
+
+    transverse = slab.reinforcement.transverse
+    assert transverse.n_stirrups == 0
+    assert transverse.A_v.to("cm**2/m").magnitude == 0
+    assert slab.shear_design.A_v_req.to("cm**2/m").magnitude == 0
+    assert slab.shear_design.A_v_min.to("cm**2/m").magnitude == 0
+    # The concrete alone still resists, so the section checks out.
+    assert slab.shear_design.DCR == 0
+
+
+@pytest.mark.parametrize(
+    "concrete",
+    [
+        Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        Concrete_EN_1992_2004(name="C25", f_c=25 * MPa),
+    ],
+    ids=["ACI_318_19", "EN_1992_2004"],
+)
+def test_slab_shear_design_places_stirrups_once_the_demand_exceeds_the_concrete(
+    concrete: Concrete_ACI_318_19 | Concrete_EN_1992_2004,
+) -> None:
+    """Waiving the minimum is not waiving the design: above V_c stirrups appear."""
+    slab = _designed_slab(concrete, V_z=200 * kN)
+
+    transverse = slab.reinforcement.transverse
+    assert transverse.n_stirrups > 0
+    assert transverse.A_v >= slab.shear_design.A_v_req
+    assert slab.shear_design.DCR <= 1


### PR DESCRIPTION
Two unrelated defects reported from a notebook session, plus three more they uncovered.

## 1. Fifty-two phantom arguments in the constructor

Building a `OneWaySlab` or a `RectangularBeam` made the editor ask for some fifty
keyword arguments that were never part of the API — `_phi_V_n`, `_V_Ed_1`, `f_yt` and
the rest of the ADR-0001 compatibility layer. `ShearWall` was unaffected because it
has an explicit `__init__`.

The comment guarding that block said `TYPE_CHECKING` kept the names out of the
constructor. That is true at runtime — `inspect.signature` was always clean — and
false for a type checker, which reads the block as taken and synthesises every name
in it as a dataclass field. Verified with pyright on `OneWaySlab()`:

```
before:  Arguments missing for parameters "_phi_V_n", "_phi_V_s", … (52), "concrete", "steel_bar", "c_c", "width", "height"
after:   Arguments missing for parameters "concrete", "steel_bar", "c_c", "width", "height"
```

The declarations moved to `_DesignCodeAttributes`, a plain base class, which
contributes no fields. An AST test in `test_architecture_boundaries.py` now fails any
dataclass that declares annotations inside an `if` or a `try` — it catches all 52 on
the parent commit.

## 2. A slab designed for bending got a stirrup cage it did not need

Designing a slab for a moment and no shear returned `4eØ10/8cm` under ACI and
`5eØ6/13cm` under EN, with `DCR = 0`. The beam minimum was being applied to it.

Both codes say otherwise. ACI 318-19 §7.6.3.1 asks for shear reinforcement in a
one-way slab only above `φVc`; EN 1992-1-1 §6.2.1(4) waives the minimum where the
load redistributes transversally, naming slabs. A single predicate,
`_stirrups_optional`, marks the sections that may go without — true only for
`OneWaySlab`, since a beam carries stirrups over its whole length whatever the shear
diagram says.

| 100×20 strip, M=20 kNm, V=0 | before | after |
|---|---|---|
| ACI 318-19 | 4eØ10/8cm, Av = 78.54 cm²/m | no stirrups, ØVc = 59.22 kN |
| EN 1992-2004 | 5eØ6/13cm, Av = 21.75 cm²/m | no stirrups, V_Rd,c = 86.62 kN |

Swept against demand, both codes now place nothing up to 60 kN and a real grid from
100 kN up. Beams are untouched.

## 3. Beams could be designed below the minimum area

The mirror defect, found while fixing the one above. ACI §9.6.3.1 waives `Av,min`
below its threshold, and the design passed that zero straight to the stirrup designer,
which then sized off the spacing limits alone. With the 6 mm bars CIRSOC 201-25 allows:

| section | designed | Table 9.6.3.4 |
|---|---|---|
| 30×60 | 1eØ6/28cm = 2.02 cm²/m | 2.50 cm²/m |
| 40×70 | 1eØ6/32cm = 1.77 cm²/m | 3.33 cm²/m |
| 50×80 | 1eØ6/37cm = 1.53 cm²/m | 4.17 cm²/m |

Designing now floors the required area at the table minimum. The check still reports
the waiver, which is what the clause says. Sweeps 3 codes × 5 sections × 3 low shears
against `Av,min` computed independently in the test.

## 4. Slab shear reinforcement was sized as a stirrup cage

Once a slab does need stirrups, the beam search sized them: it spreads an even number
of legs between the outermost bar centres of a closed stirrup, so a 100 cm strip
started from far more legs than the shear asked for and never came back down —
78.5 cm²/m against 6.97 required.

A strip is a metre cut out of a wider member; both spacings are free and it catches
whatever number of legs the transverse one gives. `transverse_rebar` branches on the
mode, and the slab branch maximises `s_l * s_w` on the whole-unit grid the spacings
are drawn on. `_apply_transverse_design` lets each element apply the row the way it is
detailed — a beam by a stirrup count, a slab by a spacing each way.

The spacing limits still bind well before `A_v_req` on a shallow slab (`s_max_l = d/2`),
so the provided area stays above the demand. That is the detailing rule, not slack.

## 5. Two defects surfaced by the above

- `set_slab_transverse_rebar` never set `_stirrup_n`, and both shear checks read it to
  decide whether a section carries shear reinforcement at all. A slab handed transverse
  rebar was checked as if it had none.
- The leg spacing across the width was derived from the cage geometry inside each code
  module, which put the legs of a designed slab at a spacing it had never been given.
  The section now answers `_leg_spacing_across_width` itself.

## 6. The output still spoke beam

The calculation was right, the label was not. A designed slab reported
`7eØ10 mm/3 cm`: a stirrup count that does not exist — a strip has no cage — and
only the longitudinal spacing, with the 7 cm across the width nowhere in the
output. Half the detail never reached the user, in the section string, the drawing
legend and the shear report alike.

`TransverseReinforcement` and `ShearDesign` now carry `s_w` and the layout the
element is detailed in, and one formatter decides the shape of the label. The
diameter is written once — both directions are the same bar.

| | before | after |
|---|---|---|
| beam | `1eØ10 mm/11 cm` | `1eØ10 mm/11 cm` |
| slab | `7eØ10 mm/3 cm` | `Ø10 mm/3 cm×7 cm` |

In the report table the row naming a stirrup count gives way to the spacing across
the width, reusing the two labels `i18n` already carries, so the table keeps three
rows and every column stays aligned:

| beam | | slab | |
|---|---|---|---|
| Number of stirrups | `ns` | Stirrup diameter | `db` |
| Stirrup diameter | `db` | Stirrup spacing along length | `sl` |
| Stirrup spacing | `s` | Stirrup spacing along width | `sw` |

## Follow-up left out

`_stirrup_n` remains a beam concept a slab fills with an equivalent row count so
that both shear checks can read it as "does this section carry shear
reinforcement". Replacing it with a predicate on `A_v` would remove the crutch,
but it touches the check of both codes and is better on its own.

## Verification

1138 tests pass (was 1021 — 117 added), `ruff check`, `ruff format --check` and
`mypy mento/` clean. No validated check result changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

