### PR TITLE
fix(slab): read a designed slab as a spacing, and cap how far apart its bars may sit

### DIFF
--- a/docs/source/theory/one_way_slab.rst
+++ b/docs/source/theory/one_way_slab.rst
@@ -56,6 +56,47 @@ from there the section behaves exactly as a beam:
 
 Positions 1 and 3 correspond to the first and second layer respectively.
 
+A design is written back as a spacing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The bar selection is the beam's, and it answers with groups of bars per layer. A
+design applied to a slab is translated back into the parameterisation above: the bars
+of a layer are spread over the design width, and the spacing is rounded to the whole
+centimetre (inch, in imperial) so that it is one that can be detailed. The rounding is
+checked against the count it produces, so it never leaves the strip with fewer bars —
+and so less steel — than the search selected.
+
+Maximum bar spacing
+^^^^^^^^^^^^^^^^^^^
+
+Area alone is not a layout: bars far enough apart leave the slab between them
+unreinforced whatever they add up to. Both codes cap the centre-to-centre spacing of
+the flexural reinforcement, and the design applies the cap, which only ever adds bars:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Code
+     - Limit
+     - Clause
+   * - ACI 318-19
+     - :math:`\min(3h,\ 450\ \text{mm})` — 18 in. in imperial
+     - §7.7.2.3
+   * - EN 1992-1-1
+     - :math:`\min(3h,\ 400\ \text{mm})`
+     - §9.3.1.1(3), principal reinforcement
+
+The check reports it as well: the row that gives a beam the clear distance between its
+bars gives a slab the spacing it is detailed at, with this maximum beside the minimum.
+
+.. note::
+
+   EN §9.3.1.1(3) tightens the limit to :math:`\min(2h,\ 250\ \text{mm})` in areas
+   with concentrated loads or of maximum moment. That provision is **not** applied: a
+   section is checked against a set of forces, with no position along the span from
+   which mento could tell that it is in one of those areas.
+
 Detailing settings
 ^^^^^^^^^^^^^^^^^^
 
@@ -141,6 +182,14 @@ Validation
    * - Spacing to bar count
      - ``test_longitudinal_rebar_spacing_updates_counts``
      - Internal consistency
+   * - Design written back as a spacing
+     - ``test_a_designed_slab_is_detailed_by_a_spacing_not_by_a_bar_count``,
+       ``test_a_spacing_is_never_rounded_into_fewer_bars_than_the_design_chose``
+     - Internal consistency
+   * - Maximum bar spacing
+     - ``test_the_code_caps_how_far_apart_the_bars_of_a_slab_may_sit``,
+       ``test_a_design_is_never_spaced_beyond_the_code_maximum``
+     - ACI 318-19 §7.7.2.3, EN 1992-1-1 §9.3.1.1(3)
    * - Slab mode defaults
      - ``test_slab_initialization_sets_slab_mode_and_defaults``
      - Detailing settings above

--- a/docs/source/user_guide/design_results.rst
+++ b/docs/source/user_guide/design_results.rst
@@ -53,6 +53,21 @@ Each face carries its layers, in order, and only the layers that hold bars:
 A face with no reinforcement has an empty ``layers`` tuple, which is what
 ``str(flexure.top)`` reports as ``'no reinforcement'``.
 
+A slab is detailed by a spacing rather than by a bar count, so each of its layers also
+carries the spacing it was designed with, and reads as one bar repeated across the strip.
+The bars are still there to be counted when what you need is the steel actually placed:
+
+.. code-block:: python
+
+    layer = slab.flexure_design.bottom.layers[0]
+
+    layer.d_b                            # 12 mm
+    layer.s.to("cm")                     # 17 cm, None on a beam
+    layer.n                              # 6, the bars that spacing puts on the strip
+    str(layer)                           # 'Ø12 mm/17 cm'
+
+    slab.flexure_design.bottom.n_bars    # 6, every layer of the face
+
 Shear
 -----
 

--- a/docs/source/user_guide/slabs.rst
+++ b/docs/source/user_guide/slabs.rst
@@ -108,6 +108,24 @@ If no reinforcement is assigned, *Mento* can design flexure and shear automatica
     node.design_flexure()
     node.design_shear()
 
+The design is written back in the slab's own terms: a diameter and a spacing per layer,
+per face. Read it through ``reinforcement`` (what the slab carries, at any time) or
+``flexure_design`` (what a check demanded of it), rather than from the private attributes:
+
+.. code-block:: python
+
+    bottom = slab.reinforcement.bottom
+
+    str(bottom)                 # 'Ø12 mm/17 cm'
+    bottom.layers[0].d_b        # 12 mm
+    bottom.layers[0].s.to("cm") # 17 cm
+    bottom.n_bars               # 6 bars across the strip
+    bottom.A_s.to("cm**2")      # 6.79 cm² placed
+
+The spacing is rounded to the whole centimetre (inch, in imperial), so it is one that can
+be detailed, and never to fewer bars than the design called for. See
+:ref:`user_guide/design_results` for the rest of that view.
+
 6. Jupyter Notebook Results
 ***************************
 

--- a/docs/source/user_guide/slabs.rst
+++ b/docs/source/user_guide/slabs.rst
@@ -123,7 +123,11 @@ per face. Read it through ``reinforcement`` (what the slab carries, at any time)
     bottom.A_s.to("cm**2")      # 6.79 cm² placed
 
 The spacing is rounded to the whole centimetre (inch, in imperial), so it is one that can
-be detailed, and never to fewer bars than the design called for. See
+be detailed, and never to fewer bars than the design called for. It is also capped at the
+maximum the design code allows between the bars of a slab — ``min(3h, 450 mm)`` under
+ACI 318-19 §7.7.2.3, ``min(3h, 400 mm)`` under EN 1992-1-1 §9.3.1.1(3) — so a lightly
+loaded strip is not detailed as a few widely spaced bars that merely add up to the area.
+A check reports that limit too, next to the spacing, in the flexure results table. See
 :ref:`user_guide/design_results` for the rest of that view.
 
 6. Jupyter Notebook Results

--- a/mento/codes/aci_318_19/code.py
+++ b/mento/codes/aci_318_19/code.py
@@ -93,6 +93,16 @@ def _min_stirrup_diameter(concrete: Any) -> Any:
     return 10 * mm if concrete.unit_system == "metric" else 3 / 8 * inch
 
 
+def _max_bar_spacing_slab(section: "RectangularBeam") -> Any:
+    """ACI 318-19 7.7.2.3: the lesser of 3h and 450 mm (18 in.).
+
+    The limit is on the flexural reinforcement of a one-way slab, so it is the
+    spacing of the layer nearest the face that has to meet it.
+    """
+    limit = 450 * mm if section.concrete.unit_system == "metric" else 18 * inch
+    return min(3 * section.height, limit)
+
+
 def _min_stirrup_diameter_cirsoc(concrete: Any) -> Any:
     """CIRSOC's catalogue starts one size below ACI's."""
     return 6 * mm
@@ -188,6 +198,7 @@ _COMMON = dict(
     capacity_columns=_capacity_columns,
     shear_symbols=_SHEAR_SYMBOLS,
     summary_drop_columns=_SUMMARY_DROP_COLUMNS,
+    max_bar_spacing_slab=_max_bar_spacing_slab,
 )
 
 ACI_318_19 = register(

--- a/mento/codes/en_1992_2004/code.py
+++ b/mento/codes/en_1992_2004/code.py
@@ -13,7 +13,7 @@ from mento.codes.EN_1992_2004_beam import (
 )
 from mento.codes.registry import DesignCode, register
 from mento.material import Concrete_EN_1992_2004
-from mento.units import cm, kN, kNm, MPa
+from mento.units import cm, kN, kNm, mm, MPa
 
 if TYPE_CHECKING:
     from mento.beam import RectangularBeam
@@ -144,6 +144,18 @@ def _longitudinal_rebar(rebar: "Rebar", A_s_req: Any, A_s_max: Any, mech_cover: 
     return rebar.longitudinal_rebar_EN_1992_2004(A_s_req, A_s_max, mech_cover)
 
 
+def _max_bar_spacing_slab(section: "RectangularBeam") -> Any:
+    """EN 1992-1-1 9.3.1.1(3): 3h, and no more than 400 mm.
+
+    The general provision for the principal reinforcement of a slab. The tighter
+    one it states for areas of concentrated load or of maximum moment (2h, and
+    no more than 250 mm) is not applied here: a section is checked against a set
+    of forces, with no position along the span for mento to tell that it is in
+    one of those areas.
+    """
+    return min(3 * section.height, 400 * mm)
+
+
 EN_1992_2004 = register(
     DesignCode(
         title="EN 1992-2004",
@@ -166,5 +178,6 @@ EN_1992_2004 = register(
         capacity_columns=_capacity_columns,
         shear_symbols=_SHEAR_SYMBOLS,
         summary_drop_columns=_SUMMARY_DROP_COLUMNS,
+        max_bar_spacing_slab=_max_bar_spacing_slab,
     )
 )

--- a/mento/codes/registry.py
+++ b/mento/codes/registry.py
@@ -81,6 +81,11 @@ class DesignCode:
     #: Smallest stirrup bar this code's detailing rules allow. Only the codes
     #: whose report tables quote it need to supply one.
     min_stirrup_diameter: Callable[..., Any] | None = None
+    #: Largest centre-to-centre spacing this code allows between the flexural
+    #: bars of a slab. ``None`` for a code that states none, which is read as
+    #: no limit rather than as an error: a spacing rule a code does not have is
+    #: not a rule an element can fail.
+    max_bar_spacing_slab: Callable[..., Any] | None = None
 
     def requires(self, hook: str) -> Callable[..., Any]:
         """The hook, or a clear error naming the code that lacks it."""

--- a/mento/design_results.py
+++ b/mento/design_results.py
@@ -31,12 +31,35 @@ class DesignNotRunError(RuntimeError):
     """Raised when results are read before a check or design has been run."""
 
 
+def format_longitudinal_rebar(n: int, d_b: str, s: Optional[str] = None) -> str:
+    """Label one layer of longitudinal bars in the notation of its element.
+
+    A beam is detailed as a number of bars of a diameter, so the count leads:
+    ``4Ø16``. A slab is one bar repeated at a spacing across the strip, and the
+    count that falls out of it says nothing about how it is drawn, so the
+    spacing takes its place: ``Ø12/17cm`` -- the same notation its grid of
+    stirrups is written in.
+
+    Takes the numbers already formatted, so each caller keeps its own precision
+    and units while the shape of the label is decided in one place.
+    """
+    if s is None:
+        return f"{n}Ø{d_b}"
+    return f"Ø{d_b}/{s}"
+
+
 @dataclass(frozen=True)
 class RebarLayer:
-    """One layer of longitudinal bars: ``n`` bars of diameter ``d_b``."""
+    """One layer of longitudinal bars: ``n`` bars of diameter ``d_b``.
+
+    ``s`` is the centre-to-centre spacing the layer was detailed with, and is
+    ``None`` on a section that is detailed by a bar count instead -- a beam.
+    The area is the same either way; what changes is how the layer reads.
+    """
 
     n: int
     d_b: Quantity
+    s: Optional[Quantity] = None
 
     @property
     def A_s(self) -> Quantity:
@@ -44,7 +67,11 @@ class RebarLayer:
         return self.n * (self.d_b**2) * math.pi / 4
 
     def __str__(self) -> str:
-        return f"{self.n}Ø{self.d_b:.4g~P}"
+        return format_longitudinal_rebar(
+            self.n,
+            f"{self.d_b:.4g~P}",
+            None if self.s is None else f"{self.s:.4g~P}",
+        )
 
 
 @dataclass(frozen=True)
@@ -352,8 +379,13 @@ def _layers(beam: RectangularBeam, face: str) -> Tuple[RebarLayer, ...]:
     for index in (1, 2, 3, 4):
         n = getattr(beam, f"_n{index}_{face}", 0)
         d_b: Optional[Quantity] = getattr(beam, f"_d_b{index}_{face}", None)
+        # Only a section detailed by a spacing carries one; a beam has no such
+        # attribute and its layers keep reading as a number of bars.
+        s: Optional[Quantity] = getattr(beam, f"_s_b{index}_{face}", None)
+        if s is not None and s.magnitude == 0:
+            s = None
         if n and d_b is not None and d_b.magnitude > 0:
-            layers.append(RebarLayer(n=int(n), d_b=d_b))
+            layers.append(RebarLayer(n=int(n), d_b=d_b, s=s))
     return tuple(layers)
 
 

--- a/mento/reports/tables.py
+++ b/mento/reports/tables.py
@@ -102,6 +102,45 @@ def _longitudinal_rebar_rows(self: "RectangularBeam", face: str) -> tuple[list[s
     return labels, variables, values
 
 
+def _bar_spacing_row(
+    self: "RectangularBeam", face: str, min_clear: Quantity
+) -> tuple[str, Quantity, Quantity | None, Quantity | None]:
+    """The label, the value and the limits of one face's bar-spacing row.
+
+    A beam is detailed to a clear distance between bars, and reports the
+    smallest one it has against the minimum its settings ask for. A slab is
+    detailed to a spacing, and what the codes limit there is how far apart the
+    bars may be -- ACI 318-19 7.7.2.3, EN 1992-1-1 9.3.1.1(3) -- since bars far
+    enough apart leave the slab between them unreinforced whatever they add up
+    to. So the row carries the centre-to-centre spacing of the layer nearest the
+    face, and a maximum along with the minimum. A face with no bars on it has
+    nothing to check either way. ``face`` is ``"b"`` or ``"t"``.
+    """
+    side = "top" if face == "t" else "bottom"
+    # Only a section detailed by a spacing carries one; a beam has no such
+    # attribute and keeps reporting the clear distance between its bars.
+    spacing = getattr(self, f"_s_b1_{face}", None)
+    if spacing is None:
+        clear: Quantity = getattr(self, f"_available_s_{'top' if face == 't' else 'bot'}")
+        return f"Minimum spacing {side}", clear, min_clear, None
+    if getattr(self, f"_n1_{face}") == 0 or spacing.magnitude == 0:
+        return f"Bar spacing {side}", spacing, None, None
+    limit_of = getattr(self, "_max_bar_spacing", None)
+    # The value is centre to centre, so the minimum clear distance is read as
+    # one bar further apart than the beam reads it.
+    return (
+        f"Bar spacing {side}",
+        spacing,
+        min_clear + getattr(self, f"_d_b1_{face}"),
+        None if limit_of is None else limit_of(),
+    )
+
+
+def _shown_mm(value: Quantity | None) -> Any:
+    """A limit in millimetres for the report tables, blank where there is none."""
+    return "" if value is None else round(value.to("mm").magnitude, 2)
+
+
 def _settings(beam: RectangularBeam) -> BeamSettings:
     """The beam's settings, which ``__post_init__`` always fills in.
 
@@ -467,23 +506,25 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
     settings = _settings(self)
     min_spacing_top: Quantity = max(settings.clear_spacing, settings.vibrator_size, self._d_b_max_top)
     min_spacing_bot: Quantity = max(settings.clear_spacing, self._d_b_max_bot)
+    label_s_top, s_top, s_top_min, s_top_max = _bar_spacing_row(self, "t", min_spacing_top)
+    label_s_bot, s_bot, s_bot_min, s_bot_max = _bar_spacing_row(self, "b", min_spacing_bot)
     min_values = [
         self._A_s_min_top,
-        min_spacing_top,
+        s_top_min,
         self._A_s_min_bot,
-        min_spacing_bot,
+        s_bot_min,
     ]  # Use None for items without a minimum constraint
     max_values = [
         self._A_s_max_top,
-        None,
+        s_top_max,
         self._A_s_max_bot,
-        None,
+        s_bot_max,
     ]  # Use None for items without a maximum constraint
     current_values = [
         self._A_s_top,
-        self._available_s_top,
+        s_top,
         self._A_s_bot,
-        self._available_s_bot,
+        s_bot,
     ]  # Current values to check
 
     ARTICLE_STR = "9.6.1.3"
@@ -522,28 +563,28 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
     self._data_min_max_flexure = {
         "Check": [
             "Min/Max As rebar top",
-            "Minimum spacing top",
+            label_s_top,
             "Min/Max As rebar bottom",
-            "Minimum spacing bottom",
+            label_s_bot,
         ],
         "Unit": ["cm²", "mm", "cm²", "mm"],
         "Value": [
             round(self._A_s_top.to("cm**2").magnitude, 2),
-            round(self._available_s_top.to("mm").magnitude, 2),
+            _shown_mm(s_top),
             round(self._A_s_bot.to("cm**2").magnitude, 2),
-            round(self._available_s_bot.to("mm").magnitude, 2),
+            _shown_mm(s_bot),
         ],
         "Min.": [
             round(self._A_s_min_top.to("cm**2").magnitude, 2),
-            round(min_spacing_top.to("mm").magnitude, 2),
+            _shown_mm(s_top_min),
             round(self._A_s_min_bot.to("cm**2").magnitude, 2),
-            round(min_spacing_bot.to("mm").magnitude, 2),
+            _shown_mm(s_bot_min),
         ],
         "Max.": [
             round(self._A_s_max_top.to("cm**2").magnitude, 2),
-            "",
+            _shown_mm(s_top_max),
             round(self._A_s_max_bot.to("cm**2").magnitude, 2),
-            "",
+            _shown_mm(s_bot_max),
         ],
         "Ok?": checks,
     }
@@ -899,23 +940,25 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
     settings = _settings(self)
     min_spacing_top: Quantity = max(settings.clear_spacing, settings.vibrator_size, self._d_b_max_top)
     min_spacing_bot: Quantity = max(settings.clear_spacing, self._d_b_max_bot)
+    label_s_top, s_top, s_top_min, s_top_max = _bar_spacing_row(self, "t", min_spacing_top)
+    label_s_bot, s_bot, s_bot_min, s_bot_max = _bar_spacing_row(self, "b", min_spacing_bot)
     min_values = [
         self._A_s_min_top,
-        min_spacing_top,
+        s_top_min,
         self._A_s_min_bot,
-        min_spacing_bot,
+        s_bot_min,
     ]  # Use None for items without a minimum constraint
     max_values = [
         self._A_s_max_top,
-        None,
+        s_top_max,
         self._A_s_max_bot,
-        None,
+        s_bot_max,
     ]  # Use None for items without a maximum constraint
     current_values = [
         self._A_s_top,
-        self._available_s_top,
+        s_top,
         self._A_s_bot,
-        self._available_s_bot,
+        s_bot,
     ]  # Current values to check
 
     # Generate check marks based on the range conditions
@@ -940,28 +983,28 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
     self._data_min_max_flexure = {
         "Check": [
             "Min/Max As rebar top",
-            "Minimum spacing top",
+            label_s_top,
             "Min/Max As rebar bottom",
-            "Minimum spacing bottom",
+            label_s_bot,
         ],
         "Unit": ["cm²", "mm", "cm²", "mm"],
         "Value": [
             round(self._A_s_top.to("cm**2").magnitude, 2),
-            round(self._available_s_top.to("mm").magnitude, 2),
+            _shown_mm(s_top),
             round(self._A_s_bot.to("cm**2").magnitude, 2),
-            round(self._available_s_bot.to("mm").magnitude, 2),
+            _shown_mm(s_bot),
         ],
         "Min.": [
             round(self._A_s_min_top.to("cm**2").magnitude, 2),
-            round(min_spacing_top.to("mm").magnitude, 2),
+            _shown_mm(s_top_min),
             round(self._A_s_min_bot.to("cm**2").magnitude, 2),
-            round(min_spacing_bot.to("mm").magnitude, 2),
+            _shown_mm(s_bot_min),
         ],
         "Max.": [
             round(self._A_s_max_top.to("cm**2").magnitude, 2),
-            "",
+            _shown_mm(s_top_max),
             round(self._A_s_max_bot.to("cm**2").magnitude, 2),
-            "",
+            _shown_mm(s_bot_max),
         ],
         "Ok?": checks,
     }

--- a/mento/reports/tables.py
+++ b/mento/reports/tables.py
@@ -22,7 +22,7 @@ from pint import Quantity
 from mento.units import inch, kN, kNm, mm
 
 from mento.codes.registry import design_code
-from mento.design_results import GRID, transverse_layout
+from mento.design_results import GRID, format_longitudinal_rebar, transverse_layout
 
 if TYPE_CHECKING:
     from mento.beam import RectangularBeam
@@ -63,6 +63,43 @@ def _transverse_rebar_rows(
         [self._stirrup_n, diameter, s_l],
         ["", "mm", "cm"],
     )
+
+
+def _longitudinal_rebar_rows(self: "RectangularBeam", face: str) -> tuple[list[str], list[str], list[Any]]:
+    """The two rows that identify the longitudinal reinforcement of one face.
+
+    A beam is a number of bars per layer, so the bars are counted: ``n1+n2``. A
+    slab is one bar repeated at a spacing, and the count that falls out of a
+    strip is not what it is drawn with, so each of its layers reads as a
+    diameter and a spacing instead. ``face`` is ``"b"`` or ``"t"``, and there
+    are two rows either way, so every column of the table stays the same length.
+    """
+    labels = ["First layer bars", "Second layer bars"]
+    variables = []
+    values = []
+    # Only a section detailed by a spacing carries these; a beam has no such
+    # attribute and its layers keep being reported as a number of bars. The
+    # notation is chosen once for the face, so an empty second layer is still
+    # written the way the rest of the face is.
+    detailed_by_spacing = getattr(self, f"_s_b1_{face}", None) is not None
+    for first, second in ((1, 2), (3, 4)):
+        n = getattr(self, f"_n{first}_{face}")
+        d_b = getattr(self, f"_d_b{first}_{face}")
+        if not detailed_by_spacing:
+            variables.append(f"n{first}+n{second}")
+            values.append(
+                self._format_longitudinal_rebar_string(
+                    n, d_b, getattr(self, f"_n{second}_{face}"), getattr(self, f"_d_b{second}_{face}")
+                )
+            )
+            continue
+        spacing = getattr(self, f"_s_b{first}_{face}")
+        variables.append(f"Ø{first}/s{first}")
+        if n == 0 or d_b.magnitude == 0 or spacing.magnitude == 0:
+            values.append("-")
+        else:
+            values.append(format_longitudinal_rebar(n, f"{d_b:.4g~P}", f"{spacing:.4g~P}"))
+    return labels, variables, values
 
 
 def _settings(beam: RectangularBeam) -> BeamSettings:
@@ -512,10 +549,10 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
     }
     check_DCR_top = "✅" if self._DCRb_top < 1 else "❌"
     check_DCR_bot = "✅" if self._DCRb_bot < 1 else "❌"
+    long_rebar_top = _longitudinal_rebar_rows(self, "t")
     self._flexure_capacity_top = {
         "Top reinforcement check": [
-            "First layer bars",
-            "Second layer bars",
+            *long_rebar_top[0],
             "Effective height",
             "Depth of equivalent strength block ratio",
             "Minimum rebar reinforcing",
@@ -527,8 +564,7 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
             "Demand Capacity Ratio",
         ],
         "Variable": [
-            "n1+n2",
-            "n3+n4",
+            *long_rebar_top[1],
             "d",
             "c/d",
             "As,min",
@@ -540,8 +576,7 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
             "DCR",
         ],
         "Value": [
-            self._format_longitudinal_rebar_string(self._n1_t, self._d_b1_t, self._n2_t, self._d_b2_t),
-            self._format_longitudinal_rebar_string(self._n3_t, self._d_b3_t, self._n4_t, self._d_b4_t),
+            *long_rebar_top[2],
             round(self._d_top.to("cm").magnitude, 2),
             round(self._c_d_top, 4),
             round(self._A_s_min_top.to("cm**2").magnitude, 2),
@@ -566,10 +601,10 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
             check_DCR_top,
         ],
     }
+    long_rebar_bot = _longitudinal_rebar_rows(self, "b")
     self._flexure_capacity_bot = {
         "Bottom reinforcement check": [
-            "First layer bars",
-            "Second layer bars",
+            *long_rebar_bot[0],
             "Effective height",
             "Depth of equivalent strength block ratio",
             "Minimum rebar reinforcing",
@@ -581,8 +616,7 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
             "Demand Capacity Ratio",
         ],
         "Variable": [
-            "n1+n2",
-            "n3+n4",
+            *long_rebar_bot[1],
             "d",
             "c/d",
             "As,min",
@@ -594,8 +628,7 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
             "DCR",
         ],
         "Value": [
-            self._format_longitudinal_rebar_string(self._n1_b, self._d_b1_b, self._n2_b, self._d_b2_b),
-            self._format_longitudinal_rebar_string(self._n3_b, self._d_b3_b, self._n4_b, self._d_b4_b),
+            *long_rebar_bot[2],
             round(self._d_bot.to("cm").magnitude, 2),
             round(self._c_d_bot, 4),
             round(self._A_s_min_bot.to("cm**2").magnitude, 2),
@@ -934,10 +967,10 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
     }
     check_DCR_top = "✅" if self._DCRb_top < 1 else "❌"
     check_DCR_bot = "✅" if self._DCRb_bot < 1 else "❌"
+    long_rebar_top = _longitudinal_rebar_rows(self, "t")
     self._flexure_capacity_top = {
         "Top reinforcement check": [
-            "First layer bars",
-            "Second layer bars",
+            *long_rebar_top[0],
             "Effective height",
             "Depth of equivalent strength block ratio",
             "Minimum rebar reinforcing",
@@ -949,8 +982,7 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
             "Demand Capacity Ratio",
         ],
         "Variable": [
-            "n1+n2",
-            "n3+n4",
+            *long_rebar_top[1],
             "d",
             "c/d",
             "As,min",
@@ -962,8 +994,7 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
             "DCR",
         ],
         "Value": [
-            self._format_longitudinal_rebar_string(self._n1_t, self._d_b1_t, self._n2_t, self._d_b2_t),
-            self._format_longitudinal_rebar_string(self._n3_t, self._d_b3_t, self._n4_t, self._d_b4_t),
+            *long_rebar_top[2],
             round(self._d_top.to("cm").magnitude, 2),
             self._c_d_top,
             round(self._A_s_min_top.to("cm**2").magnitude, 2),
@@ -988,10 +1019,10 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
             check_DCR_top,
         ],
     }
+    long_rebar_bot = _longitudinal_rebar_rows(self, "b")
     self._flexure_capacity_bot = {
         "Bottom reinforcement check": [
-            "First layer bars",
-            "Second layer bars",
+            *long_rebar_bot[0],
             "Effective height",
             "Depth of equivalent strength block ratio",
             "Minimum rebar reinforcing",
@@ -1003,8 +1034,7 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
             "Demand Capacity Ratio",
         ],
         "Variable": [
-            "n1+n2",
-            "n3+n4",
+            *long_rebar_bot[1],
             "d",
             "c/d",
             "As,min",
@@ -1016,8 +1046,7 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
             "DCR",
         ],
         "Value": [
-            self._format_longitudinal_rebar_string(self._n1_b, self._d_b1_b, self._n2_b, self._d_b2_b),
-            self._format_longitudinal_rebar_string(self._n3_b, self._d_b3_b, self._n4_b, self._d_b4_b),
+            *long_rebar_bot[2],
             round(self._d_bot.to("cm").magnitude, 2),
             self._c_d_bot,
             round(self._A_s_min_bot.to("cm**2").magnitude, 2),

--- a/mento/slab.py
+++ b/mento/slab.py
@@ -11,6 +11,18 @@ if TYPE_CHECKING:
     from pint import Quantity
 
 
+def _bars_at_spacing(spacing: Quantity, width: Quantity) -> int:
+    """How many bars a strip of ``width`` carries at a centre-to-centre ``spacing``.
+
+    The one place the count-from-spacing rule lives, so that a spacing chosen
+    for a given number of bars can be checked against the count it produces.
+    """
+    if spacing == 0 * mm:
+        return 0  # Default to 0 bars if spacing is zero
+    # Round up to ensure full bars (e.g., 3.2 bars → 4 bars)
+    return int(np.ceil((width.to("cm").magnitude / spacing.to("cm").magnitude)))  # Returns dimensionless count
+
+
 @dataclass
 class OneWaySlab(RectangularBeam):
     """
@@ -120,6 +132,87 @@ class OneWaySlab(RectangularBeam):
             s_trans=design["s_w"],
         )
 
+    def _zero_diameter(self) -> Quantity:
+        """A bar diameter of zero, in the length unit of this slab."""
+        return 0 * mm if self.concrete.unit_system == "metric" else 0 * inch
+
+    def _spacing_for_bars(self, n: int) -> Quantity:
+        """The spacing that puts ``n`` bars across the strip, as it would be drawn.
+
+        The exact answer is ``width / n``, which is rarely a number anyone
+        details to, so it is rounded to the whole centimetre (inch). Rounding up
+        is what usually keeps the layout the search chose -- the count comes
+        back as ``ceil(width / s)``, so a slightly wider spacing still asks for
+        the same ``n`` bars, while a narrower one would silently add one -- but
+        it is checked rather than assumed, because it does not always hold.
+        """
+        if n <= 0:
+            return 0 * cm
+        unit = cm if self.concrete.unit_system == "metric" else inch
+        exact = (self.width / n).to(unit).magnitude
+        spacing = math.ceil(exact) * unit
+        if _bars_at_spacing(spacing, self.width) < n:
+            # Rounding up costs a bar once the bars are close enough that a whole
+            # centimetre spans more than one of them -- from about eleven bars in
+            # a metre. Round down there instead: that can only ask for more bars
+            # than the design chose, never fewer, so the strip is never detailed
+            # with less steel than it needs. (The floor is only ever zero at a
+            # spacing below one centimetre, where the bars would already overlap.)
+            spacing = max(math.floor(exact), 1) * unit
+        return spacing
+
+    def _layer_from_design(self, design: Any, first: int, second: int) -> tuple[Quantity, Quantity]:
+        """The diameter and spacing of the layer a design gives as two bar groups."""
+        n_first = int(design.get(f"n_{first}", 0) or 0)
+        n_second = int(design.get(f"n_{second}", 0) or 0)
+        # A slab is searched with max_diameter_diff = 0, so a layer only ever
+        # comes back with one diameter: whichever group carries the bars.
+        d_b = design.get(f"d_b{first}") if n_first > 0 else design.get(f"d_b{second}")
+        if d_b is None or d_b.magnitude == 0:
+            return self._zero_diameter(), 0 * cm
+        return d_b, self._spacing_for_bars(n_first + n_second)
+
+    def _apply_longitudinal_design(self, design: Any, face: str) -> None:
+        """Apply a design given in bar counts to a face, as a spacing per layer.
+
+        The rebar search is the beam's -- a slab is not worth a second one --
+        and it answers with groups of bars: ``n_1`` and ``n_2`` are the layer
+        nearest the face, ``n_3`` and ``n_4`` the one behind it. A slab is not
+        detailed that way; it is a diameter repeated at a spacing. So each
+        layer is spread over the strip here, and the spacings are what the slab
+        stores. Applying the design the beam's way left the bars split across
+        two groups that are really one layer, and left the spacings -- the only
+        thing a slab is drawn with -- empty.
+        """
+        d_b1, s_b1 = self._layer_from_design(design, 1, 2)
+        d_b3, s_b3 = self._layer_from_design(design, 3, 4)
+        setattr(self, f"_d_b1_{face}", d_b1)
+        setattr(self, f"_s_b1_{face}", s_b1)
+        setattr(self, f"_d_b3_{face}", d_b3)
+        setattr(self, f"_s_b3_{face}", s_b3)
+        self._calculate_longitudinal_rebars()
+        self._update_longitudinal_rebar_attributes()
+
+    def _apply_longitudinal_design_bot(self, design: Any) -> None:
+        """See :meth:`_apply_longitudinal_design`."""
+        self._apply_longitudinal_design(design, "b")
+
+    def _apply_longitudinal_design_top(self, design: Any) -> None:
+        """See :meth:`_apply_longitudinal_design`."""
+        self._apply_longitudinal_design(design, "t")
+
+    def _clear_top_longitudinal(self) -> None:
+        """Clear the top face, its spacings included.
+
+        A beam clears a face by zeroing the bar counts. On a slab those counts
+        are derived from the spacings, so a spacing left behind would put the
+        bars back the next time any layer is recalculated.
+        """
+        self._d_b1_t, self._s_b1_t = self._zero_diameter(), 0 * cm
+        self._d_b3_t, self._s_b3_t = self._zero_diameter(), 0 * cm
+        self._calculate_longitudinal_rebars()
+        self._update_longitudinal_rebar_attributes()
+
     def set_slab_longitudinal_rebar_bot(
         self,
         d_b1: Quantity = 0 * mm,
@@ -168,17 +261,10 @@ class OneWaySlab(RectangularBeam):
     def _calculate_longitudinal_rebars(self) -> None:
         """Calculate the total rebar area for a slab, given spacing and slab width."""
 
-        # Helper function: Calculate number of bars given spacing and slab width
-        def calculate_bars(spacing: Quantity, width: Quantity) -> int:
-            if spacing == 0 * mm:
-                return 0  # Default to 0 bars if spacing is zero
-            # Round up to ensure full bars (e.g., 3.2 bars → 4 bars)
-            return int(np.ceil((width.to("cm").magnitude / spacing.to("cm").magnitude)))  # Returns dimensionless count
-
         # --- BOTTOM REBAR ---
-        self._n1_b = calculate_bars(self._s_b1_b, self.width)
-        self._n3_b = calculate_bars(self._s_b3_b, self.width)
+        self._n1_b = _bars_at_spacing(self._s_b1_b, self.width)
+        self._n3_b = _bars_at_spacing(self._s_b3_b, self.width)
 
         # --- TOP REBAR ---
-        self._n1_t = calculate_bars(self._s_b1_t, self.width)
-        self._n3_t = calculate_bars(self._s_b3_t, self.width)
+        self._n1_t = _bars_at_spacing(self._s_b1_t, self.width)
+        self._n3_t = _bars_at_spacing(self._s_b3_t, self.width)

--- a/mento/slab.py
+++ b/mento/slab.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, cast
 from dataclasses import dataclass
 import math
 import numpy as np
 
 from mento.beam import RectangularBeam
+from mento.codes.registry import design_code
 from mento.units import m, mm, cm, inch
 
 if TYPE_CHECKING:
@@ -136,6 +137,17 @@ class OneWaySlab(RectangularBeam):
         """A bar diameter of zero, in the length unit of this slab."""
         return 0 * mm if self.concrete.unit_system == "metric" else 0 * inch
 
+    def _max_bar_spacing(self) -> Quantity | None:
+        """The largest spacing the design code allows between the flexural bars.
+
+        ACI 318-19 7.7.2.3 and EN 1992-1-1 9.3.1.1(3) both cap it as a multiple
+        of the thickness, which is what keeps a slab from being detailed as a
+        handful of widely spaced bars that happen to add up to the area. A code
+        that states no such limit returns ``None``.
+        """
+        limit = design_code(self.concrete).max_bar_spacing_slab
+        return None if limit is None else cast("Quantity", limit(self))
+
     def _spacing_for_bars(self, n: int) -> Quantity:
         """The spacing that puts ``n`` bars across the strip, as it would be drawn.
 
@@ -144,7 +156,9 @@ class OneWaySlab(RectangularBeam):
         is what usually keeps the layout the search chose -- the count comes
         back as ``ceil(width / s)``, so a slightly wider spacing still asks for
         the same ``n`` bars, while a narrower one would silently add one -- but
-        it is checked rather than assumed, because it does not always hold.
+        it is checked rather than assumed, because it does not always hold. The
+        result is then capped at what the code allows between the bars of a
+        slab, which only ever asks for more of them.
         """
         if n <= 0:
             return 0 * cm
@@ -159,6 +173,13 @@ class OneWaySlab(RectangularBeam):
             # with less steel than it needs. (The floor is only ever zero at a
             # spacing below one centimetre, where the bars would already overlap.)
             spacing = max(math.floor(exact), 1) * unit
+        limit = self._max_bar_spacing()
+        if limit is not None:
+            # The area the search asked for is not the only thing the layout has
+            # to satisfy: bars far enough apart leave the slab between them
+            # unreinforced whatever they add up to. Capping the spacing only
+            # ever adds bars, so the area is still covered.
+            spacing = min(spacing, math.floor(limit.to(unit).magnitude) * unit)
         return spacing
 
     def _layer_from_design(self, design: Any, first: int, second: int) -> tuple[Quantity, Quantity]:

--- a/tests/test_design_results.py
+++ b/tests/test_design_results.py
@@ -143,6 +143,15 @@ def test_rebar_layer_str_is_the_engineering_shorthand() -> None:
     assert str(RebarLayer(n=2, d_b=12 * mm)) == "2Ø12 mm"
 
 
+def test_a_layer_detailed_by_a_spacing_reads_as_one_bar_at_that_spacing() -> None:
+    """A slab layer carries a spacing; counting its bars is not how it is drawn."""
+    layer = RebarLayer(n=6, d_b=12 * mm, s=17 * cm)
+
+    assert str(layer) == "Ø12 mm/17 cm"
+    # The area is the bars either way.
+    assert layer.A_s.to("cm**2").magnitude == pytest.approx(6 * math.pi * (1.2**2) / 4)
+
+
 # ============================================================================
 # Reading results before running anything
 # ============================================================================

--- a/tests/test_slab.py
+++ b/tests/test_slab.py
@@ -3,6 +3,7 @@ import math
 import pytest
 from pint import Quantity
 
+from mento.beam import RectangularBeam
 from mento.node import Node
 from mento.slab import OneWaySlab, _bars_at_spacing
 from mento.material import Concrete_ACI_318_19, SteelBar, Concrete_EN_1992_2004
@@ -692,6 +693,97 @@ def test_a_hogging_slab_is_designed_on_its_top_face_by_a_spacing() -> None:
     assert top.layers[0].s is not None
     assert _bars_at_spacing(slab._s_b1_t, slab.width) == top.layers[0].n
     assert top.A_s >= slab.flexure_design.top.A_s_req
+
+
+@pytest.mark.parametrize(
+    ("concrete", "height", "expected_cm"),
+    [
+        (Concrete_ACI_318_19(name="H25", f_c=25 * MPa), 12 * cm, 36),  # 3h governs
+        (Concrete_ACI_318_19(name="H25", f_c=25 * MPa), 25 * cm, 45),  # 450 mm governs
+        (Concrete_EN_1992_2004(name="C25", f_c=25 * MPa), 12 * cm, 36),  # 3h governs
+        (Concrete_EN_1992_2004(name="C25", f_c=25 * MPa), 25 * cm, 40),  # 400 mm governs
+    ],
+    ids=["ACI_3h", "ACI_450mm", "EN_3h", "EN_400mm"],
+)
+def test_the_code_caps_how_far_apart_the_bars_of_a_slab_may_sit(
+    concrete: Concrete_ACI_318_19 | Concrete_EN_1992_2004, height: Quantity, expected_cm: float
+) -> None:
+    """ACI 318-19 7.7.2.3 is 3h or 450 mm; EN 1992-1-1 9.3.1.1(3) is 3h or 400 mm."""
+    slab = OneWaySlab(
+        label="Slab s_max",
+        concrete=concrete,
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=height,
+        c_c=20 * mm,
+    )
+
+    assert slab._max_bar_spacing().to("cm").magnitude == pytest.approx(expected_cm)
+
+
+def test_a_design_is_never_spaced_beyond_the_code_maximum() -> None:
+    """Area alone is not a layout.
+
+    A light strip needs so little steel that the search covers it with the two
+    bars it starts from, which on a metre of slab is a bar every half metre:
+    the area is there and most of the slab is not reinforced. The spacing is
+    capped at what the code allows, which only ever adds bars.
+    """
+    slab = OneWaySlab(
+        label="Slab lightly loaded",
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=12 * cm,
+        c_c=20 * mm,
+    )
+    Node(section=slab, forces=Forces(label="C1", M_y=2 * kNm)).design()
+
+    s_max = slab._max_bar_spacing()
+    assert s_max.to("cm").magnitude == 36  # 3h on a 12 cm slab
+    assert slab._s_b1_b <= s_max
+    assert slab.reinforcement.bottom.layers[0].n == _bars_at_spacing(s_max, slab.width)
+    assert slab.reinforcement.bottom.A_s >= slab.flexure_design.bottom.A_s_req
+
+
+def test_a_slab_spaced_beyond_the_code_maximum_fails_the_check() -> None:
+    """The bars add up to the area and the slab between them is still bare."""
+    slab = OneWaySlab(
+        label="Slab too spread out",
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=25 * cm,
+        c_c=25 * mm,
+    )
+    slab.set_slab_longitudinal_rebar_bot(d_b1=20 * mm, s_b1=60 * cm)
+
+    Node(section=slab, forces=Forces(label="C1", M_y=20 * kNm)).check_flexure()
+
+    rows = slab._data_min_max_flexure
+    assert rows["Check"][3] == "Bar spacing bottom"
+    assert rows["Value"][3] == pytest.approx(600)
+    assert rows["Max."][3] == pytest.approx(450)
+    assert rows["Ok?"][3] == "❌"
+    assert slab._all_flexure_checks_passed is False
+
+
+def test_a_beam_still_reports_the_clear_distance_between_its_bars() -> None:
+    """The max-spacing row is the slab's; a beam has no such limit to report."""
+    beam = RectangularBeam(
+        label="B1",
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=20 * cm,
+        height=50 * cm,
+        c_c=25 * mm,
+    )
+    Node(section=beam, forces=Forces(label="C1", M_y=100 * kNm)).design()
+
+    rows = beam._data_min_max_flexure
+    assert rows["Check"][3] == "Minimum spacing bottom"
+    assert rows["Value"][3] == pytest.approx(beam._available_s_bot.to("mm").magnitude, rel=1e-9)
+    assert rows["Max."][3] == ""
 
 
 def test_the_flexure_report_of_a_slab_names_the_spacing() -> None:

--- a/tests/test_slab.py
+++ b/tests/test_slab.py
@@ -4,7 +4,7 @@ import pytest
 from pint import Quantity
 
 from mento.node import Node
-from mento.slab import OneWaySlab
+from mento.slab import OneWaySlab, _bars_at_spacing
 from mento.material import Concrete_ACI_318_19, SteelBar, Concrete_EN_1992_2004
 from mento.units import kip, inch, mm, cm, kN, MPa, kNm, ksi
 from mento.forces import Forces
@@ -553,6 +553,157 @@ def test_slab_shear_design_is_the_least_steel_the_spacing_limits_allow() -> None
                     assert A_v.to("cm**2/m").magnitude >= chosen * (1 - 1e-9), (
                         f"Ø{row['d_b']} at {s_l} cm x {s_w} cm covers A_v_req with less steel"
                     )
+
+
+##########################################################
+# HOW A DESIGN IS WRITTEN ONTO A SLAB
+##########################################################
+
+
+def test_a_designed_slab_is_detailed_by_a_spacing_not_by_a_bar_count() -> None:
+    """The search is the beam's; what it produces has to be read as a slab.
+
+    Its answer is groups of bars -- ``n_1`` and ``n_2`` are one and the same
+    layer -- and the beam applies it as such. A slab that went through it came
+    out split into "2Ø12 + 4Ø12", two layers that are really one, with the
+    spacing that actually details a slab left empty: there was no way to read
+    the result other than by counting bars.
+    """
+    slab = _designed_slab(Concrete_ACI_318_19(name="H25", f_c=25 * MPa), V_z=0 * kN)
+
+    bottom = slab.reinforcement.bottom
+    assert len(bottom.layers) == 1
+    layer = bottom.layers[0]
+    assert layer.s is not None and layer.s.to("cm").magnitude > 0
+    assert str(bottom) == f"Ø{layer.d_b:.4g~P}/{layer.s:.4g~P}"
+    # Positions 2 and 4 stay empty: a slab layer is one bar at one spacing.
+    assert slab._n2_b == 0 and slab._n4_b == 0
+    # The spacing is the state, and the count is what it produces.
+    assert _bars_at_spacing(slab._s_b1_b, slab.width) == layer.n
+
+
+def test_the_spacing_a_design_leaves_is_one_that_can_be_drawn() -> None:
+    """Rounded to the centimetre, and up, so the bars the search chose stay."""
+    slab = _designed_slab(Concrete_ACI_318_19(name="H25", f_c=25 * MPa), V_z=0 * kN)
+
+    spacing = slab._s_b1_b.to("cm").magnitude
+    assert spacing == pytest.approx(round(spacing))
+    n = slab.reinforcement.bottom.layers[0].n
+    # Rounding up cannot cost a bar: n bars at width/n rounded up still ask for n.
+    assert spacing >= slab.width.to("cm").magnitude / n
+    assert slab.reinforcement.bottom.A_s >= slab.flexure_design.bottom.A_s_req
+
+
+def test_a_spacing_is_never_rounded_into_fewer_bars_than_the_design_chose() -> None:
+    """Rounding up is the rule, but it does not always hold.
+
+    ``ceil(width / n)`` normally asks for the same ``n`` bars back. Once the
+    bars are close enough that a whole centimetre spans more than one of them
+    -- from about eleven in a metre -- rounding up drops one, so the spacing is
+    checked against the count it produces and rounded down instead.
+    """
+    slab = OneWaySlab(
+        label="Slab spacing",
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=20 * cm,
+        c_c=20 * mm,
+    )
+
+    # 100/6 = 16.7 -> 17 cm, and 17 cm still asks for 6 bars.
+    assert slab._spacing_for_bars(6).to("cm").magnitude == 17
+    # 100/11 = 9.1 -> 10 cm would only ask for 10, so it rounds the other way.
+    assert slab._spacing_for_bars(11).to("cm").magnitude == 9
+    for n in range(1, 30):
+        assert _bars_at_spacing(slab._spacing_for_bars(n), slab.width) >= n
+    assert slab._spacing_for_bars(0).magnitude == 0
+
+
+def test_an_imperial_slab_is_designed_to_a_whole_inch_spacing() -> None:
+    slab = OneWaySlab(
+        label="Slab imperial flexure",
+        concrete=Concrete_ACI_318_19(name="C4", f_c=4 * ksi),
+        steel_bar=SteelBar(name="G60", f_y=60 * ksi),
+        width=36 * inch,
+        height=10 * inch,
+        c_c=0.75 * inch,
+    )
+    Node(section=slab, forces=Forces(label="C1", M_y=20 * kNm)).design()
+
+    spacing = slab._s_b1_b.to("inch").magnitude
+    assert spacing == pytest.approx(round(spacing))
+    assert _bars_at_spacing(slab._s_b1_b, slab.width) == slab._n1_b
+
+
+def test_designing_a_slab_that_needs_no_top_steel_clears_the_top_spacing() -> None:
+    """A cleared face has to lose its spacing, or the bars come back.
+
+    The beam clears a face by zeroing the bar counts. On a slab those counts are
+    derived from the spacing, so a spacing left behind would be turned back into
+    bars by the next recalculation -- the following design of the bottom face.
+    """
+    slab = OneWaySlab(
+        label="Slab top cleared",
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=20 * cm,
+        c_c=20 * mm,
+    )
+    slab.set_slab_longitudinal_rebar_top(d_b1=12 * mm, s_b1=15 * cm)
+
+    # Sagging only: nothing is required on the top face.
+    Node(section=slab, forces=Forces(label="C1", M_y=30 * kNm)).design()
+
+    assert slab._s_b1_t.magnitude == 0
+    assert slab._n1_t == 0
+    assert slab.reinforcement.top.layers == ()
+    assert slab.reinforcement.top.A_s.magnitude == 0
+
+    # The same, through the path the design takes when the face has no layout
+    # at all to apply rather than an empty one.
+    slab.set_slab_longitudinal_rebar_top(d_b1=12 * mm, s_b1=15 * cm)
+    assert slab.reinforcement.top.n_bars > 0
+
+    slab._clear_top_longitudinal()
+
+    assert slab._s_b1_t.magnitude == 0
+    assert slab._s_b3_t.magnitude == 0
+    assert slab.reinforcement.top.layers == ()
+    # And the bars stay gone once another face is recalculated.
+    slab.set_slab_longitudinal_rebar_bot(d_b1=10 * mm, s_b1=20 * cm)
+    assert slab.reinforcement.top.layers == ()
+
+
+def test_a_hogging_slab_is_designed_on_its_top_face_by_a_spacing() -> None:
+    slab = OneWaySlab(
+        label="Slab hogging",
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=20 * cm,
+        c_c=20 * mm,
+    )
+    Node(section=slab, forces=Forces(label="C1", M_y=-30 * kNm)).design()
+
+    top = slab.reinforcement.top
+    assert len(top.layers) == 1
+    assert top.layers[0].s is not None
+    assert _bars_at_spacing(slab._s_b1_t, slab.width) == top.layers[0].n
+    assert top.A_s >= slab.flexure_design.top.A_s_req
+
+
+def test_the_flexure_report_of_a_slab_names_the_spacing() -> None:
+    """The count row gives way to the notation the strip is drawn in."""
+    slab = _designed_slab(Concrete_ACI_318_19(name="H25", f_c=25 * MPa), V_z=0 * kN)
+
+    rows = slab._flexure_capacity_bot
+    assert rows["Variable"][:2] == ["Ø1/s1", "Ø3/s3"]
+    assert rows["Value"][0] == str(slab.reinforcement.bottom.layers[0])
+    assert rows["Value"][1] == "-"
+    # Every column of the table still has one entry per row.
+    assert len({len(column) for column in rows.values()}) == 1
 
 
 ##########################################################


### PR DESCRIPTION
Two changes to `OneWaySlab`, both about the same thing: a slab that goes through the design comes out detailed the way a slab is detailed.

## A design is applied as a spacing, not as a bar count

The rebar search is the beam's — a slab is not worth a second one — and it answers with groups of bars: `n_1` and `n_2` are one and the same layer, `n_3` and `n_4` the one behind it. `OneWaySlab` applied that answer the beam's way, so a designed slab came out split into `2Ø12 + 4Ø12`, two layers that are really one, with `_s_b1_b` — the spacing that actually details a slab — left at zero. There was no way to read the result other than by counting bars.

Each layer is now spread over the strip when the design is applied, and the spacing is what the slab stores, exactly as its transverse reinforcement already did (`_apply_transverse_design`). The spacing is rounded to the whole centimetre (inch) so it can be drawn, and checked against the count it produces, so the strip is never detailed with less steel than the design chose. Clearing a face clears its spacings too: the bar counts are derived from them, so one left behind would put the bars back on the next recalculation.

Areas and DCRs are unchanged — the bar count the search selected is preserved exactly.

```python
slab.reinforcement.bottom          # 'Ø12 mm/17 cm'   (was '2Ø12 mm + 4Ø12 mm')
slab.reinforcement.bottom.n_bars   # 6
slab.reinforcement.bottom.layers[0].s.to("cm")   # 17 cm, None on a beam
```

`RebarLayer` carries the spacing it was detailed with, the detailed flexure tables follow, and a beam reads exactly as before.

## Maximum bar spacing

Area alone is not a layout: on a lightly loaded strip the search covers the required area with the two bars it starts from — a bar every half metre, with most of the slab unreinforced. Both codes cap the centre-to-centre spacing for that reason, and mento applied neither.

The limit is a registry hook, so the code states it:

| Code | Limit | Clause |
|---|---|---|
| ACI 318-19 | lesser of 3h and 450 mm (18 in.) | §7.7.2.3 |
| EN 1992-1-1 | 3h, no more than 400 mm | §9.3.1.1(3), principal reinforcement |

The design caps the spacing it writes back — which only ever adds bars, so the area stays covered — and the check reports it: the row that gives a beam the clear distance between its bars gives a slab the spacing it is detailed at, with the maximum beside the minimum. A slab spaced beyond it now fails the flexure checks instead of passing quietly.

The tighter EN provision for areas of concentrated load or maximum moment (2h, 250 mm) is deliberately not applied: a section is checked against a set of forces, with no position along the span from which mento could tell it is in one of those areas. That is stated in the theory page.

## Verification

- 1157 tests pass (7 new for the layout, 7 for the spacing limit)
- 100% line coverage on `mento/slab.py`, `mento/reports/tables.py` and both `codes/*/code.py`
- `ruff check`, `ruff format --check`, `mypy mento/` clean
- `sphinx-build -W` clean; user guide and the one-way slab theory page updated

## Not in scope

- The slab search itself is still the beam's (`n1` fixed at 2, second layer only as a mirror). It no longer leaks into the result, and the spacing cap covers the layout consequence.
- `BeamSummary` builds `RectangularBeam` internally, so slabs never reach it; left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)