### PR TITLE
feat(footing): Footing section — minimum reinforcement and mat detailing for a member on the ground

### DIFF
--- a/docs/source/getting_started/what_is_mento.rst
+++ b/docs/source/getting_started/what_is_mento.rst
@@ -12,6 +12,9 @@ Mento can handle the design and analysis of:
 
 - **Rectangular concrete beams** for flexure and shear.
 - **One-way slabs** for flexure and shear.
+- **Footing sections** for flexure and shear, with the minimum reinforcement and
+  detailing rules a member bearing on the ground is designed to. Sectional design
+  only — mento does no geotechnical calculation.
 
 Some key features of Mento include:
 

--- a/docs/source/theory/footing.rst
+++ b/docs/source/theory/footing.rst
@@ -188,6 +188,32 @@ A heavier demand is therefore answered with a larger bar rather than with bars c
 together. Both bounds are reported in the flexure check table, so a footing detailed
 outside the range fails the check rather than passing quietly.
 
+One spacing for the whole mat
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A footing is not built as two independently detailed faces. The bars go down as one
+mat: the bottom grid is placed, the top grid is placed over it on the same module, and
+the two are tied at the same spacing. A design that answers the bottom at 120 mm and
+the top at 250 mm is not a drawing anyone details, so once both faces are settled they
+are reconciled to one number:
+
+.. math::
+
+   s_{mat} = \min\bigl(s_{bot},\ s_{top}\bigr)
+
+The **smaller** of the two, because it is the only direction that is safe. Closing the
+wider face up adds bars to it, so each face still covers the area its own moment asked
+for, and the face that governed keeps exactly the spacing it needed. The lightly loaded
+face ends up with more steel than its own moment required — which is what detailing a
+mat costs, and what the drawing would have shown anyway.
+
+Only the spacing is reconciled; the diameters stay as the design chose them, so the two
+faces may differ there. Adding bars to a layer does not move its centroid, so the
+effective depths are unchanged and the capacity of the closed-up face can only rise —
+which is why the reconciliation runs **after** the design's final capacity
+verification. A face carrying no reinforcement is left with none: a footing reinforced
+on the bottom only has no second grid to match, and one is not invented for it.
+
 Minimum thickness
 ^^^^^^^^^^^^^^^^^
 
@@ -322,6 +348,18 @@ Validation
      - Detailing rules above
    * - Both bounds reported in the check table
      - ``test_the_spacing_row_of_a_footing_reports_both_bounds``
+     - Internal consistency
+   * - One spacing across both faces, the smaller of the two
+     - ``test_a_designed_footing_is_one_mat``,
+       ``test_the_mat_takes_the_smaller_of_the_two_spacings``,
+       ``test_the_diameters_are_left_as_designed``,
+       ``test_matching_is_idempotent``
+     - Detailing practice; the rule above
+   * - Matching never undoes the design
+     - ``test_matching_the_mat_never_undoes_the_design``,
+       ``test_the_mat_keeps_each_face_within_the_spacing_range``,
+       ``test_a_footing_reinforced_on_one_face_gets_no_second_grid``,
+       ``test_a_slab_still_details_its_faces_independently``
      - Internal consistency
    * - The bounds are a footing's, not every slab's
      - ``test_a_slab_keeps_the_wider_slab_limits``,

--- a/docs/source/theory/footing.rst
+++ b/docs/source/theory/footing.rst
@@ -1,0 +1,339 @@
+Footing
+=======
+
+``Footing`` subclasses ``OneWaySlab``, which subclasses ``RectangularBeam``.
+**The strength provisions are identical** — a footing strip is solved as a wide,
+shallow beam, and every equation on the :doc:`ACI <beam_aci_318_19>` and
+:doc:`EN <beam_en_1992_2004>` pages applies unchanged, as does everything on the
+:doc:`one_way_slab` page.
+
+This page covers only what differs: the minimum reinforcement, and the detailing
+limits that go with it.
+
+.. warning::
+
+   mento performs **no geotechnical calculation**. Bearing pressure, settlement,
+   sliding, overturning, uplift and the plan dimensions needed to spread the load are
+   outside its scope, and so is the choice of thickness. The plan size and the depth
+   are decided from the soil first; ``Footing`` then designs the section that
+   decision produced, for the sectional forces it is given. Punching shear is a
+   separate check — see ``PunchingSlab`` in the API reference.
+
+Why the minimum differs
+-----------------------
+
+The minimum flexural reinforcement of a beam exists to prevent one failure mode: a
+lightly reinforced section that cracks and, at that instant, finds its steel unable to
+carry the moment the uncracked concrete had been carrying. The failure is sudden,
+which is why the minimum is written as the steel needed to exceed the cracking moment.
+
+A member bearing on the ground cannot fail that way. The soil under it goes on
+carrying it after the section cracks, so there is no sudden loss of support to guard
+against. Both codes recognise this and exempt the member, then substitute a rule with
+a different purpose — restraining shrinkage and temperature movement under ACI,
+controlling crack widths under EN.
+
+mento expresses the distinction as a single attribute on the section,
+``Section.support``: ``"free"`` for anything spanning between supports, ``"soil"``
+for a member bearing on the ground. ``Footing`` sets it to ``"soil"``; the design code
+reads it and picks the clause. It is a class attribute, not a constructor argument —
+it says what kind of element this is.
+
+ACI 318-19 and CIRSOC 201-25
+----------------------------
+
+§9.6.1.1(b) exempts a member supported on the ground from the flexural minimum of
+§9.6.1.2, and §13.3.1.2 sends a footing to the shrinkage and temperature
+reinforcement of Table 24.4.3.2 instead. That minimum is written on the **gross**
+section, so the effective depth does not enter it:
+
+.. math::
+
+   A_{s,min} = \rho_{st}\, b\, h
+   \qquad
+   \rho_{st} = \max\!\left(0.0018\,\frac{f_{y,ref}}{f_y},\ 0.0014\right)
+
+with :math:`f_{y,ref} = 420` MPa in SI and 60 000 psi in US customary. The ratio is
+0.0018 at the reference grade, scales inversely for a stronger steel, and never falls
+below the 0.0014 floor of the table.
+
+For comparison, the beam minimum this replaces is
+
+.. math::
+
+   A_{s,min} = \rho_{min}\, b\, d
+   \qquad
+   \rho_{min} = \max\!\left(\frac{0.25\sqrt{f'_c}}{f_y},\ \frac{1.4}{f_y}\right)
+
+On a 1 m strip 600 mm deep in H25 with :math:`f_y = 420` MPa, the footing rule gives
+10.8 cm² against the beam rule's 18.1 cm².
+
+EN 1992-1-1:2004
+----------------
+
+Two rules apply and **the larger governs**.
+
+Geometric minimum
+^^^^^^^^^^^^^^^^^
+
+The non-fragility minimum of §9.2.1.1 is halved per direction for a foundation and
+written on the gross section:
+
+.. math::
+
+   A_{s,min} = \rho_{geo}\, b\, h
+   \qquad
+   \rho_{geo} =
+   \begin{cases}
+     0.0010 & f_{yk} \le 400\ \text{MPa} \\
+     0.0009 & f_{yk} \ge 500\ \text{MPa}
+   \end{cases}
+
+Crack control — §7.3.2(2), Eq. (7.1)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Enough steel to carry, without breaking, the tension the concrete releases at the
+instant it cracks:
+
+.. math::
+
+   A_{s,min}\,\sigma_s = k_c\, k\, f_{ct,eff}\, A_{ct}
+   \qquad\Longrightarrow\qquad
+   A_{s,min} = \frac{k_c\, k\, f_{ct,eff}\, A_{ct}}{\sigma_s}
+
+with
+
+.. list-table::
+   :header-rows: 1
+   :widths: 14 46 40
+
+   * - Term
+     - Value mento uses
+     - Source
+   * - :math:`k_c`
+     - 0.40 — rectangular section in pure bending
+     - §7.3.2(2)
+   * - :math:`k`
+     - :math:`1.00` at :math:`h \le 300` mm, :math:`0.65` at :math:`h \ge 800` mm,
+       linear between, saturated outside
+     - §7.3.2(2)
+   * - :math:`f_{ct,eff}`
+     - :math:`f_{ctm} = 0.3\,f_{ck}^{2/3}` for :math:`\le` C50/60
+     - §7.3.2(2), Table 3.1
+   * - :math:`A_{ct}`
+     - :math:`b\,h/2` — see below
+     - §7.3.2(2)
+   * - :math:`\sigma_s`
+     - :math:`f_{yd} = f_{yk}/\gamma_s`
+     - §7.3.2(2), §2.4.2.4
+
+Worked reference case — a 1 m strip, :math:`h = 600` mm, C25
+(:math:`f_{ctm} = 2.565` MPa), B500S:
+
+.. math::
+
+   k = 1.00 - \frac{600 - 300}{800 - 300}\,(1.00 - 0.65) = 0.79
+
+.. math::
+
+   A_{s,min} = \frac{0.40 \times 0.79 \times 2.565 \times (1000 \times 600 / 2)}
+                    {500/1.15} = 559\ \text{mm}^2 = 5.59\ \text{cm}^2
+
+against a geometric minimum of :math:`0.0009 \times 1000 \times 600 = 540` mm², so
+crack control governs. The beam rule this replaces,
+:math:`\max(0.26 f_{ctm}/f_{yk},\ 0.0013)\, b\, d`, would give 7.26 cm².
+
+Which rule governs depends only on :math:`k`, since both are proportional to
+:math:`h`: crack control governs the shallower sections, and the geometric minimum
+takes over once :math:`k` has decayed — around :math:`h = 640` mm for C25 with B500S.
+
+Detailing
+---------
+
+Bar spacing
+^^^^^^^^^^^
+
+Kept between **100 and 300 mm**, both bounds supplied by the design code through the
+registry:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Bound
+     - Value
+     - Reason
+   * - Maximum
+     - 300 mm, in place of the slab's
+       :math:`\min(3h,\ 450\,/\,400\ \text{mm})`
+     - A footing is thick, so :math:`3h` stops binding long before the bars are close
+       enough to spread the bearing pressure into them. ACI §7.7.2.3 and
+       EN §9.3.1.1(3) still apply; the 300 mm cap is simply always the smaller.
+   * - Minimum
+     - 100 mm
+     - EN detailing practice for foundations, applied under both codes: nothing about
+       it is particular to EN. Below it, placing and vibrating over the soil stops
+       being worth the closer bars.
+
+The maximum is applied when a design is written back as a spacing, which only ever
+adds bars, so the area stays covered. The minimum cannot be applied that way — the
+rebar search chooses a **bar count**, and the spacing is what that count implies — so
+it is enforced as a cap on ``max_bars_per_layer``:
+
+.. math::
+
+   n_{max} = \left\lfloor \frac{b}{s_{min}} \right\rfloor
+
+A heavier demand is therefore answered with a larger bar rather than with bars closer
+together. Both bounds are reported in the flexure check table, so a footing detailed
+outside the range fails the check rather than passing quietly.
+
+Minimum thickness
+^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Code
+     - Minimum
+     - Source
+   * - ACI 318-19, CIRSOC 201-25
+     - 200 mm (8 in.)
+     - §13.3.1.2, written as :math:`d \ge 150` mm above the bottom reinforcement
+   * - EN 1992-1-1
+     - 250 mm
+     - Practice, not a clause — the depth below which bar anchorage and the tolerance
+       on a surface cast against the ground stop working out
+
+A thinner section **warns and is still designed**. The thickness is the engineer's to
+choose, and the design that follows is the right design for the section given;
+refusing would decline to answer a question that has an answer.
+
+Implementation decisions
+------------------------
+
+.. _footing-decisions:
+
+Where the codes leave room for judgement, mento takes these readings:
+
+**The tension zone is half the section.** :math:`A_{ct}` in Eq. (7.1) is *"the area of
+concrete within the tensile zone... just before formation of the first crack"*. Just
+before cracking the section is still uncracked, so for a rectangle in pure bending the
+neutral axis sits at mid-depth and :math:`A_{ct} = b\,h/2`. Taking the full
+:math:`b\,h` would double the minimum and make the geometric rule irrelevant at every
+depth.
+
+**The 4/3 relief is not applied to a footing.** ACI §9.6.1.3 lets a section satisfy
+:math:`4/3` of the required steel instead of the minimum. It belongs to the clause it
+relieves, §9.6.1.2, which §9.6.1.1(b) has already exempted the member from — there is
+no sudden cracking failure here for extra steel to buy off, so the shrinkage and
+temperature minimum stands as written.
+
+**The 1.8‰ geometric minimum still applies to a free member.** The custom
+:math:`1.8\text{‰}\,b\,h` rule mento adds under ACI (see :ref:`aci-decisions`) is
+unchanged for beams and suspended slabs. On a footing it is superseded — and at
+:math:`f_y = 420` MPa the two coincide, since Table 24.4.3.2 gives exactly 0.0018.
+
+**Steel grades between the EN anchors are interpolated.** The halved geometric
+minimum is tabulated at :math:`f_{yk} = 400` and 500 MPa only. mento interpolates
+linearly between them and holds the value flat outside, rather than extrapolating a
+rule the source does not state.
+
+**ACI's f_y < 420 MPa branch is not special-cased.** Table 24.4.3.2 gives a flat
+0.0020 for deformed bars below the reference grade, where the scaling used here gives
+:math:`0.0018 \times 420/f_y`, which is larger — 0.0025 at 300 MPa. mento uses the
+scaling in both directions, so the answer is conservative for the lower grades rather
+than exact.
+
+**The minimum is split by face, as it is for a beam.** A check reports the minimum on
+the face in tension for the combination and zero on the other, following the same
+convention every element uses. A footing with reinforcement on both faces meets it on
+each face through the combination that puts that face in tension.
+
+**An unreinforced face reports DCR ≫ 1.** A footing whose demand cannot be met within
+the 100 mm spacing floor comes back with no layout, as any section does when the bar
+catalogue cannot satisfy it. The DCR is then formed against a floor of 0.01 kNm rather
+than against zero, so it reports a ratio far above 1 instead of failing to divide.
+
+Not implemented
+---------------
+
+Everything the :doc:`one_way_slab` page lists as out of scope, plus:
+
+- **Any geotechnical quantity** — see the warning at the top of this page.
+- **Punching shear** — a separate element, ``PunchingSlab``.
+- **The transverse direction.** A footing spans both ways; mento designs one strip at
+  a time, and the second direction is a second ``Footing``. Distribution steel and the
+  reduction some codes allow in the short direction of a rectangular footing are the
+  engineer's.
+- **Anchorage of the bars beyond the critical section**, which for a footing is often
+  what sets the plan dimension.
+
+Validation
+----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 40 26
+
+   * - Check
+     - Test (``tests/test_footing.py``)
+     - Verified against
+   * - :math:`\rho_{st}`, both unit systems and the 0.0014 floor
+     - ``test_aci_shrinkage_and_temperature_ratio``,
+       ``test_aci_shrinkage_and_temperature_ratio_imperial``
+     - ACI 318-19 Table 24.4.3.2
+   * - :math:`A_{s,min}` on the gross section, ACI
+     - ``test_aci_footing_minimum_is_the_gross_section_rule``,
+       ``test_aci_footing_minimum_scales_with_the_steel_grade``,
+       ``test_aci_footing_minimum_in_imperial_units``
+     - ACI 318-19 §9.6.1.1(b), §13.3.1.2, Table 24.4.3.2
+   * - The exemption lowers the minimum
+     - ``test_aci_footing_minimum_is_lower_than_the_slab_minimum``,
+       ``test_en_footing_minimum_is_lower_than_the_slab_minimum``
+     - ACI 318-19 §9.6.1.1(b); EN 1992-1-1 §9.2.1.1
+   * - CIRSOC shares the ACI clause
+     - ``test_cirsoc_shares_the_aci_clause``
+     - CIRSOC 201-25
+   * - :math:`k` interpolated with the depth
+     - ``test_en_crack_control_coefficient_k``
+     - EN 1992-1-1 §7.3.2(2)
+   * - :math:`\rho_{geo}` at and between the anchors
+     - ``test_en_foundation_min_reinforcement_ratio``
+     - EN 1992-1-1 §9.2.1.1, §9.8.1
+   * - Eq. (7.1) as written
+     - ``test_en_crack_control_min_reinforcement_is_equation_7_1``
+     - EN 1992-1-1 §7.3.2(2)
+   * - The larger of the two rules governs
+     - ``test_en_footing_minimum_is_the_crack_control_rule``,
+       ``test_en_footing_minimum_is_the_larger_of_the_two_rules``
+     - Worked reference case above
+   * - A design covers the minimum without correction
+     - ``test_design_already_covers_the_minimum``,
+       ``test_aci_footing_with_no_moment_still_gets_the_minimum``,
+       ``test_a_footing_still_carries_its_moment``
+     - Internal consistency
+   * - Spacing bounds, and a design inside them
+     - ``test_footing_bars_are_capped_at_300_mm``,
+       ``test_footing_bars_are_floored_at_100_mm``,
+       ``test_a_designed_footing_stays_inside_the_spacing_range``,
+       ``test_the_floor_is_what_holds_the_footing_apart``
+     - Detailing rules above
+   * - Both bounds reported in the check table
+     - ``test_the_spacing_row_of_a_footing_reports_both_bounds``
+     - Internal consistency
+   * - The bounds are a footing's, not every slab's
+     - ``test_a_slab_keeps_the_wider_slab_limits``,
+       ``test_support_says_which_clause_applies``
+     - ACI 318-19 §7.7.2.3; EN 1992-1-1 §9.3.1.1(3)
+   * - Thickness warns and still designs
+     - ``test_a_thin_footing_warns``,
+       ``test_a_footing_of_the_usual_depth_does_not_warn``,
+       ``test_a_thin_slab_does_not_warn``,
+       ``test_a_thin_footing_is_still_designed``,
+       ``test_the_warning_names_the_footing_and_the_code``
+     - ACI 318-19 §13.3.1.2; EN practice
+   * - An unreinforced face reports a failing DCR
+     - ``test_an_unreinforced_face_reports_a_failing_dcr``
+     - Internal consistency, both codes

--- a/docs/source/theory/footing.rst
+++ b/docs/source/theory/footing.rst
@@ -188,38 +188,64 @@ A heavier demand is therefore answered with a larger bar rather than with bars c
 together. Both bounds are reported in the flexure check table, so a footing detailed
 outside the range fails the check rather than passing quietly.
 
-One spacing for the whole mat
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+One mat, chosen rather than reconciled
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A footing is not built as two independently detailed faces. The bars go down as one
-mat: the bottom grid is placed, the top grid is placed over it on the same module, and
-the two are tied at the same spacing. A design that answers the bottom at 120 mm and
-the top at 250 mm is not a drawing anyone details, so once both faces are settled they
-are reconciled to one number:
+grid: the bottom is placed, the top is placed over it, and the two are tied. The module
+has to be one number, and on a drawing the top sits either at the bottom's spacing or at
+exactly twice it, so that one top bar lands on every second bottom bar.
+
+Reconciling the two spacings the per-face design arrived at — taking the smaller of them
+— is safe but expensive. The face governed by the minimum is detailed as many thin bars,
+which comes out closer than the few thick bars the loaded face needs, so the smaller of
+the two is often the *lightly loaded* face's spacing, and adopting it closes the loaded
+face up and buys steel nobody asked for. Measured over twenty typical footings, that
+costs about 20% more longitudinal steel than the two faces actually require.
+
+So the mat is chosen, not reconciled. Over the modules the code allows and the bars the
+catalogue holds, mento takes the lightest combination that covers both faces:
 
 .. math::
 
-   s_{mat} = \min\bigl(s_{bot},\ s_{top}\bigr)
+   \min_{s,\ d_{bot},\ d_{top}} \;
+   n(s)\,A_b(d_{bot}) + n(s_{top})\,A_b(d_{top})
 
-The **smaller** of the two, because it is the only direction that is safe: closing the
-wider face up adds bars to it, so every face still covers the area its own moment asked
-for.
+subject to
 
-Which face sets the module is not always the one carrying the moment. A face governed
-by the minimum is detailed as many thin bars, and that lands at a closer spacing than
-the few thick bars the governing face needs — under ACI, whose minimum is the larger of
-the two codes', the top face sets the module about half the time and closes the bottom
-up with it. Measured over a range of typical footings, the mat costs about **12% more
-longitudinal steel** than detailing the two faces independently would, and in the worst
-case seen, close to 50%. That is the price of a single grid, and it is the grid the
-drawing would have shown anyway.
+.. math::
 
-Only the spacing is reconciled; the diameters stay as the design chose them, so the two
-faces may differ there. Adding bars to a layer does not move its centroid, so the
-effective depths are unchanged and the capacity of the closed-up face can only rise —
-which is why the reconciliation runs **after** the design's final capacity
-verification. A face carrying no reinforcement is left with none: a footing reinforced
-on the bottom only has no second grid to match, and one is not invented for it.
+   s_{top} \in \{s,\ 2s\}, \qquad
+   s_{min} \le s \le s_{top} \le s_{max}, \qquad
+   n(s) = \left\lceil \frac{b}{s} \right\rceil
+
+with each face covering its own required area and each bar leaving the clear distance
+the settings ask for. The module is searched in whole centimetres (inches in imperial),
+so it is a number a detailer writes. Allowing a triple module as well was tried and
+changes nothing: ``s`` and ``2s`` already carry it.
+
+That lands within about **7% (EN) to 11% (ACI)** of what the two faces require, against
+the 20% of taking the smaller spacing — and within 1% (EN) to 4% (ACI) of what mento's
+own per-face design produces, which is not even buildable as a single mat.
+
+Every candidate is verified before it is kept, because the choice feeds back into
+itself: a thicker bar sits deeper, lowering the effective depth the required area was
+computed against. Candidates are tried lightest first and applied to the section, and
+the first that resists both design moments is the answer. If none within the budget
+verifies — a section too small for its demand — the design falls back to reconciling the
+two spacings it had already proved, which needs no verification because it only ever
+adds bars.
+
+A face carrying no reinforcement is left with none: a footing reinforced on the bottom
+only has no second grid to place, and one is not invented for it.
+
+Practical bar size
+^^^^^^^^^^^^^^^^^^
+
+The search does not reach below **Ø10** for a footing mat, whatever the catalogue holds
+under it. Practice rather than code: a mesh finer than that is not what goes down over
+the ground, and without the floor the optimisation reaches for the thinnest bar
+available to shave the lightly loaded face.
 
 Minimum thickness
 ^^^^^^^^^^^^^^^^^
@@ -356,17 +382,33 @@ Validation
    * - Both bounds reported in the check table
      - ``test_the_spacing_row_of_a_footing_reports_both_bounds``
      - Internal consistency
-   * - One spacing across both faces, the smaller of the two
+   * - One module across both faces, the top at ``s`` or ``2s``
      - ``test_a_designed_footing_is_one_mat``,
-       ``test_the_mat_takes_the_smaller_of_the_two_spacings``,
-       ``test_the_diameters_are_left_as_designed``,
-       ``test_matching_is_idempotent``
+       ``test_the_top_may_be_set_out_at_twice_the_bottom``,
+       ``test_each_face_keeps_its_own_diameter``
      - Detailing practice; the rule above
-   * - Matching never undoes the design
+   * - The chosen mat is lighter than reconciling the two spacings
+     - ``test_the_mat_is_lighter_than_reconciling_the_two_spacings``
+     - The measured comparison above
+   * - Ø10 floor on the mat
+     - ``test_no_mat_is_detailed_below_the_practical_bar``
+     - Detailing practice
+   * - The mat never undoes the design
      - ``test_matching_the_mat_never_undoes_the_design``,
        ``test_the_mat_keeps_each_face_within_the_spacing_range``,
        ``test_a_footing_reinforced_on_one_face_gets_no_second_grid``,
        ``test_a_slab_still_details_its_faces_independently``
+     - Internal consistency
+   * - A candidate that does not verify is passed over
+     - ``test_a_mat_that_does_not_verify_is_passed_over``,
+       ``test_a_section_that_cannot_carry_the_moment_falls_back``,
+       ``test_the_fallback_takes_the_smaller_of_the_two_spacings``,
+       ``test_the_fallback_leaves_a_single_grid_alone``,
+       ``test_reconciling_an_existing_mat_is_a_no_op``
+     - Internal consistency
+   * - The edges of the search
+     - ``test_a_section_needing_nothing_is_offered_no_mat``,
+       ``test_a_face_no_bar_can_cover_drops_that_module``
      - Internal consistency
    * - The bounds are a footing's, not every slab's
      - ``test_a_slab_keeps_the_wider_slab_limits``,

--- a/docs/source/theory/footing.rst
+++ b/docs/source/theory/footing.rst
@@ -201,11 +201,18 @@ are reconciled to one number:
 
    s_{mat} = \min\bigl(s_{bot},\ s_{top}\bigr)
 
-The **smaller** of the two, because it is the only direction that is safe. Closing the
-wider face up adds bars to it, so each face still covers the area its own moment asked
-for, and the face that governed keeps exactly the spacing it needed. The lightly loaded
-face ends up with more steel than its own moment required — which is what detailing a
-mat costs, and what the drawing would have shown anyway.
+The **smaller** of the two, because it is the only direction that is safe: closing the
+wider face up adds bars to it, so every face still covers the area its own moment asked
+for.
+
+Which face sets the module is not always the one carrying the moment. A face governed
+by the minimum is detailed as many thin bars, and that lands at a closer spacing than
+the few thick bars the governing face needs — under ACI, whose minimum is the larger of
+the two codes', the top face sets the module about half the time and closes the bottom
+up with it. Measured over a range of typical footings, the mat costs about **12% more
+longitudinal steel** than detailing the two faces independently would, and in the worst
+case seen, close to 50%. That is the price of a single grid, and it is the grid the
+drawing would have shown anyway.
 
 Only the spacing is reconciled; the diameters stay as the design chose them, so the two
 faces may differ there. Adding bars to a layer does not move its centroid, so the

--- a/docs/source/theory/index.rst
+++ b/docs/source/theory/index.rst
@@ -21,6 +21,7 @@ source that test is verified against.
    beam_aci_318_19
    beam_en_1992_2004
    one_way_slab
+   footing
    shear_wall_aci_318_19
 
 What is implemented
@@ -43,6 +44,12 @@ What is implemented
      - Flexure + shear
      - Same provisions as the beam, different detailing —
        :doc:`one_way_slab`
+   * - Footing
+     - Flexure + shear
+     - Flexure + shear
+     - Slab provisions with the minimum reinforcement and detailing of a
+       member on the ground — :doc:`footing`. Sectional only; no
+       geotechnical calculation
    * - Shear wall
      - In-plane shear
      - Not implemented
@@ -59,7 +66,8 @@ the :doc:`ACI page <beam_aci_318_19>` rather than duplicated.
 
 What is **not** implemented, for any code: torsion, crack width and deflection
 serviceability checks, fatigue, fire design, anchorage and development length,
-seismic detailing provisions, and prestressing.
+seismic detailing provisions, and prestressing. Nor is anything geotechnical —
+mento designs sections, and the soil a footing bears on is outside its scope.
 
 Conventions
 -----------

--- a/docs/source/theory/one_way_slab.rst
+++ b/docs/source/theory/one_way_slab.rst
@@ -56,6 +56,47 @@ from there the section behaves exactly as a beam:
 
 Positions 1 and 3 correspond to the first and second layer respectively.
 
+A design is written back as a spacing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The bar selection is the beam's, and it answers with groups of bars per layer. A
+design applied to a slab is translated back into the parameterisation above: the bars
+of a layer are spread over the design width, and the spacing is rounded to the whole
+centimetre (inch, in imperial) so that it is one that can be detailed. The rounding is
+checked against the count it produces, so it never leaves the strip with fewer bars —
+and so less steel — than the search selected.
+
+Maximum bar spacing
+^^^^^^^^^^^^^^^^^^^
+
+Area alone is not a layout: bars far enough apart leave the slab between them
+unreinforced whatever they add up to. Both codes cap the centre-to-centre spacing of
+the flexural reinforcement, and the design applies the cap, which only ever adds bars:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Code
+     - Limit
+     - Clause
+   * - ACI 318-19
+     - :math:`\min(3h,\ 450\ \text{mm})` — 18 in. in imperial
+     - §7.7.2.3
+   * - EN 1992-1-1
+     - :math:`\min(3h,\ 400\ \text{mm})`
+     - §9.3.1.1(3), principal reinforcement
+
+The check reports it as well: the row that gives a beam the clear distance between its
+bars gives a slab the spacing it is detailed at, with this maximum beside the minimum.
+
+.. note::
+
+   EN §9.3.1.1(3) tightens the limit to :math:`\min(2h,\ 250\ \text{mm})` in areas
+   with concentrated loads or of maximum moment. That provision is **not** applied: a
+   section is checked against a set of forces, with no position along the span from
+   which mento could tell that it is in one of those areas.
+
 Detailing settings
 ^^^^^^^^^^^^^^^^^^
 
@@ -141,6 +182,14 @@ Validation
    * - Spacing to bar count
      - ``test_longitudinal_rebar_spacing_updates_counts``
      - Internal consistency
+   * - Design written back as a spacing
+     - ``test_a_designed_slab_is_detailed_by_a_spacing_not_by_a_bar_count``,
+       ``test_a_spacing_is_never_rounded_into_fewer_bars_than_the_design_chose``
+     - Internal consistency
+   * - Maximum bar spacing
+     - ``test_the_code_caps_how_far_apart_the_bars_of_a_slab_may_sit``,
+       ``test_a_design_is_never_spaced_beyond_the_code_maximum``
+     - ACI 318-19 §7.7.2.3, EN 1992-1-1 §9.3.1.1(3)
    * - Slab mode defaults
      - ``test_slab_initialization_sets_slab_mode_and_defaults``
      - Detailing settings above

--- a/docs/source/user_guide/design_results.rst
+++ b/docs/source/user_guide/design_results.rst
@@ -53,6 +53,21 @@ Each face carries its layers, in order, and only the layers that hold bars:
 A face with no reinforcement has an empty ``layers`` tuple, which is what
 ``str(flexure.top)`` reports as ``'no reinforcement'``.
 
+A slab is detailed by a spacing rather than by a bar count, so each of its layers also
+carries the spacing it was designed with, and reads as one bar repeated across the strip.
+The bars are still there to be counted when what you need is the steel actually placed:
+
+.. code-block:: python
+
+    layer = slab.flexure_design.bottom.layers[0]
+
+    layer.d_b                            # 12 mm
+    layer.s.to("cm")                     # 17 cm, None on a beam
+    layer.n                              # 6, the bars that spacing puts on the strip
+    str(layer)                           # 'Ø12 mm/17 cm'
+
+    slab.flexure_design.bottom.n_bars    # 6, every layer of the face
+
 Shear
 -----
 

--- a/docs/source/user_guide/footings.rst
+++ b/docs/source/user_guide/footings.rst
@@ -1,0 +1,134 @@
+Footing
+=======
+
+The `Footing` class models the **section** of a spread footing or raft — a one-way
+slab bearing directly on the ground.
+
+It is a `OneWaySlab` in every respect but the rules the design codes write differently
+for a member on the ground: the minimum longitudinal reinforcement, the spacing the bars
+are detailed at, and the thickness the section is expected to have. Everything else —
+geometry, materials, reinforcement given as diameter and spacing, flexure and shear
+checks through a `Node` — is the slab's, unchanged.
+
+.. warning::
+
+    **Sectional design only. Mento does no geotechnical calculation.**
+
+    `Footing` answers one question: what reinforcement does this section need for
+    the forces it is given. It knows nothing about the soil under it and does not
+    check bearing pressure, settlement, sliding, overturning, uplift, or the plan
+    dimensions the footing needs to spread its load. It does not size the footing.
+
+    Those are the engineer's, and they come first: the plan size and the thickness
+    are decided from the soil, and only then is the resulting section handed to
+    `Footing`. Punching shear is a separate check — see
+    :class:`~mento.punching.PunchingSlab`.
+
+Key Concepts
+------------
+
+- **Geometry**: a strip of the footing, given as a `width` and a `height` (the total
+  thickness). Results are the totals across that width, so a 1 m strip reads directly
+  as per-metre values.
+- **Forces**: the sectional forces at the face being designed — the moment and shear
+  the soil pressure produces in the strip. Mento does not derive them from the soil;
+  they are an input.
+- **Reinforcement**: bar diameter and spacing, one direction at a time. A footing spans
+  both ways, so it is designed as two strips, one per direction.
+- **Design code**: taken from the `Concrete` object, as everywhere else in mento.
+  ACI 318-19, CIRSOC 201-25 and EN 1992-2004 are all supported.
+
+Usage
+-----
+
+1. Creating a Footing
+*********************
+
+.. code-block:: python
+
+    from mento import Concrete_ACI_318_19, Footing, SteelBar, MPa, cm, mm, m
+
+    concrete = Concrete_ACI_318_19(name="H25", f_c=25 * MPa)
+    steel = SteelBar(name="ADN 420", f_y=420 * MPa)
+
+    # A 1 m strip of a footing 60 cm thick
+    footing = Footing(label="Z1", concrete=concrete, steel_bar=steel,
+                      width=1 * m, height=60 * cm, c_c=50 * mm)
+
+2. Checking and Designing
+*************************
+
+Exactly as for a slab: forces are attached through a `Node`, which drives the check
+and the design.
+
+.. code-block:: python
+
+    from mento import Forces, Node, kN, kNm
+
+    node = Node(section=footing, forces=[Forces(label="ELU 1", M_y=120 * kNm, V_z=90 * kN)])
+
+    node.design()          # flexure + shear
+    node.check_flexure()   # per-combination table
+    node.check_shear()
+
+Reinforcement can also be assigned by hand with `set_slab_longitudinal_rebar_bot()` and
+`set_slab_longitudinal_rebar_top()`, and read back afterwards, the same way as for a
+`OneWaySlab`. See :doc:`slabs` for the full reinforcement and results API.
+
+What the codes do differently
+-----------------------------
+
+Minimum reinforcement
+*********************
+
+A member spanning between supports is given a minimum sized so that it cannot fail the
+instant it cracks. A member on the ground cannot fail that way — the soil goes on
+carrying it — so both codes exempt it and put a different rule in its place:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 78
+
+   * - Code
+     - A\ :sub:`s,min`
+   * - ACI 318-19,
+       CIRSOC 201-25
+     - §9.6.1.1(b) grants the exemption and §13.3.1.2 replaces the flexural minimum
+       with the shrinkage and temperature reinforcement of Table 24.4.3.2:
+       :math:`0.0018\,b\,h` at :math:`f_y = 420` MPa, scaling as
+       :math:`0.0018 \cdot 420 / f_y` and never below :math:`0.0014`. Written on the
+       **gross** section, so the effective depth does not enter it.
+   * - EN 1992-2004
+     - The larger of the halved geometric minimum of a foundation
+       (:math:`0.0010\,b\,h` at :math:`f_{yk} = 400` MPa, :math:`0.0009\,b\,h` at
+       500 MPa) and the crack-control minimum of §7.3.2(2), Eq. (7.1),
+       :math:`k_c\,k\,f_{ct,eff}\,A_{ct} / \sigma_s`. The second usually governs a
+       thick footing.
+
+The design returns the largest applicable minimum **already applied**, so the
+reinforcement it reports needs no correction afterwards.
+
+Bar spacing
+***********
+
+Kept between **100 and 300 mm**. The 300 mm cap replaces the 3h of a suspended slab,
+which stops binding on a section this thick; the 100 mm floor is the spacing below which
+a footing is not detailed in practice. A design answers a heavier demand with a larger
+bar rather than with bars closer than 100 mm, and the flexure check table reports the
+spacing against both bounds.
+
+Thickness
+*********
+
+A section thinner than the code asks of a footing on soil — 200 mm in ACI 318-19
+§13.3.1.2, 250 mm in EN practice — warns when it is built:
+
+.. code-block:: python
+
+    Footing(label="Z2", concrete=concrete, steel_bar=steel,
+            width=1 * m, height=18 * cm, c_c=50 * mm)
+    # UserWarning: Footing Z2 is 18 cm thick, below the 200 mm ACI 318-19 asks
+    # of a footing on soil. It is designed as given.
+
+It is advice, not a limit. The section is still designed as given, because the thickness
+is the engineer's to choose.

--- a/docs/source/user_guide/footings.rst
+++ b/docs/source/user_guide/footings.rst
@@ -87,6 +87,10 @@ Three rules, and the design applies all of them for you:
 - **Bar spacing.** Kept between 100 and 300 mm. A design answers a heavier demand with
   a larger bar rather than with bars closer than 100 mm, and both bounds appear in the
   flexure check table.
+- **One mat.** A footing is placed as a single grid, not as two independently detailed
+  faces, so a design ends with **bottom and top set out at the same spacing** — the
+  smaller of the two it arrived at. The diameters are left as designed, so the faces can
+  still differ there. A footing reinforced on one face only keeps its single grid.
 - **Thickness.** A section thinner than the code asks of a footing on soil warns when
   it is built:
 

--- a/docs/source/user_guide/footings.rst
+++ b/docs/source/user_guide/footings.rst
@@ -75,60 +75,30 @@ Reinforcement can also be assigned by hand with `set_slab_longitudinal_rebar_bot
 `set_slab_longitudinal_rebar_top()`, and read back afterwards, the same way as for a
 `OneWaySlab`. See :doc:`slabs` for the full reinforcement and results API.
 
-What the codes do differently
------------------------------
+What differs from a slab
+------------------------
 
-Minimum reinforcement
-*********************
+Three rules, and the design applies all of them for you:
 
-A member spanning between supports is given a minimum sized so that it cannot fail the
-instant it cracks. A member on the ground cannot fail that way — the soil goes on
-carrying it — so both codes exempt it and put a different rule in its place:
+- **Minimum reinforcement.** A member on the ground is exempt from the flexural
+  minimum written for a member spanning between supports, and each code puts a
+  different rule in its place. `Footing` returns the largest applicable minimum
+  **already applied**, so the reinforcement it reports needs no correction afterwards.
+- **Bar spacing.** Kept between 100 and 300 mm. A design answers a heavier demand with
+  a larger bar rather than with bars closer than 100 mm, and both bounds appear in the
+  flexure check table.
+- **Thickness.** A section thinner than the code asks of a footing on soil warns when
+  it is built:
 
-.. list-table::
-   :header-rows: 1
-   :widths: 22 78
+  .. code-block:: python
 
-   * - Code
-     - A\ :sub:`s,min`
-   * - ACI 318-19,
-       CIRSOC 201-25
-     - §9.6.1.1(b) grants the exemption and §13.3.1.2 replaces the flexural minimum
-       with the shrinkage and temperature reinforcement of Table 24.4.3.2:
-       :math:`0.0018\,b\,h` at :math:`f_y = 420` MPa, scaling as
-       :math:`0.0018 \cdot 420 / f_y` and never below :math:`0.0014`. Written on the
-       **gross** section, so the effective depth does not enter it.
-   * - EN 1992-2004
-     - The larger of the halved geometric minimum of a foundation
-       (:math:`0.0010\,b\,h` at :math:`f_{yk} = 400` MPa, :math:`0.0009\,b\,h` at
-       500 MPa) and the crack-control minimum of §7.3.2(2), Eq. (7.1),
-       :math:`k_c\,k\,f_{ct,eff}\,A_{ct} / \sigma_s`. The second usually governs a
-       thick footing.
+      Footing(label="Z2", concrete=concrete, steel_bar=steel,
+              width=1 * m, height=18 * cm, c_c=50 * mm)
+      # UserWarning: Footing Z2 is 18 cm thick, below the 200 mm ACI 318-19 asks
+      # of a footing on soil. It is designed as given.
 
-The design returns the largest applicable minimum **already applied**, so the
-reinforcement it reports needs no correction afterwards.
+  It is advice, not a limit. The section is still designed as given, because the
+  thickness is the engineer's to choose.
 
-Bar spacing
-***********
-
-Kept between **100 and 300 mm**. The 300 mm cap replaces the 3h of a suspended slab,
-which stops binding on a section this thick; the 100 mm floor is the spacing below which
-a footing is not detailed in practice. A design answers a heavier demand with a larger
-bar rather than with bars closer than 100 mm, and the flexure check table reports the
-spacing against both bounds.
-
-Thickness
-*********
-
-A section thinner than the code asks of a footing on soil — 200 mm in ACI 318-19
-§13.3.1.2, 250 mm in EN practice — warns when it is built:
-
-.. code-block:: python
-
-    Footing(label="Z2", concrete=concrete, steel_bar=steel,
-            width=1 * m, height=18 * cm, c_c=50 * mm)
-    # UserWarning: Footing Z2 is 18 cm thick, below the 200 mm ACI 318-19 asks
-    # of a footing on soil. It is designed as given.
-
-It is advice, not a limit. The section is still designed as given, because the thickness
-is the engineer's to choose.
+For the clauses these come from, the equations, and the readings mento takes where the
+codes leave room for judgement, see :doc:`../theory/footing`.

--- a/docs/source/user_guide/footings.rst
+++ b/docs/source/user_guide/footings.rst
@@ -88,9 +88,13 @@ Three rules, and the design applies all of them for you:
   a larger bar rather than with bars closer than 100 mm, and both bounds appear in the
   flexure check table.
 - **One mat.** A footing is placed as a single grid, not as two independently detailed
-  faces, so a design ends with **bottom and top set out at the same spacing** — the
-  smaller of the two it arrived at. The diameters are left as designed, so the faces can
-  still differ there. A footing reinforced on one face only keeps its single grid.
+  faces, so a design ends on **one module**: the top either at the bottom's spacing or at
+  exactly twice it, so one top bar lands on every second bottom bar. Within that, mento
+  picks the module and both diameters that give the least steel covering what each face
+  needs — e.g. ``Ø20 c/15`` abajo con ``Ø20 c/30`` arriba. A footing reinforced on one
+  face only keeps its single grid.
+- **Ø10 minimum.** A footing mesh is not detailed with the thinnest bar in the
+  catalogue, so the search does not reach below Ø10 to shave the lightly loaded face.
 - **Thickness.** A section thinner than the code asks of a footing on soil warns when
   it is built:
 

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -15,6 +15,7 @@ User Guide
    sections
    beams
    slabs
+   footings
    shear_wall
    node
    design_results

--- a/docs/source/user_guide/slabs.rst
+++ b/docs/source/user_guide/slabs.rst
@@ -179,8 +179,26 @@ carrying it — so both codes exempt it and put a different rule in its place:
 The design returns the largest applicable minimum already applied, so the reinforcement
 it reports needs no correction afterwards.
 
+A footing is also detailed differently, and the same `support` tells the codes so:
+
+- **Bar spacing** is kept between 100 and 300 mm. The upper bound replaces the 3h of
+  a suspended slab, which stops binding on a section this thick; the lower one is the
+  spacing below which a footing is not detailed in practice. A design answers a heavy
+  demand with a larger bar rather than with bars closer than 100 mm, and the flexure
+  check table reports the spacing against both bounds.
+- **Thickness** below what the code asks of a footing on soil — 200 mm in ACI 318-19
+  13.3.1.2, 250 mm in EN practice — raises a warning when the section is built. It is
+  advice, not a limit: the section is still designed as given, because the thickness is
+  the engineer's to choose.
+
+.. code-block:: python
+
+    Footing(label="Z2", concrete=concrete, steel_bar=steel_bar,
+            width=1 * m, height=18 * cm, c_c=50 * mm)
+    # UserWarning: Footing Z2 is 18 cm thick, below the 200 mm ACI 318-19 asks
+    # of a footing on soil. It is designed as given.
+
 .. note::
 
    `Footing` designs the section, not the foundation. Bearing pressure, punching
-   (see `PunchingSlab`), sliding and overturning are outside its scope, as are the
-   minimum thickness and the bar spacing range each code sets for footings.
+   (see `PunchingSlab`), sliding and overturning are outside its scope.

--- a/docs/source/user_guide/slabs.rst
+++ b/docs/source/user_guide/slabs.rst
@@ -108,6 +108,24 @@ If no reinforcement is assigned, *Mento* can design flexure and shear automatica
     node.design_flexure()
     node.design_shear()
 
+The design is written back in the slab's own terms: a diameter and a spacing per layer,
+per face. Read it through ``reinforcement`` (what the slab carries, at any time) or
+``flexure_design`` (what a check demanded of it), rather than from the private attributes:
+
+.. code-block:: python
+
+    bottom = slab.reinforcement.bottom
+
+    str(bottom)                 # 'Ø12 mm/17 cm'
+    bottom.layers[0].d_b        # 12 mm
+    bottom.layers[0].s.to("cm") # 17 cm
+    bottom.n_bars               # 6 bars across the strip
+    bottom.A_s.to("cm**2")      # 6.79 cm² placed
+
+The spacing is rounded to the whole centimetre (inch, in imperial), so it is one that can
+be detailed, and never to fewer bars than the design called for. See
+:ref:`user_guide/design_results` for the rest of that view.
+
 6. Jupyter Notebook Results
 ***************************
 

--- a/docs/source/user_guide/slabs.rst
+++ b/docs/source/user_guide/slabs.rst
@@ -151,54 +151,9 @@ See the `Node` section for how to display and save detailed per-load-case result
 8. Footings
 ***********
 
-A `Footing` is a `OneWaySlab` that bears directly on the ground. It takes the same
-arguments, carries the same reinforcement — diameter and spacing — and goes through
-the same checks. The one difference is the minimum longitudinal reinforcement.
+A footing is a slab bearing directly on the ground, and mento models it as a
+`Footing` — a `OneWaySlab` whose minimum reinforcement, bar spacing and thickness
+follow the rules the codes write for a member on the ground. Everything on this page
+applies to it unchanged.
 
-.. code-block:: python
-
-    from mento import Footing, Forces, Node, cm, kNm, m, mm
-
-    footing = Footing(label="Z1", concrete=concrete, steel_bar=steel_bar,
-                      width=1 * m, height=60 * cm, c_c=50 * mm)
-
-    Node(section=footing, forces=[Forces(label="ELU 1", M_y=120 * kNm)]).design()
-
-A member spanning between supports is given a minimum sized so that it cannot fail
-the instant it cracks. A member on the ground cannot fail that way — the soil goes on
-carrying it — so both codes exempt it and put a different rule in its place:
-
-- **ACI 318-19** (and **CIRSOC 201-25**): §9.6.1.1(b) grants the exemption and
-  §13.3.1.2 replaces the flexural minimum with the shrinkage and temperature
-  reinforcement of §24.4.3.2 — :math:`0.0018\,b\,h` at :math:`f_y = 420` MPa,
-  written on the gross section rather than on the effective depth.
-- **EN 1992-2004**: the larger of the halved geometric minimum of a foundation and
-  the crack-control minimum of §7.3.2(2), Eq. (7.1). The second usually governs a
-  thick footing.
-
-The design returns the largest applicable minimum already applied, so the reinforcement
-it reports needs no correction afterwards.
-
-A footing is also detailed differently, and the same `support` tells the codes so:
-
-- **Bar spacing** is kept between 100 and 300 mm. The upper bound replaces the 3h of
-  a suspended slab, which stops binding on a section this thick; the lower one is the
-  spacing below which a footing is not detailed in practice. A design answers a heavy
-  demand with a larger bar rather than with bars closer than 100 mm, and the flexure
-  check table reports the spacing against both bounds.
-- **Thickness** below what the code asks of a footing on soil — 200 mm in ACI 318-19
-  13.3.1.2, 250 mm in EN practice — raises a warning when the section is built. It is
-  advice, not a limit: the section is still designed as given, because the thickness is
-  the engineer's to choose.
-
-.. code-block:: python
-
-    Footing(label="Z2", concrete=concrete, steel_bar=steel_bar,
-            width=1 * m, height=18 * cm, c_c=50 * mm)
-    # UserWarning: Footing Z2 is 18 cm thick, below the 200 mm ACI 318-19 asks
-    # of a footing on soil. It is designed as given.
-
-.. note::
-
-   `Footing` designs the section, not the foundation. Bearing pressure, punching
-   (see `PunchingSlab`), sliding and overturning are outside its scope.
+See :doc:`footings`.

--- a/docs/source/user_guide/slabs.rst
+++ b/docs/source/user_guide/slabs.rst
@@ -123,7 +123,11 @@ per face. Read it through ``reinforcement`` (what the slab carries, at any time)
     bottom.A_s.to("cm**2")      # 6.79 cm² placed
 
 The spacing is rounded to the whole centimetre (inch, in imperial), so it is one that can
-be detailed, and never to fewer bars than the design called for. See
+be detailed, and never to fewer bars than the design called for. It is also capped at the
+maximum the design code allows between the bars of a slab — ``min(3h, 450 mm)`` under
+ACI 318-19 §7.7.2.3, ``min(3h, 400 mm)`` under EN 1992-1-1 §9.3.1.1(3) — so a lightly
+loaded strip is not detailed as a few widely spaced bars that merely add up to the area.
+A check reports that limit too, next to the spacing, in the flexure results table. See
 :ref:`user_guide/design_results` for the rest of that view.
 
 6. Jupyter Notebook Results

--- a/docs/source/user_guide/slabs.rst
+++ b/docs/source/user_guide/slabs.rst
@@ -125,3 +125,40 @@ See the `Node` section for more information on detailed results and Word report 
 
 See the `Node` section for how to display and save detailed per-load-case results using
 `shear_results_detailed()`, `flexure_results_detailed()`, and their `_doc()` variants.
+
+8. Footings
+***********
+
+A `Footing` is a `OneWaySlab` that bears directly on the ground. It takes the same
+arguments, carries the same reinforcement — diameter and spacing — and goes through
+the same checks. The one difference is the minimum longitudinal reinforcement.
+
+.. code-block:: python
+
+    from mento import Footing, Forces, Node, cm, kNm, m, mm
+
+    footing = Footing(label="Z1", concrete=concrete, steel_bar=steel_bar,
+                      width=1 * m, height=60 * cm, c_c=50 * mm)
+
+    Node(section=footing, forces=[Forces(label="ELU 1", M_y=120 * kNm)]).design()
+
+A member spanning between supports is given a minimum sized so that it cannot fail
+the instant it cracks. A member on the ground cannot fail that way — the soil goes on
+carrying it — so both codes exempt it and put a different rule in its place:
+
+- **ACI 318-19** (and **CIRSOC 201-25**): §9.6.1.1(b) grants the exemption and
+  §13.3.1.2 replaces the flexural minimum with the shrinkage and temperature
+  reinforcement of §24.4.3.2 — :math:`0.0018\,b\,h` at :math:`f_y = 420` MPa,
+  written on the gross section rather than on the effective depth.
+- **EN 1992-2004**: the larger of the halved geometric minimum of a foundation and
+  the crack-control minimum of §7.3.2(2), Eq. (7.1). The second usually governs a
+  thick footing.
+
+The design returns the largest applicable minimum already applied, so the reinforcement
+it reports needs no correction afterwards.
+
+.. note::
+
+   `Footing` designs the section, not the foundation. Bearing pressure, punching
+   (see `PunchingSlab`), sliding and overturning are outside its scope, as are the
+   minimum thickness and the bar spacing range each code sets for footings.

--- a/mento/__init__.py
+++ b/mento/__init__.py
@@ -57,6 +57,7 @@ __all__ = [
     "Node",
     "Forces",
     "OneWaySlab",
+    "Footing",
     "Concrete_ACI_318_19",
     "SteelBar",
     "Concrete_CIRSOC_201_25",
@@ -91,7 +92,7 @@ if TYPE_CHECKING:
         Concrete_EN_1992_2004,
         SteelBar,
     )
-    from mento.slab import OneWaySlab
+    from mento.slab import Footing, OneWaySlab
     from mento.settings import BeamSettings
     from mento.node import Node
     from mento.results import DocumentBuilder, Formatter, TablePrinter
@@ -108,6 +109,7 @@ def __getattr__(name: str) -> object:
     module_mapping = {
         "RectangularBeam": "beam",
         "OneWaySlab": "slab",
+        "Footing": "slab",
         "Node": "node",
         "BeamSettings": "settings",
         "Forces": "forces",

--- a/mento/beam.py
+++ b/mento/beam.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional, Dict, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Optional, Dict, Tuple
 
 if TYPE_CHECKING:
     from matplotlib.figure import Figure
@@ -325,13 +325,26 @@ class RectangularBeam(RectangularSection, _DesignCodeAttributes):
             design.get("d_b4"),
         )
 
-    def _finalize_longitudinal_design(self) -> None:
+    def _finalize_longitudinal_design(
+        self,
+        A_req_bot: Quantity,
+        A_req_top: Quantity,
+        resists: Callable[[], bool],
+    ) -> None:
         """Last word on the layout, once both faces have been designed.
 
         Nothing to do for a beam: its two faces are detailed independently, so
         the layout the design arrived at is the layout it keeps. It exists for
         the elements whose faces are tied to each other -- a footing is placed
-        as one mat, and reconciles the two spacings here.
+        as one mat, and chooses the module and both bars here.
+
+        Args:
+            A_req_bot: Steel the bottom face has to carry, minimum included.
+            A_req_top: The same for the top.
+            resists: Whether the layout now on the section resists both design
+                moments. An element that re-selects bars has to ask, since a
+                thicker bar sits deeper and lowers the effective depth it was
+                chosen against.
         """
 
     def _clear_top_longitudinal(self) -> None:

--- a/mento/beam.py
+++ b/mento/beam.py
@@ -325,6 +325,15 @@ class RectangularBeam(RectangularSection, _DesignCodeAttributes):
             design.get("d_b4"),
         )
 
+    def _finalize_longitudinal_design(self) -> None:
+        """Last word on the layout, once both faces have been designed.
+
+        Nothing to do for a beam: its two faces are detailed independently, so
+        the layout the design arrived at is the layout it keeps. It exists for
+        the elements whose faces are tied to each other -- a footing is placed
+        as one mat, and reconciles the two spacings here.
+        """
+
     def _clear_top_longitudinal(self) -> None:
         """Reset the top reinforcement to the default placeholder bars."""
         if self.concrete.unit_system == "metric":

--- a/mento/codes/ACI_318_19_beam.py
+++ b/mento/codes/ACI_318_19_beam.py
@@ -444,6 +444,36 @@ def _minimum_flexural_reinforcement_ratio_ACI_318_19(self: "RectangularBeam", M_
     return flexure_eq.min_reinforcement_ratio(sec.f_c, sec.f_y, is_imperial=sec.is_imperial)
 
 
+def _minimum_flexural_reinforcement_area_ACI_318_19(self: "RectangularBeam", M_u: float, d: float) -> float:
+    """A_s,min on the tension face, for the way this element is supported.
+
+    Two different clauses, and which one applies is a property of the element,
+    not of the moment:
+
+    * A member spanning between supports gets the flexural minimum of §9.6.1.2,
+      ``rho_min * b * d``, sized so the cracked section can still carry the
+      moment that cracked it.
+    * A member supported on the ground is exempt from that clause by
+      §9.6.1.1(b) — it cannot fail suddenly on cracking, because the soil goes
+      on carrying it — and §13.3.1.2 replaces it with the shrinkage and
+      temperature reinforcement of §24.4.3.2. That one is written on the gross
+      section ``b * h``, so ``d`` does not enter it.
+
+    Args:
+        M_u: Factored moment on the face (N·mm, or lb·in). Only its being zero
+            matters: with no moment there is no flexural minimum to satisfy.
+        d: Effective depth of the tension reinforcement (mm, or in).
+
+    Returns:
+        A_s,min (mm², or in²).
+    """
+    sec = section_floats(self)
+    if self.support == "soil":
+        rho_st = flexure_eq.shrinkage_and_temperature_ratio(sec.f_y, is_imperial=sec.is_imperial)
+        return rho_st * sec.width * sec.height
+    return _minimum_flexural_reinforcement_ratio_ACI_318_19(self, M_u) * d * sec.width
+
+
 def _calculate_flexural_reinforcement_ACI_318_19(
     self: "RectangularBeam", M_u: float, d: float, d_prima: float
 ) -> tuple[float, float, float, float, float, bool, bool]:
@@ -479,8 +509,7 @@ def _calculate_flexural_reinforcement_ACI_318_19(
     f_y_mag = sec.f_y
 
     # Determine minimum and maximum reinforcement areas
-    rho_min = _minimum_flexural_reinforcement_ratio_ACI_318_19(self, M_u)  # Mechanical minimum reinforcement ratio
-    A_s_min = rho_min * d * b
+    A_s_min = _minimum_flexural_reinforcement_area_ACI_318_19(self, M_u, d)
     rho_max = _maximum_flexural_reinforcement_ratio_ACI_318_19(
         self,
     )
@@ -513,7 +542,18 @@ def _calculate_flexural_reinforcement_ACI_318_19(
     # 1.8‰ of the gross section (custom geometric minimum rule), same for beams and slabs
     A_s_geo_min = (1.8 / (1000)) * sec.width * sec.height
 
-    if M_u == 0:
+    if self.support == "soil":
+        # Case S:
+        # A_s_min above is already the shrinkage and temperature reinforcement
+        # of §24.4.3.2, on the gross section -- the only minimum a member on
+        # the ground has to meet. The 4/3 relief of §9.6.1.3 belongs to the
+        # clause it relieves, §9.6.1.2, which §9.6.1.1(b) has exempted this
+        # member from: there is no sudden cracking failure here for extra steel
+        # to buy off, so the minimum stands as written. With M_u = 0, A_s_calc
+        # is zero and this is the minimum itself, which is also what the
+        # section needs for detailing and for rho_w in the shear provisions.
+        A_s_final = max(A_s_calc, A_s_min)
+    elif M_u == 0:
         # Case 0:
         # No flexural demand (e.g. a shear-only load combination). ACI does not
         # require flexural minimum steel here, so rho_min -- and therefore
@@ -663,19 +703,17 @@ def _determine_nominal_moment_ACI_318_19(self: "RectangularBeam", st: FlexureChe
 
     sec = section_floats(self)
     # Calculate minimum and maximum reinforcement ratios
-    rho_min = _minimum_flexural_reinforcement_ratio_ACI_318_19(self, force._M_y.magnitude)
+    M_u = force._M_y.magnitude
     rho_max = _maximum_flexural_reinforcement_ratio_ACI_318_19(self)
 
-    # For positive moments (tension in the bottom), set minimum reinforcement accordingly.
-    if force._M_y > 0 * kNm:
-        rho_min_top = 0.0
-        rho_min_bot = rho_min
-    else:
-        rho_min_top = rho_min
-        rho_min_bot = 0.0
+    # For positive moments (tension in the bottom), set minimum reinforcement
+    # accordingly. The minimum is asked for as an area rather than a ratio: the
+    # clause that applies to a member on the ground is written on the gross
+    # section, so there is no single ratio both cases can be expressed in.
+    tension_at_bottom = force._M_y > 0 * kNm
 
     # Calculate minimum and maximum bottom reinforcement areas
-    st.A_s_min_bot = rho_min_bot * sec.d_bot * sec.width
+    st.A_s_min_bot = _minimum_flexural_reinforcement_area_ACI_318_19(self, M_u, sec.d_bot) if tension_at_bottom else 0.0
     st.A_s_max_bot = rho_max * sec.d_bot * sec.width
 
     # Determine the nominal moment for positive moments.
@@ -701,7 +739,7 @@ def _determine_nominal_moment_ACI_318_19(self: "RectangularBeam", st: FlexureChe
         )
 
     # Determine capacity for negative moment (tension at the top)
-    st.A_s_min_top = rho_min_top * sec.d_top * sec.width
+    st.A_s_min_top = 0.0 if tension_at_bottom else _minimum_flexural_reinforcement_area_ACI_318_19(self, M_u, sec.d_top)
     st.A_s_max_top = rho_max * sec.d_top * sec.width
 
     # Determine the nominal moment for negative moments (tension on top face).

--- a/mento/codes/EN_1992_2004_beam.py
+++ b/mento/codes/EN_1992_2004_beam.py
@@ -304,6 +304,56 @@ def _min_max_flexural_reinforcement_ratio_EN_1992_2004(
     return rho_min, rho_max
 
 
+#: Stress distribution coefficient k_c of EN 1992-1-1 §7.3.2(2) for a
+#: rectangular section in pure bending. The clause's other value, 1.0, is for
+#: pure tension, which is not a state a section designed here is in.
+_K_C_BENDING = 0.4
+
+
+def _minimum_flexural_reinforcement_area_EN_1992_2004(self: "RectangularBeam", d: float) -> float:
+    """A_s,min on the tension face, for the way this element is supported.
+
+    A member spanning between supports gets the non-fragility minimum of
+    §9.2.1.1, ``rho_min * b_t * d``.
+
+    A member bearing on the ground does not: the brittle failure that clause
+    guards against needs the support to disappear when the section cracks, and
+    here the soil goes on carrying it. Two rules take its place, and the larger
+    governs:
+
+    * the halved geometric minimum of a foundation, on the gross section; and
+    * the crack-control minimum of §7.3.2(2), which is what actually sizes the
+      steel of a thick footing — the concrete releases its tension at the
+      instant of cracking and the bars have to take it without breaking.
+
+    Args:
+        d: Effective depth of the tension reinforcement (mm).
+
+    Returns:
+        A_s,min (mm²).
+    """
+    sec = section_floats(self)
+    if self.support != "soil":
+        rho_min, _ = _min_max_flexural_reinforcement_ratio_EN_1992_2004(self)
+        return rho_min * d * sec.width
+
+    concrete_en = cast("Concrete_EN_1992_2004", self.concrete)
+    A_s_geometric = flexure_eq.foundation_min_reinforcement_ratio(sec.f_y) * sec.width * sec.height
+    A_s_crack = flexure_eq.crack_control_min_reinforcement(
+        _K_C_BENDING,
+        flexure_eq.crack_control_coefficient_k(sec.height),
+        concrete_en.f_ctm.to(MPa).magnitude,
+        # The tension zone just before the first crack: the section is still
+        # uncracked there, so the neutral axis sits at mid-depth and half of a
+        # rectangle is in tension.
+        sec.width * sec.height / 2,
+        # The stress permitted in the bars right after cracking, taken at the
+        # design yield strength.
+        sec.f_y / concrete_en._gamma_s,
+    )
+    return max(A_s_geometric, A_s_crack)
+
+
 def _compression_zone_limits_EN_1992_2004(self: "RectangularBeam", d: float) -> Tuple[float, float]:
     """Compression zone at the ductility limit, as (neutral axis, block depth).
 
@@ -339,13 +389,13 @@ def _calculate_flexural_reinforcement_EN_1992_2004(
     """
     Calculate the required top and bottom reinforcement areas for bending.
     """
-    rho_min, rho_max = _min_max_flexural_reinforcement_ratio_EN_1992_2004(self)
+    _, rho_max = _min_max_flexural_reinforcement_ratio_EN_1992_2004(self)
     # ADR-0005 boundary: convert once, compute in floats (N, mm, MPa, N·mm),
     # re-apply units on the way out.
     sec = section_floats(self)
     b = sec.width
     d_mm = d
-    A_s_min = rho_min * d_mm * b
+    A_s_min = _minimum_flexural_reinforcement_area_EN_1992_2004(self, d_mm)
     A_s_max = rho_max * d_mm * b
 
     # Constants and material properties
@@ -477,26 +527,24 @@ def _determine_nominal_moment_EN_1992_2004(self: "RectangularBeam", st: ENFlexur
         None
     """
     # Calculate minimum and maximum reinforcement ratios
-    [rho_min, rho_max] = _min_max_flexural_reinforcement_ratio_EN_1992_2004(self)
+    [_, rho_max] = _min_max_flexural_reinforcement_ratio_EN_1992_2004(self)
 
-    # For positive moments (tension in the bottom), set minimum reinforcement accordingly.
+    # For positive moments (tension in the bottom), set minimum reinforcement
+    # accordingly. The minimum is asked for as an area rather than a ratio: the
+    # rules that apply to a member on the ground are written on the gross
+    # section, so there is no single ratio both cases can be expressed in.
     sec = section_floats(self)
-    if force._M_y > 0 * kNm:
-        rho_min_top = 0.0
-        rho_min_bot = rho_min
-    else:
-        rho_min_top = rho_min
-        rho_min_bot = 0.0
+    tension_at_bottom = force._M_y > 0 * kNm
 
     # Calculate minimum and maximum bottom reinforcement areas
-    st.A_s_min_bot = rho_min_bot * sec.d_bot * sec.width
+    st.A_s_min_bot = _minimum_flexural_reinforcement_area_EN_1992_2004(self, sec.d_bot) if tension_at_bottom else 0.0
     st.A_s_max_bot = rho_max * sec.d_bot * sec.width
     # Determine the nominal moment for positive moments
     st.M_Rd_bot = _simple_determine_nominal_moment_EN_1992_2004(
         self, sec.A_s_bot, sec.d_bot, sec.A_s_top, sec.c_mec_top
     )
     # Determine capacity for negative moment (tension at the top)
-    st.A_s_min_top = rho_min_top * sec.d_top * sec.width
+    st.A_s_min_top = 0.0 if tension_at_bottom else _minimum_flexural_reinforcement_area_EN_1992_2004(self, sec.d_top)
     st.A_s_max_top = rho_max * sec.d_top * sec.width
     st.M_Rd_top = _simple_determine_nominal_moment_EN_1992_2004(
         self, sec.A_s_top, sec.d_top, sec.A_s_bot, sec.c_mec_bot

--- a/mento/codes/EN_1992_2004_beam.py
+++ b/mento/codes/EN_1992_2004_beam.py
@@ -33,6 +33,12 @@ if TYPE_CHECKING:
 _mm2 = mm**2
 _Nmm = N * mm
 
+#: Stands in for a resistance of exactly zero when the DCR is formed, so that a
+#: face with no reinforcement on it reports a ratio far above 1 -- which is what
+#: it is -- instead of dividing by zero. ACI keeps the same floor, at the same
+#: 0.01 kNm; a resistance that small is already indistinguishable from none.
+_MOMENT_FLOOR = 0.01e6  # N·mm; EN is metric only
+
 
 def _initialize_variables_EN_1992_2004(self: "RectangularBeam") -> None:
     """
@@ -657,6 +663,8 @@ def _check_flexure_EN_1992_2004(self: "RectangularBeam", force: Forces) -> ENFle
         ) = _calculate_flexural_reinforcement_EN_1992_2004(self, st.M_Ed_bot, sec.d_bot, sec.c_mec_top)
         st.c_d_top = 0
         # Calculate the design capacity ratio for the bottom side.
+        if st.M_Rd_bot == 0:
+            st.M_Rd_bot = _MOMENT_FLOOR
         st.DCR_bot = round(st.M_Ed_bot / st.M_Rd_bot, 3)
         st.DCR_top = 0
     else:
@@ -669,6 +677,8 @@ def _check_flexure_EN_1992_2004(self: "RectangularBeam", force: Forces) -> ENFle
         ) = _calculate_flexural_reinforcement_EN_1992_2004(self, abs(st.M_Ed_top), sec.d_top, sec.c_mec_bot)
         st.c_d_bot = 0
         # Calculate the design capacity ratio for the top side.
+        if st.M_Rd_top == 0:
+            st.M_Rd_top = _MOMENT_FLOOR
         st.DCR_top = round(-st.M_Ed_top / st.M_Rd_top, 3)
         st.DCR_bot = 0
 

--- a/mento/codes/aci_318_19/code.py
+++ b/mento/codes/aci_318_19/code.py
@@ -93,6 +93,16 @@ def _min_stirrup_diameter(concrete: Any) -> Any:
     return 10 * mm if concrete.unit_system == "metric" else 3 / 8 * inch
 
 
+def _max_bar_spacing_slab(section: "RectangularBeam") -> Any:
+    """ACI 318-19 7.7.2.3: the lesser of 3h and 450 mm (18 in.).
+
+    The limit is on the flexural reinforcement of a one-way slab, so it is the
+    spacing of the layer nearest the face that has to meet it.
+    """
+    limit = 450 * mm if section.concrete.unit_system == "metric" else 18 * inch
+    return min(3 * section.height, limit)
+
+
 def _min_stirrup_diameter_cirsoc(concrete: Any) -> Any:
     """CIRSOC's catalogue starts one size below ACI's."""
     return 6 * mm
@@ -188,6 +198,7 @@ _COMMON = dict(
     capacity_columns=_capacity_columns,
     shear_symbols=_SHEAR_SYMBOLS,
     summary_drop_columns=_SUMMARY_DROP_COLUMNS,
+    max_bar_spacing_slab=_max_bar_spacing_slab,
 )
 
 ACI_318_19 = register(

--- a/mento/codes/aci_318_19/code.py
+++ b/mento/codes/aci_318_19/code.py
@@ -88,6 +88,15 @@ _SHEAR_SYMBOLS = {
 }
 
 
+#: How far apart the bars of a member on the ground are detailed, whichever
+#: code it is designed to. The upper bound is what keeps the pressure from the
+#: soil spread across the reinforcement rather than arching between distant
+#: bars; the lower one is EN practice, applied to both codes because nothing
+#: about it is particular to EN.
+_MAX_BAR_SPACING_ON_SOIL = 300 * mm
+_MIN_BAR_SPACING_ON_SOIL = 100 * mm
+
+
 def _min_stirrup_diameter(concrete: Any) -> Any:
     """ACI's smallest stirrup: a #3 bar, or 10 mm in metric practice."""
     return 10 * mm if concrete.unit_system == "metric" else 3 / 8 * inch
@@ -98,9 +107,37 @@ def _max_bar_spacing_slab(section: "RectangularBeam") -> Any:
 
     The limit is on the flexural reinforcement of a one-way slab, so it is the
     spacing of the layer nearest the face that has to meet it.
+
+    A footing is detailed more tightly than 7.7.2.3 alone would ask: a slab on
+    the ground is thick, so 3h stops binding long before the bars are close
+    enough to spread the bearing pressure into them, and practice caps them at
+    300 mm.
     """
     limit = 450 * mm if section.concrete.unit_system == "metric" else 18 * inch
+    if section.support == "soil":
+        limit = min(limit, _MAX_BAR_SPACING_ON_SOIL)
     return min(3 * section.height, limit)
+
+
+def _min_bar_spacing_slab(section: "RectangularBeam") -> Any:
+    """The closest together the bars of a footing are detailed.
+
+    Not a strength limit -- the clear distance of 25.2.1 is, and the settings
+    already carry it -- but the spacing below which a footing is not detailed
+    in practice, because placing and vibrating over the soil stops being
+    worth it. A slab spanning between supports has no such floor.
+    """
+    return _MIN_BAR_SPACING_ON_SOIL if section.support == "soil" else None
+
+
+def _min_thickness_on_soil(concrete: Any) -> Any:
+    """ACI 318-19 13.3.1.2: a footing on soil is at least 200 mm (8 in.) thick.
+
+    The clause is written as an effective depth of 150 mm above the bottom
+    reinforcement, which with the cover and bars of a footing is the overall
+    200 mm quoted here.
+    """
+    return 200 * mm if concrete.unit_system == "metric" else 8 * inch
 
 
 def _min_stirrup_diameter_cirsoc(concrete: Any) -> Any:
@@ -199,6 +236,8 @@ _COMMON = dict(
     shear_symbols=_SHEAR_SYMBOLS,
     summary_drop_columns=_SUMMARY_DROP_COLUMNS,
     max_bar_spacing_slab=_max_bar_spacing_slab,
+    min_bar_spacing_slab=_min_bar_spacing_slab,
+    min_thickness_on_soil=_min_thickness_on_soil,
 )
 
 ACI_318_19 = register(

--- a/mento/codes/aci_318_19/equations/flexure.py
+++ b/mento/codes/aci_318_19/equations/flexure.py
@@ -12,6 +12,7 @@ import math
 __all__ = [
     "max_reinforcement_ratio",
     "min_reinforcement_ratio",
+    "shrinkage_and_temperature_ratio",
     "neutral_axis_at_ductility_limit",
     "compression_steel_net_stress",
     "flexural_resistance_factor",
@@ -57,6 +58,29 @@ def min_reinforcement_ratio(f_c: float, f_y: float, *, is_imperial: bool = False
     if is_imperial:
         return max(3 * math.sqrt(f_c) / f_y, 200 / f_y)
     return max(0.25 * math.sqrt(f_c) / f_y, 1.4 / f_y)
+
+
+def shrinkage_and_temperature_ratio(f_y: float, *, is_imperial: bool = False) -> float:
+    """Shrinkage and temperature reinforcement ratio — ACI 318-19 Table 24.4.3.2.
+
+    The minimum that governs when the flexural minimum of §9.6.1.2 does not
+    apply. §9.6.1.1(b) exempts a member supported on the ground from that
+    clause, and §13.3.1.2 sends a footing here instead — which is why this
+    ratio is written on the GROSS section ``b*h``, not on the effective depth
+    the flexural minimum uses.
+
+    Args:
+        f_y: Specified steel yield strength (MPa, or psi).
+        is_imperial: Selects the reference yield strength the table is anchored
+            at: 60000 psi in US customary, 420 MPa in SI.
+
+    Returns:
+        A_s,min/(b*h), dimensionless. 0.0018 at the reference yield strength,
+        scaled inversely for a stronger steel, and never below the 0.0014 floor
+        the table imposes.
+    """
+    f_y_reference = 60000.0 if is_imperial else 420.0
+    return max(0.0018 * f_y_reference / f_y, 0.0014)
 
 
 def neutral_axis_at_ductility_limit(d: float, epsilon_y: float) -> float:

--- a/mento/codes/en_1992_2004/code.py
+++ b/mento/codes/en_1992_2004/code.py
@@ -144,6 +144,12 @@ def _longitudinal_rebar(rebar: "Rebar", A_s_req: Any, A_s_max: Any, mech_cover: 
     return rebar.longitudinal_rebar_EN_1992_2004(A_s_req, A_s_max, mech_cover)
 
 
+#: How far apart the bars of a member on the ground are detailed. Both codes
+#: use the same pair; see the ACI module for why.
+_MAX_BAR_SPACING_ON_SOIL = 300 * mm
+_MIN_BAR_SPACING_ON_SOIL = 100 * mm
+
+
 def _max_bar_spacing_slab(section: "RectangularBeam") -> Any:
     """EN 1992-1-1 9.3.1.1(3): 3h, and no more than 400 mm.
 
@@ -152,8 +158,35 @@ def _max_bar_spacing_slab(section: "RectangularBeam") -> Any:
     no more than 250 mm) is not applied here: a section is checked against a set
     of forces, with no position along the span for mento to tell that it is in
     one of those areas.
+
+    A footing is detailed more tightly than 9.3.1.1(3) alone would ask: a slab
+    on the ground is thick, so 3h stops binding long before the bars are close
+    enough to spread the bearing pressure into them, and 9.8.2.1 practice caps
+    them at 300 mm.
     """
-    return min(3 * section.height, 400 * mm)
+    limit = min(400 * mm, _MAX_BAR_SPACING_ON_SOIL) if section.support == "soil" else 400 * mm
+    return min(3 * section.height, limit)
+
+
+def _min_bar_spacing_slab(section: "RectangularBeam") -> Any:
+    """The closest together the bars of a footing are detailed.
+
+    Not a strength limit -- the clear distance of 8.2 is, and the settings
+    already carry it -- but the spacing below which a footing is not detailed
+    in practice, because placing and vibrating over the soil stops being worth
+    it. A slab spanning between supports has no such floor.
+    """
+    return _MIN_BAR_SPACING_ON_SOIL if section.support == "soil" else None
+
+
+def _min_thickness_on_soil(concrete: Any) -> Any:
+    """The thinnest footing EN practice details.
+
+    EN 1992-1-1 states no overall minimum for a footing the way ACI 13.3.1.2
+    does; 250 mm is the thickness below which the anchorage of the bars and the
+    tolerance on a surface cast against the ground stop working out.
+    """
+    return 250 * mm
 
 
 EN_1992_2004 = register(
@@ -179,5 +212,7 @@ EN_1992_2004 = register(
         shear_symbols=_SHEAR_SYMBOLS,
         summary_drop_columns=_SUMMARY_DROP_COLUMNS,
         max_bar_spacing_slab=_max_bar_spacing_slab,
+        min_bar_spacing_slab=_min_bar_spacing_slab,
+        min_thickness_on_soil=_min_thickness_on_soil,
     )
 )

--- a/mento/codes/en_1992_2004/code.py
+++ b/mento/codes/en_1992_2004/code.py
@@ -13,7 +13,7 @@ from mento.codes.EN_1992_2004_beam import (
 )
 from mento.codes.registry import DesignCode, register
 from mento.material import Concrete_EN_1992_2004
-from mento.units import cm, kN, kNm, MPa
+from mento.units import cm, kN, kNm, mm, MPa
 
 if TYPE_CHECKING:
     from mento.beam import RectangularBeam
@@ -144,6 +144,18 @@ def _longitudinal_rebar(rebar: "Rebar", A_s_req: Any, A_s_max: Any, mech_cover: 
     return rebar.longitudinal_rebar_EN_1992_2004(A_s_req, A_s_max, mech_cover)
 
 
+def _max_bar_spacing_slab(section: "RectangularBeam") -> Any:
+    """EN 1992-1-1 9.3.1.1(3): 3h, and no more than 400 mm.
+
+    The general provision for the principal reinforcement of a slab. The tighter
+    one it states for areas of concentrated load or of maximum moment (2h, and
+    no more than 250 mm) is not applied here: a section is checked against a set
+    of forces, with no position along the span for mento to tell that it is in
+    one of those areas.
+    """
+    return min(3 * section.height, 400 * mm)
+
+
 EN_1992_2004 = register(
     DesignCode(
         title="EN 1992-2004",
@@ -166,5 +178,6 @@ EN_1992_2004 = register(
         capacity_columns=_capacity_columns,
         shear_symbols=_SHEAR_SYMBOLS,
         summary_drop_columns=_SUMMARY_DROP_COLUMNS,
+        max_bar_spacing_slab=_max_bar_spacing_slab,
     )
 )

--- a/mento/codes/en_1992_2004/equations/flexure.py
+++ b/mento/codes/en_1992_2004/equations/flexure.py
@@ -16,6 +16,9 @@ import math
 
 __all__ = [
     "min_reinforcement_ratio",
+    "foundation_min_reinforcement_ratio",
+    "crack_control_coefficient_k",
+    "crack_control_min_reinforcement",
     "max_reinforcement_ratio",
     "neutral_axis_depth_limit_ratio",
     "limit_moment",
@@ -41,6 +44,78 @@ def min_reinforcement_ratio(f_ctm: float, f_yk: float) -> float:
         absolute floor of 0.0013 the clause also imposes.
     """
     return max(0.26 * f_ctm / f_yk, 0.0013)
+
+
+def foundation_min_reinforcement_ratio(f_yk: float) -> float:
+    """Geometric minimum for a foundation, per direction — EN 1992-1-1 §9.2.1.1, §9.8.1.
+
+    A footing or raft bears on the ground, so the brittle-failure mechanism the
+    non-fragility minimum of §9.2.1.1 guards against cannot develop: the soil
+    keeps carrying the element after the section cracks. §9.8.1 detailing
+    practice therefore takes the minimum at half of it in each of the two
+    directions, and writes it on the GROSS section ``b*h`` rather than on the
+    effective depth.
+
+    Args:
+        f_yk: Characteristic yield strength of the reinforcement (MPa).
+
+    Returns:
+        A_s,min/(b*h), dimensionless: 1.0 per mille at f_yk = 400 MPa and
+        0.9 per mille at f_yk = 500 MPa, the two grades the rule is tabulated
+        for, interpolated linearly between them and held flat outside.
+    """
+    ratio_400, ratio_500 = 0.0010, 0.0009
+    if f_yk <= 400.0:
+        return ratio_400
+    if f_yk >= 500.0:
+        return ratio_500
+    return ratio_400 + (f_yk - 400.0) * (ratio_500 - ratio_400) / (500.0 - 400.0)
+
+
+def crack_control_coefficient_k(h: float) -> float:
+    """Coefficient k of the crack-control minimum — EN 1992-1-1 §7.3.2(2).
+
+    Accounts for the non-uniform self-equilibrating stresses that relieve the
+    tension a thick section has to carry: the deeper the member, the more of
+    the restraint is taken by them and the less by the reinforcement.
+
+    Args:
+        h: Overall depth of the section (mm); for a flange or web the clause
+            takes the smaller of the width and the height instead.
+
+    Returns:
+        k, dimensionless: 1.0 for h <= 300 mm, 0.65 for h >= 800 mm, linear in
+        between and saturated at both ends.
+    """
+    if h <= 300.0:
+        return 1.0
+    if h >= 800.0:
+        return 0.65
+    return 1.0 + (h - 300.0) * (0.65 - 1.0) / (800.0 - 300.0)
+
+
+def crack_control_min_reinforcement(k_c: float, k: float, f_ct_eff: float, A_ct: float, sigma_s: float) -> float:
+    """Minimum reinforcement for crack control — EN 1992-1-1 §7.3.2(2), Eq. (7.1).
+
+    ``A_s,min * sigma_s = k_c * k * f_ct,eff * A_ct``: enough steel to carry,
+    without breaking, the tension the concrete releases at the instant it
+    cracks.
+
+    Args:
+        k_c: Stress distribution coefficient — 0.4 for a rectangular section in
+            pure bending, 1.0 in pure tension.
+        k: Coefficient from :func:`crack_control_coefficient_k`.
+        f_ct_eff: Tensile strength of the concrete at the moment cracking is
+            expected, taken as f_ctm (MPa).
+        A_ct: Area of concrete in the tension zone just before the first crack
+            forms (mm²).
+        sigma_s: Stress permitted in the reinforcement immediately after
+            cracking (MPa).
+
+    Returns:
+        A_s,min (mm²).
+    """
+    return k_c * k * f_ct_eff * A_ct / sigma_s
 
 
 def max_reinforcement_ratio() -> float:

--- a/mento/codes/flexure_design.py
+++ b/mento/codes/flexure_design.py
@@ -371,3 +371,9 @@ def _run_flexure_design(
         if capacity("top", M_demand_top) < M_demand_top and top_visited:
             chosen_top = _select_safe_design(self, list(top_visited.values()), M_demand_top, "top", capacity)
             self._apply_longitudinal_design_top(chosen_top)
+
+    # Both faces are settled. An element whose faces are detailed as one -- a
+    # footing mat -- gets the last word here, after the verification above and
+    # never before it: what it does can only add steel, so a layout that passed
+    # still passes.
+    self._finalize_longitudinal_design()

--- a/mento/codes/flexure_design.py
+++ b/mento/codes/flexure_design.py
@@ -374,6 +374,17 @@ def _run_flexure_design(
 
     # Both faces are settled. An element whose faces are detailed as one -- a
     # footing mat -- gets the last word here, after the verification above and
-    # never before it: what it does can only add steel, so a layout that passed
-    # still passes.
-    self._finalize_longitudinal_design()
+    # never before it, so that what it starts from is a layout already known to
+    # work. It may re-select the bars rather than only the spacing, so it is
+    # handed the means to verify its own choice.
+    def _layout_resists() -> bool:
+        """Does the layout currently on the section carry both moments?"""
+        if max_M_y_bot > 0 * kNm and capacity("bot", max_M_y_bot) < max_M_y_bot:
+            return False
+        if max_M_y_top < 0 * kNm:
+            M_demand = abs(max_M_y_top.to("kN*m"))
+            if capacity("top", M_demand) < M_demand:
+                return False
+        return True
+
+    self._finalize_longitudinal_design(A_req_bot, A_req_top, _layout_resists)

--- a/mento/codes/registry.py
+++ b/mento/codes/registry.py
@@ -86,6 +86,14 @@ class DesignCode:
     #: no limit rather than as an error: a spacing rule a code does not have is
     #: not a rule an element can fail.
     max_bar_spacing_slab: Callable[..., Any] | None = None
+    #: Smallest centre-to-centre spacing this code asks for between the
+    #: flexural bars of a slab, over and above the clear distance the settings
+    #: already impose. ``None`` where the code states none.
+    min_bar_spacing_slab: Callable[..., Any] | None = None
+    #: Thinnest section this code allows for a member bearing on the ground.
+    #: Read as advice, not as a limit: a thinner footing is reported and still
+    #: designed, because the thickness is the engineer's to choose.
+    min_thickness_on_soil: Callable[..., Any] | None = None
 
     def requires(self, hook: str) -> Callable[..., Any]:
         """The hook, or a clear error naming the code that lacks it."""

--- a/mento/codes/registry.py
+++ b/mento/codes/registry.py
@@ -81,6 +81,11 @@ class DesignCode:
     #: Smallest stirrup bar this code's detailing rules allow. Only the codes
     #: whose report tables quote it need to supply one.
     min_stirrup_diameter: Callable[..., Any] | None = None
+    #: Largest centre-to-centre spacing this code allows between the flexural
+    #: bars of a slab. ``None`` for a code that states none, which is read as
+    #: no limit rather than as an error: a spacing rule a code does not have is
+    #: not a rule an element can fail.
+    max_bar_spacing_slab: Callable[..., Any] | None = None
 
     def requires(self, hook: str) -> Callable[..., Any]:
         """The hook, or a clear error naming the code that lacks it."""

--- a/mento/design_results.py
+++ b/mento/design_results.py
@@ -31,12 +31,35 @@ class DesignNotRunError(RuntimeError):
     """Raised when results are read before a check or design has been run."""
 
 
+def format_longitudinal_rebar(n: int, d_b: str, s: Optional[str] = None) -> str:
+    """Label one layer of longitudinal bars in the notation of its element.
+
+    A beam is detailed as a number of bars of a diameter, so the count leads:
+    ``4Ø16``. A slab is one bar repeated at a spacing across the strip, and the
+    count that falls out of it says nothing about how it is drawn, so the
+    spacing takes its place: ``Ø12/17cm`` -- the same notation its grid of
+    stirrups is written in.
+
+    Takes the numbers already formatted, so each caller keeps its own precision
+    and units while the shape of the label is decided in one place.
+    """
+    if s is None:
+        return f"{n}Ø{d_b}"
+    return f"Ø{d_b}/{s}"
+
+
 @dataclass(frozen=True)
 class RebarLayer:
-    """One layer of longitudinal bars: ``n`` bars of diameter ``d_b``."""
+    """One layer of longitudinal bars: ``n`` bars of diameter ``d_b``.
+
+    ``s`` is the centre-to-centre spacing the layer was detailed with, and is
+    ``None`` on a section that is detailed by a bar count instead -- a beam.
+    The area is the same either way; what changes is how the layer reads.
+    """
 
     n: int
     d_b: Quantity
+    s: Optional[Quantity] = None
 
     @property
     def A_s(self) -> Quantity:
@@ -44,7 +67,11 @@ class RebarLayer:
         return self.n * (self.d_b**2) * math.pi / 4
 
     def __str__(self) -> str:
-        return f"{self.n}Ø{self.d_b:.4g~P}"
+        return format_longitudinal_rebar(
+            self.n,
+            f"{self.d_b:.4g~P}",
+            None if self.s is None else f"{self.s:.4g~P}",
+        )
 
 
 @dataclass(frozen=True)
@@ -352,8 +379,13 @@ def _layers(beam: RectangularBeam, face: str) -> Tuple[RebarLayer, ...]:
     for index in (1, 2, 3, 4):
         n = getattr(beam, f"_n{index}_{face}", 0)
         d_b: Optional[Quantity] = getattr(beam, f"_d_b{index}_{face}", None)
+        # Only a section detailed by a spacing carries one; a beam has no such
+        # attribute and its layers keep reading as a number of bars.
+        s: Optional[Quantity] = getattr(beam, f"_s_b{index}_{face}", None)
+        if s is not None and s.magnitude == 0:
+            s = None
         if n and d_b is not None and d_b.magnitude > 0:
-            layers.append(RebarLayer(n=int(n), d_b=d_b))
+            layers.append(RebarLayer(n=int(n), d_b=d_b, s=s))
     return tuple(layers)
 
 

--- a/mento/reports/tables.py
+++ b/mento/reports/tables.py
@@ -113,8 +113,10 @@ def _bar_spacing_row(
     bars may be -- ACI 318-19 7.7.2.3, EN 1992-1-1 9.3.1.1(3) -- since bars far
     enough apart leave the slab between them unreinforced whatever they add up
     to. So the row carries the centre-to-centre spacing of the layer nearest the
-    face, and a maximum along with the minimum. A face with no bars on it has
-    nothing to check either way. ``face`` is ``"b"`` or ``"t"``.
+    face, and a maximum along with the minimum -- and on a footing, whose bars
+    are kept 100 mm apart at the closest, a minimum the code raises above the
+    one the settings ask for. A face with no bars on it has nothing to check
+    either way. ``face`` is ``"b"`` or ``"t"``.
     """
     side = "top" if face == "t" else "bottom"
     # Only a section detailed by a spacing carries one; a beam has no such
@@ -125,14 +127,20 @@ def _bar_spacing_row(
         return f"Minimum spacing {side}", clear, min_clear, None
     if getattr(self, f"_n1_{face}") == 0 or spacing.magnitude == 0:
         return f"Bar spacing {side}", spacing, None, None
-    limit_of = getattr(self, "_max_bar_spacing", None)
+    max_of = getattr(self, "_max_bar_spacing", None)
+    min_of = getattr(self, "_min_bar_spacing", None)
     # The value is centre to centre, so the minimum clear distance is read as
-    # one bar further apart than the beam reads it.
+    # one bar further apart than the beam reads it. A code that asks for a
+    # spacing of its own -- a footing does -- raises that floor.
+    minimum: Quantity = min_clear + getattr(self, f"_d_b1_{face}")
+    from_code = None if min_of is None else min_of()
+    if from_code is not None:
+        minimum = max(minimum, from_code)
     return (
         f"Bar spacing {side}",
         spacing,
-        min_clear + getattr(self, f"_d_b1_{face}"),
-        None if limit_of is None else limit_of(),
+        minimum,
+        None if max_of is None else max_of(),
     )
 
 

--- a/mento/reports/tables.py
+++ b/mento/reports/tables.py
@@ -102,6 +102,45 @@ def _longitudinal_rebar_rows(self: "RectangularBeam", face: str) -> tuple[list[s
     return labels, variables, values
 
 
+def _bar_spacing_row(
+    self: "RectangularBeam", face: str, min_clear: Quantity
+) -> tuple[str, Quantity, Quantity | None, Quantity | None]:
+    """The label, the value and the limits of one face's bar-spacing row.
+
+    A beam is detailed to a clear distance between bars, and reports the
+    smallest one it has against the minimum its settings ask for. A slab is
+    detailed to a spacing, and what the codes limit there is how far apart the
+    bars may be -- ACI 318-19 7.7.2.3, EN 1992-1-1 9.3.1.1(3) -- since bars far
+    enough apart leave the slab between them unreinforced whatever they add up
+    to. So the row carries the centre-to-centre spacing of the layer nearest the
+    face, and a maximum along with the minimum. A face with no bars on it has
+    nothing to check either way. ``face`` is ``"b"`` or ``"t"``.
+    """
+    side = "top" if face == "t" else "bottom"
+    # Only a section detailed by a spacing carries one; a beam has no such
+    # attribute and keeps reporting the clear distance between its bars.
+    spacing = getattr(self, f"_s_b1_{face}", None)
+    if spacing is None:
+        clear: Quantity = getattr(self, f"_available_s_{'top' if face == 't' else 'bot'}")
+        return f"Minimum spacing {side}", clear, min_clear, None
+    if getattr(self, f"_n1_{face}") == 0 or spacing.magnitude == 0:
+        return f"Bar spacing {side}", spacing, None, None
+    limit_of = getattr(self, "_max_bar_spacing", None)
+    # The value is centre to centre, so the minimum clear distance is read as
+    # one bar further apart than the beam reads it.
+    return (
+        f"Bar spacing {side}",
+        spacing,
+        min_clear + getattr(self, f"_d_b1_{face}"),
+        None if limit_of is None else limit_of(),
+    )
+
+
+def _shown_mm(value: Quantity | None) -> Any:
+    """A limit in millimetres for the report tables, blank where there is none."""
+    return "" if value is None else round(value.to("mm").magnitude, 2)
+
+
 def _settings(beam: RectangularBeam) -> BeamSettings:
     """The beam's settings, which ``__post_init__`` always fills in.
 
@@ -467,23 +506,25 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
     settings = _settings(self)
     min_spacing_top: Quantity = max(settings.clear_spacing, settings.vibrator_size, self._d_b_max_top)
     min_spacing_bot: Quantity = max(settings.clear_spacing, self._d_b_max_bot)
+    label_s_top, s_top, s_top_min, s_top_max = _bar_spacing_row(self, "t", min_spacing_top)
+    label_s_bot, s_bot, s_bot_min, s_bot_max = _bar_spacing_row(self, "b", min_spacing_bot)
     min_values = [
         self._A_s_min_top,
-        min_spacing_top,
+        s_top_min,
         self._A_s_min_bot,
-        min_spacing_bot,
+        s_bot_min,
     ]  # Use None for items without a minimum constraint
     max_values = [
         self._A_s_max_top,
-        None,
+        s_top_max,
         self._A_s_max_bot,
-        None,
+        s_bot_max,
     ]  # Use None for items without a maximum constraint
     current_values = [
         self._A_s_top,
-        self._available_s_top,
+        s_top,
         self._A_s_bot,
-        self._available_s_bot,
+        s_bot,
     ]  # Current values to check
 
     ARTICLE_STR = "9.6.1.3"
@@ -522,28 +563,28 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
     self._data_min_max_flexure = {
         "Check": [
             "Min/Max As rebar top",
-            "Minimum spacing top",
+            label_s_top,
             "Min/Max As rebar bottom",
-            "Minimum spacing bottom",
+            label_s_bot,
         ],
         "Unit": ["cm²", "mm", "cm²", "mm"],
         "Value": [
             round(self._A_s_top.to("cm**2").magnitude, 2),
-            round(self._available_s_top.to("mm").magnitude, 2),
+            _shown_mm(s_top),
             round(self._A_s_bot.to("cm**2").magnitude, 2),
-            round(self._available_s_bot.to("mm").magnitude, 2),
+            _shown_mm(s_bot),
         ],
         "Min.": [
             round(self._A_s_min_top.to("cm**2").magnitude, 2),
-            round(min_spacing_top.to("mm").magnitude, 2),
+            _shown_mm(s_top_min),
             round(self._A_s_min_bot.to("cm**2").magnitude, 2),
-            round(min_spacing_bot.to("mm").magnitude, 2),
+            _shown_mm(s_bot_min),
         ],
         "Max.": [
             round(self._A_s_max_top.to("cm**2").magnitude, 2),
-            "",
+            _shown_mm(s_top_max),
             round(self._A_s_max_bot.to("cm**2").magnitude, 2),
-            "",
+            _shown_mm(s_bot_max),
         ],
         "Ok?": checks,
     }
@@ -899,23 +940,25 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
     settings = _settings(self)
     min_spacing_top: Quantity = max(settings.clear_spacing, settings.vibrator_size, self._d_b_max_top)
     min_spacing_bot: Quantity = max(settings.clear_spacing, self._d_b_max_bot)
+    label_s_top, s_top, s_top_min, s_top_max = _bar_spacing_row(self, "t", min_spacing_top)
+    label_s_bot, s_bot, s_bot_min, s_bot_max = _bar_spacing_row(self, "b", min_spacing_bot)
     min_values = [
         self._A_s_min_top,
-        min_spacing_top,
+        s_top_min,
         self._A_s_min_bot,
-        min_spacing_bot,
+        s_bot_min,
     ]  # Use None for items without a minimum constraint
     max_values = [
         self._A_s_max_top,
-        None,
+        s_top_max,
         self._A_s_max_bot,
-        None,
+        s_bot_max,
     ]  # Use None for items without a maximum constraint
     current_values = [
         self._A_s_top,
-        self._available_s_top,
+        s_top,
         self._A_s_bot,
-        self._available_s_bot,
+        s_bot,
     ]  # Current values to check
 
     # Generate check marks based on the range conditions
@@ -940,28 +983,28 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
     self._data_min_max_flexure = {
         "Check": [
             "Min/Max As rebar top",
-            "Minimum spacing top",
+            label_s_top,
             "Min/Max As rebar bottom",
-            "Minimum spacing bottom",
+            label_s_bot,
         ],
         "Unit": ["cm²", "mm", "cm²", "mm"],
         "Value": [
             round(self._A_s_top.to("cm**2").magnitude, 2),
-            round(self._available_s_top.to("mm").magnitude, 2),
+            _shown_mm(s_top),
             round(self._A_s_bot.to("cm**2").magnitude, 2),
-            round(self._available_s_bot.to("mm").magnitude, 2),
+            _shown_mm(s_bot),
         ],
         "Min.": [
             round(self._A_s_min_top.to("cm**2").magnitude, 2),
-            round(min_spacing_top.to("mm").magnitude, 2),
+            _shown_mm(s_top_min),
             round(self._A_s_min_bot.to("cm**2").magnitude, 2),
-            round(min_spacing_bot.to("mm").magnitude, 2),
+            _shown_mm(s_bot_min),
         ],
         "Max.": [
             round(self._A_s_max_top.to("cm**2").magnitude, 2),
-            "",
+            _shown_mm(s_top_max),
             round(self._A_s_max_bot.to("cm**2").magnitude, 2),
-            "",
+            _shown_mm(s_bot_max),
         ],
         "Ok?": checks,
     }

--- a/mento/reports/tables.py
+++ b/mento/reports/tables.py
@@ -22,7 +22,7 @@ from pint import Quantity
 from mento.units import inch, kN, kNm, mm
 
 from mento.codes.registry import design_code
-from mento.design_results import GRID, transverse_layout
+from mento.design_results import GRID, format_longitudinal_rebar, transverse_layout
 
 if TYPE_CHECKING:
     from mento.beam import RectangularBeam
@@ -63,6 +63,43 @@ def _transverse_rebar_rows(
         [self._stirrup_n, diameter, s_l],
         ["", "mm", "cm"],
     )
+
+
+def _longitudinal_rebar_rows(self: "RectangularBeam", face: str) -> tuple[list[str], list[str], list[Any]]:
+    """The two rows that identify the longitudinal reinforcement of one face.
+
+    A beam is a number of bars per layer, so the bars are counted: ``n1+n2``. A
+    slab is one bar repeated at a spacing, and the count that falls out of a
+    strip is not what it is drawn with, so each of its layers reads as a
+    diameter and a spacing instead. ``face`` is ``"b"`` or ``"t"``, and there
+    are two rows either way, so every column of the table stays the same length.
+    """
+    labels = ["First layer bars", "Second layer bars"]
+    variables = []
+    values = []
+    # Only a section detailed by a spacing carries these; a beam has no such
+    # attribute and its layers keep being reported as a number of bars. The
+    # notation is chosen once for the face, so an empty second layer is still
+    # written the way the rest of the face is.
+    detailed_by_spacing = getattr(self, f"_s_b1_{face}", None) is not None
+    for first, second in ((1, 2), (3, 4)):
+        n = getattr(self, f"_n{first}_{face}")
+        d_b = getattr(self, f"_d_b{first}_{face}")
+        if not detailed_by_spacing:
+            variables.append(f"n{first}+n{second}")
+            values.append(
+                self._format_longitudinal_rebar_string(
+                    n, d_b, getattr(self, f"_n{second}_{face}"), getattr(self, f"_d_b{second}_{face}")
+                )
+            )
+            continue
+        spacing = getattr(self, f"_s_b{first}_{face}")
+        variables.append(f"Ø{first}/s{first}")
+        if n == 0 or d_b.magnitude == 0 or spacing.magnitude == 0:
+            values.append("-")
+        else:
+            values.append(format_longitudinal_rebar(n, f"{d_b:.4g~P}", f"{spacing:.4g~P}"))
+    return labels, variables, values
 
 
 def _settings(beam: RectangularBeam) -> BeamSettings:
@@ -512,10 +549,10 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
     }
     check_DCR_top = "✅" if self._DCRb_top < 1 else "❌"
     check_DCR_bot = "✅" if self._DCRb_bot < 1 else "❌"
+    long_rebar_top = _longitudinal_rebar_rows(self, "t")
     self._flexure_capacity_top = {
         "Top reinforcement check": [
-            "First layer bars",
-            "Second layer bars",
+            *long_rebar_top[0],
             "Effective height",
             "Depth of equivalent strength block ratio",
             "Minimum rebar reinforcing",
@@ -527,8 +564,7 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
             "Demand Capacity Ratio",
         ],
         "Variable": [
-            "n1+n2",
-            "n3+n4",
+            *long_rebar_top[1],
             "d",
             "c/d",
             "As,min",
@@ -540,8 +576,7 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
             "DCR",
         ],
         "Value": [
-            self._format_longitudinal_rebar_string(self._n1_t, self._d_b1_t, self._n2_t, self._d_b2_t),
-            self._format_longitudinal_rebar_string(self._n3_t, self._d_b3_t, self._n4_t, self._d_b4_t),
+            *long_rebar_top[2],
             round(self._d_top.to("cm").magnitude, 2),
             round(self._c_d_top, 4),
             round(self._A_s_min_top.to("cm**2").magnitude, 2),
@@ -566,10 +601,10 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
             check_DCR_top,
         ],
     }
+    long_rebar_bot = _longitudinal_rebar_rows(self, "b")
     self._flexure_capacity_bot = {
         "Bottom reinforcement check": [
-            "First layer bars",
-            "Second layer bars",
+            *long_rebar_bot[0],
             "Effective height",
             "Depth of equivalent strength block ratio",
             "Minimum rebar reinforcing",
@@ -581,8 +616,7 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
             "Demand Capacity Ratio",
         ],
         "Variable": [
-            "n1+n2",
-            "n3+n4",
+            *long_rebar_bot[1],
             "d",
             "c/d",
             "As,min",
@@ -594,8 +628,7 @@ def _initialize_dicts_ACI_318_19_flexure(self: "RectangularBeam") -> None:
             "DCR",
         ],
         "Value": [
-            self._format_longitudinal_rebar_string(self._n1_b, self._d_b1_b, self._n2_b, self._d_b2_b),
-            self._format_longitudinal_rebar_string(self._n3_b, self._d_b3_b, self._n4_b, self._d_b4_b),
+            *long_rebar_bot[2],
             round(self._d_bot.to("cm").magnitude, 2),
             round(self._c_d_bot, 4),
             round(self._A_s_min_bot.to("cm**2").magnitude, 2),
@@ -934,10 +967,10 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
     }
     check_DCR_top = "✅" if self._DCRb_top < 1 else "❌"
     check_DCR_bot = "✅" if self._DCRb_bot < 1 else "❌"
+    long_rebar_top = _longitudinal_rebar_rows(self, "t")
     self._flexure_capacity_top = {
         "Top reinforcement check": [
-            "First layer bars",
-            "Second layer bars",
+            *long_rebar_top[0],
             "Effective height",
             "Depth of equivalent strength block ratio",
             "Minimum rebar reinforcing",
@@ -949,8 +982,7 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
             "Demand Capacity Ratio",
         ],
         "Variable": [
-            "n1+n2",
-            "n3+n4",
+            *long_rebar_top[1],
             "d",
             "c/d",
             "As,min",
@@ -962,8 +994,7 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
             "DCR",
         ],
         "Value": [
-            self._format_longitudinal_rebar_string(self._n1_t, self._d_b1_t, self._n2_t, self._d_b2_t),
-            self._format_longitudinal_rebar_string(self._n3_t, self._d_b3_t, self._n4_t, self._d_b4_t),
+            *long_rebar_top[2],
             round(self._d_top.to("cm").magnitude, 2),
             self._c_d_top,
             round(self._A_s_min_top.to("cm**2").magnitude, 2),
@@ -988,10 +1019,10 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
             check_DCR_top,
         ],
     }
+    long_rebar_bot = _longitudinal_rebar_rows(self, "b")
     self._flexure_capacity_bot = {
         "Bottom reinforcement check": [
-            "First layer bars",
-            "Second layer bars",
+            *long_rebar_bot[0],
             "Effective height",
             "Depth of equivalent strength block ratio",
             "Minimum rebar reinforcing",
@@ -1003,8 +1034,7 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
             "Demand Capacity Ratio",
         ],
         "Variable": [
-            "n1+n2",
-            "n3+n4",
+            *long_rebar_bot[1],
             "d",
             "c/d",
             "As,min",
@@ -1016,8 +1046,7 @@ def _initialize_dicts_EN_1992_2004_flexure(self: "RectangularBeam") -> None:
             "DCR",
         ],
         "Value": [
-            self._format_longitudinal_rebar_string(self._n1_b, self._d_b1_b, self._n2_b, self._d_b2_b),
-            self._format_longitudinal_rebar_string(self._n3_b, self._d_b3_b, self._n4_b, self._d_b4_b),
+            *long_rebar_bot[2],
             round(self._d_bot.to("cm").magnitude, 2),
             self._c_d_bot,
             round(self._A_s_min_bot.to("cm**2").magnitude, 2),

--- a/mento/section.py
+++ b/mento/section.py
@@ -1,6 +1,6 @@
 import math
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, ClassVar, List, Optional
 
 from mento.material import Concrete, SteelBar
 from mento.forces import Forces
@@ -35,6 +35,18 @@ class Section:
         flexure_results_detailed_doc(force: Optional[Forces] = None): Provides detailed flexure results for documentation.
         results: Property to access beam results for Jupyter Notebook.
     """
+
+    #: How the element reaches the ground, in the terms the minimum
+    #: reinforcement clauses distinguish. ``"free"`` is anything spanning
+    #: between supports; ``"soil"`` is an element bearing directly on the
+    #: ground, which ACI 318-19 §9.6.1.1(b) exempts from the flexural minimum
+    #: written for a beam and EN 1992-1-1 reinforces to the halved geometric
+    #: minimum of a foundation instead.
+    #:
+    #: A ClassVar and not a field on purpose: it says what kind of element this
+    #: is, so it belongs to the class -- ``Footing`` sets it -- rather than
+    #: being a constructor argument any beam could be handed.
+    support: ClassVar[str] = "free"
 
     concrete: Concrete = field(kw_only=True)
     steel_bar: SteelBar = field(kw_only=True)

--- a/mento/slab.py
+++ b/mento/slab.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, ClassVar, TYPE_CHECKING, cast
+from typing import Any, Callable, ClassVar, TYPE_CHECKING, cast
 from dataclasses import dataclass
 import math
 import warnings
@@ -9,6 +9,9 @@ import numpy as np
 from mento.beam import RectangularBeam
 from mento.codes.registry import design_code
 from mento.units import m, mm, cm, inch
+
+#: Area unit the mat search works in, built once.
+_MM2 = mm**2
 
 if TYPE_CHECKING:
     from pint import Quantity
@@ -361,44 +364,158 @@ class Footing(OneWaySlab):
     #: What makes it a footing, and the only thing the design codes read.
     support: ClassVar[str] = "soil"
 
+    #: The thinnest bar a footing mat is detailed with, whatever the catalogue
+    #: holds below it. Practice rather than code: a mesh finer than this is not
+    #: what goes down over the ground, and the search below would otherwise
+    #: reach for it to shave the lightly loaded face.
+    _MIN_MAT_DIAMETER = 10 * mm
+
     def __post_init__(self) -> None:
         super().__post_init__()
+        if self.concrete.unit_system == "metric":
+            self.settings.minimum_longitudinal_diameter = max(
+                self.settings.minimum_longitudinal_diameter, self._MIN_MAT_DIAMETER
+            )
         self._warn_if_thinner_than_the_code_allows()
 
     #: The layers a mat is placed in, as (diameter attribute, spacing attribute).
     _MAT_LAYERS = (("_d_b1_b", "_s_b1_b"), ("_d_b3_b", "_s_b3_b"), ("_d_b1_t", "_s_b1_t"), ("_d_b3_t", "_s_b3_t"))
 
-    def _finalize_longitudinal_design(self) -> None:
-        """Detail both faces at one spacing, the smaller of the two designed.
+    #: How many candidate mats are verified before falling back. They are tried
+    #: lightest first, so the first is almost always the answer; the budget only
+    #: bounds the cost when the lightest ones do not verify.
+    _MAT_CANDIDATES = 12
+
+    def _finalize_longitudinal_design(
+        self,
+        A_req_bot: Quantity,
+        A_req_top: Quantity,
+        resists: Callable[[], bool],
+    ) -> None:
+        """Detail both faces as one mat, at the least steel that still covers them.
 
         A footing is not built as two independently detailed faces. The bars go
-        down as one mat: the bottom grid is placed, the top grid is placed over
-        it on the same module, and the two are tied at the same spacing. A
-        design that answered the bottom at 120 mm and the top at 250 mm is not
-        a drawing anyone details, so the two are reconciled here into the one
-        number the mat is set out at.
+        down as one grid: the bottom is placed, the top is placed over it, and
+        the two are tied. The module has to be one number, and on a drawing the
+        top sits either at the bottom spacing or at exactly twice it, so that
+        one top bar lands on every second bottom bar.
 
-        The *smaller* of the two, because that is the only direction that is
-        safe: it adds bars to the face that had the wider spacing, so every
-        face still covers the area its own moment asked for.
+        Reconciling the two spacings the design arrived at is not enough. The
+        face governed by the minimum is detailed as many thin bars, which comes
+        out closer than the few thick bars the loaded face needs, so simply
+        taking the smaller of the two often closes the *loaded* face up and buys
+        steel nobody asked for -- about 20% more than the two faces actually
+        need, measured across a range of typical footings.
 
-        Which face sets the module is not always the one carrying the moment.
-        A face governed by the minimum is detailed as many thin bars, and that
-        comes out at a closer spacing than the few thick bars the governing
-        face needs -- under ACI, whose minimum is the larger of the two codes',
-        the top face sets the module about half the time and closes the bottom
-        up with it. The section is then further from its own optimum than the
-        wider spacing would have left it, and measurably so: about 12% more
-        longitudinal steel across a range of typical footings. That is what
-        detailing a mat costs, and what the drawing would have shown anyway.
+        So the mat is chosen rather than reconciled: over the spacings the code
+        allows and the bars the catalogue holds, the lightest combination of
+        module and two diameters -- with the top at ``s`` or ``2s`` -- that
+        covers what each face requires. That lands within about 7% (EN) to 11%
+        (ACI) of the two faces' own requirement, against the 20% of taking the
+        smaller.
 
-        Only the spacing is reconciled. The diameters stay as the design chose
-        them, so the two faces can differ there -- it is the module the mat is
-        set out at that has to be one number, not the bar.
+        Every candidate is verified before it is kept, because the choice feeds
+        back into itself: a thicker bar sits deeper, which lowers the effective
+        depth and raises the area the face needed in the first place. Anything
+        that fails to resist the moments is passed over, and if nothing within
+        the budget verifies, the design falls back to reconciling the two
+        spacings it had already proved.
 
-        A face with no reinforcement is left with none: a footing reinforced on
-        the bottom only has no second grid to match, and inventing one is not
-        this method's call.
+        Args:
+            A_req_bot: Steel the bottom face has to carry, minimum included.
+            A_req_top: The same for the top; zero when it carries none.
+            resists: Whether the layout now on the section resists both design
+                moments.
+        """
+        snapshot = [(name, getattr(self, name)) for pair in self._MAT_LAYERS for name in pair]
+        for spacing, diameter in self._mat_candidates(A_req_bot, A_req_top):
+            self._apply_mat(spacing, diameter)
+            if resists():
+                return
+
+        for name, value in snapshot:
+            setattr(self, name, value)
+        self._calculate_longitudinal_rebars()
+        self._update_longitudinal_rebar_attributes()
+        self._match_spacings_downward()
+
+    def _mat_candidates(self, A_req_bot: Quantity, A_req_top: Quantity) -> Any:
+        """The mats worth trying, lightest first, as (spacings, diameters)."""
+        needed_bot = A_req_bot.to(_MM2).magnitude if A_req_bot is not None else 0.0
+        needed_top = A_req_top.to(_MM2).magnitude if A_req_top is not None else 0.0
+        if needed_bot <= 0 and needed_top <= 0:
+            return
+
+        limit_max = self._max_bar_spacing()
+        if limit_max is None:
+            return  # a code that caps nothing gives the search no space to work in
+        limit_min = self._min_bar_spacing()
+
+        width = self.width.to(mm).magnitude
+        clear = self.settings.clear_spacing.to(mm).magnitude
+        # The unit a spacing is drawn in, so the module is one a detailer writes.
+        step = 10.0 if self.concrete.unit_system == "metric" else 25.4
+        s_lo = step if limit_min is None else limit_min.to(mm).magnitude
+        s_hi = limit_max.to(mm).magnitude
+
+        rebar = self._create_rebar_designer()
+        bars = [
+            (d.to(mm).magnitude, rebar.rebar_areas[d].to(_MM2).magnitude)
+            for d in rebar.rebar_diameters
+            if self.settings.minimum_longitudinal_diameter <= d <= self.settings.max_longitudinal_diameter
+        ]
+
+        def grid(spacing: float, needed: float) -> Any:
+            """The lightest bar that covers ``needed`` at ``spacing``, or None."""
+            if needed <= 0:
+                return (0.0, 0.0)
+            n = math.ceil(width / spacing)
+            covering = [(n * area, d) for d, area in bars if spacing - d >= clear and n * area >= needed]
+            return min(covering) if covering else None
+
+        found = []
+        for k in range(math.ceil(s_lo / step), math.floor(s_hi / step) + 1):
+            s_bot = k * step
+            bottom = grid(s_bot, needed_bot)
+            if bottom is None:
+                continue
+            for factor in (1, 2):
+                s_top = s_bot * factor
+                if s_top > s_hi:
+                    continue
+                top = grid(s_top, needed_top)
+                if top is None:
+                    continue
+                # Lightest first; among equals the wider module, which is the
+                # cheaper mat to place for the same steel.
+                found.append((bottom[0] + top[0], -s_bot, (s_bot, s_top), (bottom[1], top[1])))
+
+        for _, _, spacing, diameter in sorted(found)[: self._MAT_CANDIDATES]:
+            yield spacing, diameter
+
+    def _apply_mat(self, spacing: Any, diameter: Any) -> None:
+        """Place a single-layer grid on each face, clearing any second layer."""
+        s_bot, s_top = spacing
+        d_bot, d_top = diameter
+        # A face that needs no steel gets no grid at all -- not a spacing with a
+        # zero bar on it, which reads as a grid everywhere it is reported and
+        # would put a row of nothing on the drawing.
+        s_bot = s_bot if d_bot > 0 else 0.0
+        s_top = s_top if d_top > 0 else 0.0
+        self._d_b1_b, self._s_b1_b = d_bot * mm, s_bot * mm
+        self._d_b1_t, self._s_b1_t = d_top * mm, s_top * mm
+        self._d_b3_b, self._s_b3_b = self._zero_diameter(), 0 * cm
+        self._d_b3_t, self._s_b3_t = self._zero_diameter(), 0 * cm
+        self._calculate_longitudinal_rebars()
+        self._update_longitudinal_rebar_attributes()
+
+    def _match_spacings_downward(self) -> None:
+        """Fallback: reconcile the spacings the design arrived at, taking the
+        smaller of the two.
+
+        Safe by construction -- it only ever adds bars to the face that had the
+        wider spacing -- and needs no verification for that reason, which is
+        what makes it the thing to fall back to when no searched mat verifies.
         """
         placed = [
             (diameter, spacing)

--- a/mento/slab.py
+++ b/mento/slab.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, TYPE_CHECKING
+from typing import Any, ClassVar, TYPE_CHECKING
 from dataclasses import dataclass
 import math
 import numpy as np
@@ -182,3 +182,48 @@ class OneWaySlab(RectangularBeam):
         # --- TOP REBAR ---
         self._n1_t = calculate_bars(self._s_b1_t, self.width)
         self._n3_t = calculate_bars(self._s_b3_t, self.width)
+
+
+@dataclass
+class Footing(OneWaySlab):
+    """A spread footing or raft: a one-way slab bearing directly on the ground.
+
+    Everything about it is a :class:`OneWaySlab` -- the same flexure and shear
+    checks, the same reinforcement given as diameter and spacing -- with one
+    difference, and it is a difference the design codes make rather than this
+    class: the minimum longitudinal reinforcement.
+
+    A member spanning between supports is given a minimum sized to keep it from
+    failing the instant it cracks. A member on the ground cannot fail that way,
+    because the soil goes on carrying it, so both codes exempt it and put a
+    different rule in place:
+
+    * ACI 318-19 §9.6.1.1(b) grants the exemption and §13.3.1.2 replaces the
+      flexural minimum with the shrinkage and temperature reinforcement of
+      §24.4.3.2 -- 0.0018*b*h at f_y = 420 MPa, on the gross section. CIRSOC
+      201-25 shares the clause.
+    * EN 1992-1-1 takes the larger of the halved geometric minimum of a
+      foundation and the crack-control minimum of §7.3.2(2), which is usually
+      the one that governs a thick footing.
+
+    Both are returned already resolved to the largest applicable minimum, so a
+    caller designs a footing and takes the answer as it comes.
+
+    Example::
+
+        footing = Footing(
+            label="Z1", concrete=concrete, steel_bar=steel,
+            width=1 * m, height=60 * cm, c_c=50 * mm,
+        )
+        Node(section=footing, forces=[Forces(M_y=120 * kNm)]).design()
+
+    Note:
+        The rest of the footing's rules are the engineer's: this class does not
+        check the minimum thickness (200 mm in ACI, 250 mm in common EN
+        practice) or the 100-300 mm bar spacing range, and it says nothing
+        about the soil below -- bearing pressure, punching and sliding are not
+        part of a section design.
+    """
+
+    #: What makes it a footing, and the only thing the design codes read.
+    support: ClassVar[str] = "soil"

--- a/mento/slab.py
+++ b/mento/slab.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 from typing import Any, ClassVar, TYPE_CHECKING, cast
 from dataclasses import dataclass
 import math
+import warnings
+
 import numpy as np
 
 from mento.beam import RectangularBeam
@@ -42,6 +44,13 @@ class OneWaySlab(RectangularBeam):
 
         # Allow slabs to place as many bars as minimum spacing permits
         self.settings.max_bars_per_layer = max(self.settings.max_bars_per_layer, 200)
+        # ... and no more than the code's own minimum spacing permits, which is
+        # the only way that limit can be enforced: the rebar search chooses a
+        # bar count, and the spacing is what that count implies. Capping the
+        # count is capping the spacing from below.
+        minimum = self._min_bar_spacing()
+        if minimum is not None:
+            self.settings.max_bars_per_layer = max(1, int(self.width / minimum))
         # Force same diameter for all bars within a layer
         self.settings.max_diameter_diff = 0 * self.settings.max_diameter_diff
 
@@ -147,6 +156,17 @@ class OneWaySlab(RectangularBeam):
         """
         limit = design_code(self.concrete).max_bar_spacing_slab
         return None if limit is None else cast("Quantity", limit(self))
+
+    def _min_bar_spacing(self) -> Quantity | None:
+        """The smallest spacing the design code asks for between the flexural bars.
+
+        Distinct from the clear distance in :class:`~mento.settings.BeamSettings`,
+        which every section has and which is about fitting a bar and a vibrator
+        between two others. This is the code's own floor, and only a footing has
+        one; a slab spanning between supports returns ``None``.
+        """
+        limit = design_code(self.concrete).min_bar_spacing_slab
+        return None if limit is None else cast("Quantity | None", limit(self))
 
     def _spacing_for_bars(self, n: int) -> Quantity:
         """The spacing that puts ``n`` bars across the strip, as it would be drawn.
@@ -324,13 +344,42 @@ class Footing(OneWaySlab):
         )
         Node(section=footing, forces=[Forces(M_y=120 * kNm)]).design()
 
+    It is also detailed differently, which the same ``support`` tells the codes:
+    the bars are kept between 100 and 300 mm apart, and a footing thinner than
+    its code allows says so when it is built.
+
     Note:
-        The rest of the footing's rules are the engineer's: this class does not
-        check the minimum thickness (200 mm in ACI, 250 mm in common EN
-        practice) or the 100-300 mm bar spacing range, and it says nothing
-        about the soil below -- bearing pressure, punching and sliding are not
+        A `Footing` designs the section, not the foundation. It says nothing
+        about the soil below it -- bearing pressure, punching (see
+        :class:`~mento.punching.PunchingSlab`), sliding and overturning are not
         part of a section design.
     """
 
     #: What makes it a footing, and the only thing the design codes read.
     support: ClassVar[str] = "soil"
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self._warn_if_thinner_than_the_code_allows()
+
+    def _warn_if_thinner_than_the_code_allows(self) -> None:
+        """Say so when the section is thinner than a footing is built.
+
+        A warning and not an error: the thickness is the engineer's to choose,
+        and the design that follows is still the right design for the section
+        it was given. Raising would refuse to answer a question that has an
+        answer.
+        """
+        minimum = design_code(self.concrete).min_thickness_on_soil
+        if minimum is None:
+            return
+        limit = cast("Quantity", minimum(self.concrete))
+        if self.height < limit:
+            label = f" {self.label}" if self.label else ""
+            warnings.warn(
+                f"Footing{label} is {self.height:.4g~P} thick, below the "
+                f"{limit:.4g~P} {self.concrete.design_code} asks of a footing on soil. "
+                "It is designed as given.",
+                UserWarning,
+                stacklevel=3,
+            )

--- a/mento/slab.py
+++ b/mento/slab.py
@@ -11,6 +11,18 @@ if TYPE_CHECKING:
     from pint import Quantity
 
 
+def _bars_at_spacing(spacing: Quantity, width: Quantity) -> int:
+    """How many bars a strip of ``width`` carries at a centre-to-centre ``spacing``.
+
+    The one place the count-from-spacing rule lives, so that a spacing chosen
+    for a given number of bars can be checked against the count it produces.
+    """
+    if spacing == 0 * mm:
+        return 0  # Default to 0 bars if spacing is zero
+    # Round up to ensure full bars (e.g., 3.2 bars → 4 bars)
+    return int(np.ceil((width.to("cm").magnitude / spacing.to("cm").magnitude)))  # Returns dimensionless count
+
+
 @dataclass
 class OneWaySlab(RectangularBeam):
     """
@@ -120,6 +132,87 @@ class OneWaySlab(RectangularBeam):
             s_trans=design["s_w"],
         )
 
+    def _zero_diameter(self) -> Quantity:
+        """A bar diameter of zero, in the length unit of this slab."""
+        return 0 * mm if self.concrete.unit_system == "metric" else 0 * inch
+
+    def _spacing_for_bars(self, n: int) -> Quantity:
+        """The spacing that puts ``n`` bars across the strip, as it would be drawn.
+
+        The exact answer is ``width / n``, which is rarely a number anyone
+        details to, so it is rounded to the whole centimetre (inch). Rounding up
+        is what usually keeps the layout the search chose -- the count comes
+        back as ``ceil(width / s)``, so a slightly wider spacing still asks for
+        the same ``n`` bars, while a narrower one would silently add one -- but
+        it is checked rather than assumed, because it does not always hold.
+        """
+        if n <= 0:
+            return 0 * cm
+        unit = cm if self.concrete.unit_system == "metric" else inch
+        exact = (self.width / n).to(unit).magnitude
+        spacing = math.ceil(exact) * unit
+        if _bars_at_spacing(spacing, self.width) < n:
+            # Rounding up costs a bar once the bars are close enough that a whole
+            # centimetre spans more than one of them -- from about eleven bars in
+            # a metre. Round down there instead: that can only ask for more bars
+            # than the design chose, never fewer, so the strip is never detailed
+            # with less steel than it needs. (The floor is only ever zero at a
+            # spacing below one centimetre, where the bars would already overlap.)
+            spacing = max(math.floor(exact), 1) * unit
+        return spacing
+
+    def _layer_from_design(self, design: Any, first: int, second: int) -> tuple[Quantity, Quantity]:
+        """The diameter and spacing of the layer a design gives as two bar groups."""
+        n_first = int(design.get(f"n_{first}", 0) or 0)
+        n_second = int(design.get(f"n_{second}", 0) or 0)
+        # A slab is searched with max_diameter_diff = 0, so a layer only ever
+        # comes back with one diameter: whichever group carries the bars.
+        d_b = design.get(f"d_b{first}") if n_first > 0 else design.get(f"d_b{second}")
+        if d_b is None or d_b.magnitude == 0:
+            return self._zero_diameter(), 0 * cm
+        return d_b, self._spacing_for_bars(n_first + n_second)
+
+    def _apply_longitudinal_design(self, design: Any, face: str) -> None:
+        """Apply a design given in bar counts to a face, as a spacing per layer.
+
+        The rebar search is the beam's -- a slab is not worth a second one --
+        and it answers with groups of bars: ``n_1`` and ``n_2`` are the layer
+        nearest the face, ``n_3`` and ``n_4`` the one behind it. A slab is not
+        detailed that way; it is a diameter repeated at a spacing. So each
+        layer is spread over the strip here, and the spacings are what the slab
+        stores. Applying the design the beam's way left the bars split across
+        two groups that are really one layer, and left the spacings -- the only
+        thing a slab is drawn with -- empty.
+        """
+        d_b1, s_b1 = self._layer_from_design(design, 1, 2)
+        d_b3, s_b3 = self._layer_from_design(design, 3, 4)
+        setattr(self, f"_d_b1_{face}", d_b1)
+        setattr(self, f"_s_b1_{face}", s_b1)
+        setattr(self, f"_d_b3_{face}", d_b3)
+        setattr(self, f"_s_b3_{face}", s_b3)
+        self._calculate_longitudinal_rebars()
+        self._update_longitudinal_rebar_attributes()
+
+    def _apply_longitudinal_design_bot(self, design: Any) -> None:
+        """See :meth:`_apply_longitudinal_design`."""
+        self._apply_longitudinal_design(design, "b")
+
+    def _apply_longitudinal_design_top(self, design: Any) -> None:
+        """See :meth:`_apply_longitudinal_design`."""
+        self._apply_longitudinal_design(design, "t")
+
+    def _clear_top_longitudinal(self) -> None:
+        """Clear the top face, its spacings included.
+
+        A beam clears a face by zeroing the bar counts. On a slab those counts
+        are derived from the spacings, so a spacing left behind would put the
+        bars back the next time any layer is recalculated.
+        """
+        self._d_b1_t, self._s_b1_t = self._zero_diameter(), 0 * cm
+        self._d_b3_t, self._s_b3_t = self._zero_diameter(), 0 * cm
+        self._calculate_longitudinal_rebars()
+        self._update_longitudinal_rebar_attributes()
+
     def set_slab_longitudinal_rebar_bot(
         self,
         d_b1: Quantity = 0 * mm,
@@ -168,17 +261,10 @@ class OneWaySlab(RectangularBeam):
     def _calculate_longitudinal_rebars(self) -> None:
         """Calculate the total rebar area for a slab, given spacing and slab width."""
 
-        # Helper function: Calculate number of bars given spacing and slab width
-        def calculate_bars(spacing: Quantity, width: Quantity) -> int:
-            if spacing == 0 * mm:
-                return 0  # Default to 0 bars if spacing is zero
-            # Round up to ensure full bars (e.g., 3.2 bars → 4 bars)
-            return int(np.ceil((width.to("cm").magnitude / spacing.to("cm").magnitude)))  # Returns dimensionless count
-
         # --- BOTTOM REBAR ---
-        self._n1_b = calculate_bars(self._s_b1_b, self.width)
-        self._n3_b = calculate_bars(self._s_b3_b, self.width)
+        self._n1_b = _bars_at_spacing(self._s_b1_b, self.width)
+        self._n3_b = _bars_at_spacing(self._s_b3_b, self.width)
 
         # --- TOP REBAR ---
-        self._n1_t = calculate_bars(self._s_b1_t, self.width)
-        self._n3_t = calculate_bars(self._s_b3_t, self.width)
+        self._n1_t = _bars_at_spacing(self._s_b1_t, self.width)
+        self._n3_t = _bars_at_spacing(self._s_b3_t, self.width)

--- a/mento/slab.py
+++ b/mento/slab.py
@@ -346,7 +346,10 @@ class Footing(OneWaySlab):
 
     It is also detailed differently, which the same ``support`` tells the codes:
     the bars are kept between 100 and 300 mm apart, and a footing thinner than
-    its code allows says so when it is built.
+    its code allows says so when it is built. And because a footing is placed as
+    a single mat rather than as two independently detailed faces, a design ends
+    with both faces set out at one spacing -- see
+    :meth:`_finalize_longitudinal_design`.
 
     Note:
         A `Footing` designs the section, not the foundation. It says nothing
@@ -361,6 +364,52 @@ class Footing(OneWaySlab):
     def __post_init__(self) -> None:
         super().__post_init__()
         self._warn_if_thinner_than_the_code_allows()
+
+    #: The layers a mat is placed in, as (diameter attribute, spacing attribute).
+    _MAT_LAYERS = (("_d_b1_b", "_s_b1_b"), ("_d_b3_b", "_s_b3_b"), ("_d_b1_t", "_s_b1_t"), ("_d_b3_t", "_s_b3_t"))
+
+    def _finalize_longitudinal_design(self) -> None:
+        """Detail both faces at one spacing, the smaller of the two designed.
+
+        A footing is not built as two independently detailed faces. The bars go
+        down as one mat: the bottom grid is placed, the top grid is placed over
+        it on the same module, and the two are tied at the same spacing. A
+        design that answered the bottom at 120 mm and the top at 250 mm is not
+        a drawing anyone details, so the two are reconciled here into the one
+        number the mat is set out at.
+
+        The *smaller* of the two, because that is the only direction that is
+        safe: it adds bars to the face that had the wider spacing, so each face
+        still covers the area its own moment asked for, and the face that
+        governed keeps exactly the spacing it needed. The lightly loaded face
+        therefore ends up with more steel than its own moment required, which
+        is what detailing a mat costs and what the drawing would have shown
+        anyway.
+
+        Only the spacing is reconciled. The diameters stay as the design chose
+        them, so the two faces can differ there -- it is the module the mat is
+        set out at that has to be one number, not the bar.
+
+        A face with no reinforcement is left with none: a footing reinforced on
+        the bottom only has no second grid to match, and inventing one is not
+        this method's call.
+        """
+        placed = [
+            (diameter, spacing)
+            for diameter, spacing in self._MAT_LAYERS
+            if getattr(self, diameter).magnitude > 0 and getattr(self, spacing).magnitude > 0
+        ]
+        if len(placed) < 2:
+            return  # one grid, or none: nothing to reconcile
+
+        module = min(getattr(self, spacing) for _, spacing in placed)
+        if all(getattr(self, spacing) == module for _, spacing in placed):
+            return  # already one mat
+
+        for _, spacing in placed:
+            setattr(self, spacing, module)
+        self._calculate_longitudinal_rebars()
+        self._update_longitudinal_rebar_attributes()
 
     def _warn_if_thinner_than_the_code_allows(self) -> None:
         """Say so when the section is thinner than a footing is built.

--- a/mento/slab.py
+++ b/mento/slab.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, cast
 from dataclasses import dataclass
 import math
 import numpy as np
 
 from mento.beam import RectangularBeam
+from mento.codes.registry import design_code
 from mento.units import m, mm, cm, inch
 
 if TYPE_CHECKING:
@@ -136,6 +137,17 @@ class OneWaySlab(RectangularBeam):
         """A bar diameter of zero, in the length unit of this slab."""
         return 0 * mm if self.concrete.unit_system == "metric" else 0 * inch
 
+    def _max_bar_spacing(self) -> Quantity | None:
+        """The largest spacing the design code allows between the flexural bars.
+
+        ACI 318-19 7.7.2.3 and EN 1992-1-1 9.3.1.1(3) both cap it as a multiple
+        of the thickness, which is what keeps a slab from being detailed as a
+        handful of widely spaced bars that happen to add up to the area. A code
+        that states no such limit returns ``None``.
+        """
+        limit = design_code(self.concrete).max_bar_spacing_slab
+        return None if limit is None else cast("Quantity", limit(self))
+
     def _spacing_for_bars(self, n: int) -> Quantity:
         """The spacing that puts ``n`` bars across the strip, as it would be drawn.
 
@@ -144,7 +156,9 @@ class OneWaySlab(RectangularBeam):
         is what usually keeps the layout the search chose -- the count comes
         back as ``ceil(width / s)``, so a slightly wider spacing still asks for
         the same ``n`` bars, while a narrower one would silently add one -- but
-        it is checked rather than assumed, because it does not always hold.
+        it is checked rather than assumed, because it does not always hold. The
+        result is then capped at what the code allows between the bars of a
+        slab, which only ever asks for more of them.
         """
         if n <= 0:
             return 0 * cm
@@ -159,6 +173,13 @@ class OneWaySlab(RectangularBeam):
             # with less steel than it needs. (The floor is only ever zero at a
             # spacing below one centimetre, where the bars would already overlap.)
             spacing = max(math.floor(exact), 1) * unit
+        limit = self._max_bar_spacing()
+        if limit is not None:
+            # The area the search asked for is not the only thing the layout has
+            # to satisfy: bars far enough apart leave the slab between them
+            # unreinforced whatever they add up to. Capping the spacing only
+            # ever adds bars, so the area is still covered.
+            spacing = min(spacing, math.floor(limit.to(unit).magnitude) * unit)
         return spacing
 
     def _layer_from_design(self, design: Any, first: int, second: int) -> tuple[Quantity, Quantity]:

--- a/mento/slab.py
+++ b/mento/slab.py
@@ -379,12 +379,18 @@ class Footing(OneWaySlab):
         number the mat is set out at.
 
         The *smaller* of the two, because that is the only direction that is
-        safe: it adds bars to the face that had the wider spacing, so each face
-        still covers the area its own moment asked for, and the face that
-        governed keeps exactly the spacing it needed. The lightly loaded face
-        therefore ends up with more steel than its own moment required, which
-        is what detailing a mat costs and what the drawing would have shown
-        anyway.
+        safe: it adds bars to the face that had the wider spacing, so every
+        face still covers the area its own moment asked for.
+
+        Which face sets the module is not always the one carrying the moment.
+        A face governed by the minimum is detailed as many thin bars, and that
+        comes out at a closer spacing than the few thick bars the governing
+        face needs -- under ACI, whose minimum is the larger of the two codes',
+        the top face sets the module about half the time and closes the bottom
+        up with it. The section is then further from its own optimum than the
+        wider spacing would have left it, and measurably so: about 12% more
+        longitudinal steel across a range of typical footings. That is what
+        detailing a mat costs, and what the drawing would have shown anyway.
 
         Only the spacing is reconciled. The diameters stay as the design chose
         them, so the two faces can differ there -- it is the module the mat is

--- a/tests/test_design_results.py
+++ b/tests/test_design_results.py
@@ -143,6 +143,15 @@ def test_rebar_layer_str_is_the_engineering_shorthand() -> None:
     assert str(RebarLayer(n=2, d_b=12 * mm)) == "2Ø12 mm"
 
 
+def test_a_layer_detailed_by_a_spacing_reads_as_one_bar_at_that_spacing() -> None:
+    """A slab layer carries a spacing; counting its bars is not how it is drawn."""
+    layer = RebarLayer(n=6, d_b=12 * mm, s=17 * cm)
+
+    assert str(layer) == "Ø12 mm/17 cm"
+    # The area is the bars either way.
+    assert layer.A_s.to("cm**2").magnitude == pytest.approx(6 * math.pi * (1.2**2) / 4)
+
+
 # ============================================================================
 # Reading results before running anything
 # ============================================================================

--- a/tests/test_footing.py
+++ b/tests/test_footing.py
@@ -1,0 +1,275 @@
+"""Footing: the minimum longitudinal reinforcement of a member on the ground.
+
+A :class:`~mento.slab.Footing` is a :class:`~mento.slab.OneWaySlab` in every
+respect but one, so these tests are about that one respect. They pin the two
+codes' minimum-reinforcement clauses to numbers, and they pin the property that
+motivated the class: the design returns the largest applicable minimum already
+applied, so a consumer never has to correct the engine's answer.
+"""
+
+import pytest
+
+from mento.codes.aci_318_19.equations import flexure as aci_flexure
+from mento.codes.en_1992_2004.equations import flexure as en_flexure
+from mento.forces import Forces
+from mento.material import (
+    Concrete_ACI_318_19,
+    Concrete_CIRSOC_201_25,
+    Concrete_EN_1992_2004,
+    SteelBar,
+)
+from mento.node import Node
+from mento.slab import Footing, OneWaySlab
+from mento.units import cm, inch, kNm, kip, m, mm, MPa, psi
+
+# A metre-wide strip 600 mm deep: the geometry of the reference case the
+# clauses below were verified against.
+_WIDTH = 1 * m
+_HEIGHT = 60 * cm
+_COVER = 50 * mm
+
+
+@pytest.fixture
+def steel_b500s() -> SteelBar:
+    return SteelBar(name="B500S", f_y=500 * MPa)
+
+
+def _strip(cls, concrete, steel, label, height=_HEIGHT):  # type: ignore[no-untyped-def]
+    return cls(
+        label=label,
+        concrete=concrete,
+        steel_bar=steel,
+        width=_WIDTH,
+        height=height,
+        c_c=_COVER,
+    )
+
+
+def _design(section, M_y=50 * kNm):  # type: ignore[no-untyped-def]
+    Node(section=section, forces=[Forces(label="C1", M_y=M_y)]).design()
+    return section
+
+
+# ---------------------------------------------------------------------------
+# The equations themselves
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "f_y, expected",
+    [
+        (420.0, 0.0018),  # the reference grade the table is written at
+        (500.0, 0.0018 * 420 / 500),  # scales inversely above it
+        (420.0 / 0.7, 0.0014),  # would scale below the floor, so the floor holds
+        (700.0, 0.0014),
+    ],
+)
+def test_aci_shrinkage_and_temperature_ratio(f_y: float, expected: float) -> None:
+    """ACI 318-19 Table 24.4.3.2, metric."""
+    assert aci_flexure.shrinkage_and_temperature_ratio(f_y) == pytest.approx(expected)
+
+
+def test_aci_shrinkage_and_temperature_ratio_imperial() -> None:
+    """The same table, anchored at 60 ksi instead of 420 MPa."""
+    assert aci_flexure.shrinkage_and_temperature_ratio(60000.0, is_imperial=True) == pytest.approx(0.0018)
+    assert aci_flexure.shrinkage_and_temperature_ratio(75000.0, is_imperial=True) == pytest.approx(0.00144)
+
+
+@pytest.mark.parametrize(
+    "h, expected",
+    [
+        (200.0, 1.00),  # saturated below 300 mm
+        (300.0, 1.00),
+        (600.0, 0.79),  # the reference case of the office
+        (800.0, 0.65),
+        (1200.0, 0.65),  # saturated above 800 mm
+    ],
+)
+def test_en_crack_control_coefficient_k(h: float, expected: float) -> None:
+    """EN 1992-1-1 §7.3.2(2): k interpolated with the depth."""
+    assert en_flexure.crack_control_coefficient_k(h) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "f_yk, expected",
+    [(300.0, 0.0010), (400.0, 0.0010), (450.0, 0.00095), (500.0, 0.0009), (600.0, 0.0009)],
+)
+def test_en_foundation_min_reinforcement_ratio(f_yk: float, expected: float) -> None:
+    assert en_flexure.foundation_min_reinforcement_ratio(f_yk) == pytest.approx(expected)
+
+
+def test_en_crack_control_min_reinforcement_is_equation_7_1() -> None:
+    """A_s,min * sigma_s = k_c * k * f_ct,eff * A_ct, rearranged."""
+    A_s_min = en_flexure.crack_control_min_reinforcement(0.4, 0.79, 2.56, 300_000.0, 500 / 1.15)
+    assert A_s_min == pytest.approx(0.4 * 0.79 * 2.56 * 300_000.0 / (500 / 1.15))
+
+
+# ---------------------------------------------------------------------------
+# ACI 318-19 and CIRSOC 201-25
+# ---------------------------------------------------------------------------
+
+
+def test_aci_footing_minimum_is_the_gross_section_rule() -> None:
+    """0.0018 * b * h at f_y = 420 MPa, and nothing about the effective depth."""
+    concrete = Concrete_ACI_318_19(name="H25", f_c=25 * MPa)
+    steel = SteelBar(name="ADN 420", f_y=420 * MPa)
+    footing = _design(_strip(Footing, concrete, steel, "Z1"))
+
+    expected = 0.0018 * (1000 * mm) * (600 * mm)
+    assert footing._A_s_min_bot.to("cm**2").magnitude == pytest.approx(expected.to("cm**2").magnitude)
+
+
+def test_aci_footing_minimum_is_lower_than_the_slab_minimum() -> None:
+    """The whole point of the exemption: §9.6.1.1(b) relieves a member on the
+    ground of the flexural minimum a slab spanning between supports carries."""
+    concrete = Concrete_ACI_318_19(name="H25", f_c=25 * MPa)
+    steel = SteelBar(name="ADN 420", f_y=420 * MPa)
+    footing = _design(_strip(Footing, concrete, steel, "Z1"))
+    slab = _design(_strip(OneWaySlab, concrete, steel, "L1"))
+
+    assert footing._A_s_min_bot < slab._A_s_min_bot
+
+
+def test_aci_footing_minimum_scales_with_the_steel_grade() -> None:
+    concrete = Concrete_ACI_318_19(name="H25", f_c=25 * MPa)
+    footing = _design(_strip(Footing, concrete, SteelBar(name="B500S", f_y=500 * MPa), "Z1"))
+
+    expected = 0.0018 * 420 / 500 * (1000 * mm) * (600 * mm)
+    assert footing._A_s_min_bot.to("cm**2").magnitude == pytest.approx(expected.to("cm**2").magnitude)
+
+
+def test_cirsoc_shares_the_aci_clause() -> None:
+    """CIRSOC 201-25 publishes ACI's formulas, this one included."""
+    steel = SteelBar(name="ADN 420", f_y=420 * MPa)
+    aci = _design(_strip(Footing, Concrete_ACI_318_19(name="H25", f_c=25 * MPa), steel, "Z1"))
+    cirsoc = _design(_strip(Footing, Concrete_CIRSOC_201_25(name="H25", f_c=25 * MPa), steel, "Z2"))
+
+    assert cirsoc._A_s_min_bot.to("cm**2").magnitude == pytest.approx(aci._A_s_min_bot.to("cm**2").magnitude)
+
+
+def test_aci_footing_minimum_in_imperial_units() -> None:
+    """Same clause, anchored at 60 ksi, and still written on b*h."""
+    concrete = Concrete_ACI_318_19(name="C4000", f_c=4000 * psi)
+    steel = SteelBar(name="G60", f_y=60000 * psi)
+    footing = Footing(
+        label="Z1",
+        concrete=concrete,
+        steel_bar=steel,
+        width=36 * inch,
+        height=24 * inch,
+        c_c=2 * inch,
+    )
+    _design(footing, M_y=40 * kip * inch)
+
+    expected = 0.0018 * 36 * 24  # in²
+    assert footing._A_s_min_bot.to("in**2").magnitude == pytest.approx(expected)
+
+
+def test_aci_footing_with_no_moment_still_gets_the_minimum() -> None:
+    """Shrinkage and temperature steel does not depend on a moment being there."""
+    concrete = Concrete_ACI_318_19(name="H25", f_c=25 * MPa)
+    steel = SteelBar(name="ADN 420", f_y=420 * MPa)
+    footing = _design(_strip(Footing, concrete, steel, "Z1"), M_y=0 * kNm)
+
+    expected = 0.0018 * (1000 * mm) * (600 * mm)
+    assert footing._A_s_bot.to("cm**2").magnitude >= expected.to("cm**2").magnitude
+
+
+# ---------------------------------------------------------------------------
+# EN 1992-2004
+# ---------------------------------------------------------------------------
+
+
+def test_en_footing_minimum_is_the_crack_control_rule(steel_b500s: SteelBar) -> None:
+    """The reference case: h = 600 mm, C25 (f_ctm = 2.56 MPa), B500S.
+
+    k = 0.79 at that depth, k_c = 0.40 in bending, A_ct is the half of the
+    section in tension and sigma_s is f_yd, so Eq. (7.1) gives the minimum --
+    and it is above the geometric one, so it governs.
+    """
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _design(_strip(Footing, concrete, steel_b500s, "Z1"))
+
+    f_ctm = concrete.f_ctm.to(MPa).magnitude
+    expected_mm2 = 0.4 * 0.79 * f_ctm * (1000 * 600 / 2) / (500 / 1.15)
+    geometric_mm2 = 0.0009 * 1000 * 600
+    assert expected_mm2 > geometric_mm2  # the crack-control rule is the governing one here
+
+    assert footing._A_s_min_bot.to("mm**2").magnitude == pytest.approx(expected_mm2)
+
+
+def test_en_footing_minimum_is_the_larger_of_the_two_rules(steel_b500s: SteelBar) -> None:
+    """Which of the two rules governs depends on the depth.
+
+    Both are proportional to h, so only k separates them: it decays past
+    300 mm, and by 900 mm it has saturated at 0.65 and the crack-control
+    minimum has fallen below the geometric one, which then governs.
+    """
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _design(_strip(Footing, concrete, steel_b500s, "Z1", height=90 * cm), M_y=100 * kNm)
+
+    f_ctm = concrete.f_ctm.to(MPa).magnitude
+    crack_mm2 = 0.4 * 0.65 * f_ctm * (1000 * 900 / 2) / (500 / 1.15)
+    geometric_mm2 = 0.0009 * 1000 * 900
+    assert geometric_mm2 > crack_mm2  # the geometric rule is the governing one here
+
+    assert footing._A_s_min_bot.to("mm**2").magnitude == pytest.approx(max(crack_mm2, geometric_mm2))
+
+
+def test_en_footing_minimum_is_lower_than_the_slab_minimum(steel_b500s: SteelBar) -> None:
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _design(_strip(Footing, concrete, steel_b500s, "Z1"))
+    slab = _design(_strip(OneWaySlab, concrete, steel_b500s, "L1"))
+
+    assert footing._A_s_min_bot < slab._A_s_min_bot
+
+
+# ---------------------------------------------------------------------------
+# What the class is, and what a design returns
+# ---------------------------------------------------------------------------
+
+
+def test_footing_is_a_one_way_slab(steel_b500s: SteelBar) -> None:
+    """Same reinforcement parameterisation, same checks -- only the minimum differs."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _strip(Footing, concrete, steel_b500s, "Z1")
+
+    assert isinstance(footing, OneWaySlab)
+    assert footing.mode == "slab"
+    assert hasattr(footing, "set_slab_longitudinal_rebar_bot")
+
+
+def test_support_says_which_clause_applies(steel_b500s: SteelBar) -> None:
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    assert _strip(Footing, concrete, steel_b500s, "Z1").support == "soil"
+    assert _strip(OneWaySlab, concrete, steel_b500s, "L1").support == "free"
+
+
+@pytest.mark.parametrize(
+    "concrete, steel",
+    [
+        (Concrete_ACI_318_19(name="H25", f_c=25 * MPa), SteelBar(name="ADN 420", f_y=420 * MPa)),
+        (Concrete_EN_1992_2004(name="C25", f_c=25 * MPa), SteelBar(name="B500S", f_y=500 * MPa)),
+    ],
+    ids=["aci", "en"],
+)
+def test_design_already_covers_the_minimum(concrete, steel) -> None:  # type: ignore[no-untyped-def]
+    """The reason this lives in mento: what the design returns needs no
+    correction by the consumer. A small moment is used so the minimum, and not
+    the demand, is what sizes the steel."""
+    footing = _design(_strip(Footing, concrete, steel, "Z1"), M_y=10 * kNm)
+
+    assert footing._A_s_bot >= footing._A_s_min_bot
+    assert footing._A_s_bot >= footing._A_s_req_bot
+
+
+def test_a_footing_still_carries_its_moment(steel_b500s: SteelBar) -> None:
+    """The relaxed minimum only ever relaxes the minimum: a demand above it is
+    still what governs, and the designed section resists it."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _strip(Footing, concrete, steel_b500s, "Z1")
+    combo = [Forces(label="C1", M_y=300 * kNm)]
+    Node(section=footing, forces=combo).design()
+
+    assert footing._A_s_bot > footing._A_s_min_bot
+    assert footing.flexure_check_results(combo)[0].bottom.DCR <= 1.0

--- a/tests/test_footing.py
+++ b/tests/test_footing.py
@@ -465,6 +465,7 @@ def test_a_code_without_the_footing_rules_imposes_none() -> None:
             **{f.name: getattr(reference, f.name) for f in dataclasses.fields(reference)},
             "title": "NBR 6118-2023",
             "year": 2023,
+            "max_bar_spacing_slab": None,
             "min_bar_spacing_slab": None,
             "min_thickness_on_soil": None,
         }
@@ -481,8 +482,12 @@ def test_a_code_without_the_footing_rules_imposes_none() -> None:
             footing = _strip(Footing, concrete, steel, "Z1", height=15 * cm)
 
         assert footing._min_bar_spacing() is None
+        assert footing._max_bar_spacing() is None
         # And the bar count is left at the slab default, since nothing bounds it.
         assert footing.settings.max_bars_per_layer >= 200
+        # With no bounds there is no space to search a mat in, so none is offered
+        # and the design keeps whatever the per-face search arrived at.
+        assert list(footing._mat_candidates(10 * cm**2, 5 * cm**2)) == []
     finally:
         _REGISTRY.pop(invented.title, None)
 
@@ -508,21 +513,24 @@ def _design_envelope(section, M_bot, M_top):  # type: ignore[no-untyped-def]
     ids=["aci", "en"],
 )
 def test_a_designed_footing_is_one_mat(concrete, steel) -> None:  # type: ignore[no-untyped-def]
-    """Both faces come out set out at the same spacing.
+    """Both faces come out on one module: the top at the bottom's spacing, or at
+    exactly twice it so one top bar lands on every second bottom bar.
 
     The bottom carries five times the top's moment here, so the two faces would
     otherwise be detailed at spacings nobody would draw on one mat.
     """
     footing, _ = _design_envelope(_strip(Footing, concrete, steel, "Z1"), 600 * kNm, 120 * kNm)
 
-    assert footing._s_b1_b.to("mm").magnitude == pytest.approx(footing._s_b1_t.to("mm").magnitude)
+    s_bot = footing._s_b1_b.to("mm").magnitude
+    s_top = footing._s_b1_t.to("mm").magnitude
+    assert s_top / s_bot in (1.0, 2.0)
 
 
-def test_the_mat_takes_the_smaller_of_the_two_spacings(steel_b500s: SteelBar) -> None:
-    """The face that governed keeps the spacing it needed; the other closes up
-    to it, which can only add bars.
+def test_the_fallback_takes_the_smaller_of_the_two_spacings(steel_b500s: SteelBar) -> None:
+    """What the design falls back to when no searched mat verifies.
 
-    Driven from a layout set by hand rather than from a design, so that the two
+    Closing the wider face up only ever adds bars, which is why it needs no
+    verification of its own. Driven from a layout set by hand, so that the two
     spacings going in are known and the rule can be read off the result.
     """
     concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
@@ -531,13 +539,25 @@ def test_the_mat_takes_the_smaller_of_the_two_spacings(steel_b500s: SteelBar) ->
     footing.set_slab_longitudinal_rebar_top(d_b1=12 * mm, s_b1=250 * mm)
     A_s_top_before = footing._A_s_top
 
-    footing._finalize_longitudinal_design()
+    footing._match_spacings_downward()
 
     assert footing._s_b1_b.to("mm").magnitude == pytest.approx(120.0)
     assert footing._s_b1_t.to("mm").magnitude == pytest.approx(120.0)
     # Closing the top up added bars, and left its bar alone.
     assert footing._A_s_top > A_s_top_before
     assert footing._d_b1_t.to("mm").magnitude == pytest.approx(12.0)
+
+
+def test_the_mat_is_lighter_than_reconciling_the_two_spacings(steel_b500s: SteelBar) -> None:
+    """Why the search exists: taking the smaller of the two spacings buys steel
+    the section never asked for, and choosing the module instead does not."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    searched, _ = _design_envelope(_strip(Footing, concrete, steel_b500s, "Z1"), 600 * kNm, 120 * kNm)
+
+    reconciled, _ = _design_envelope(_strip(Footing, concrete, steel_b500s, "Z2"), 600 * kNm, 120 * kNm)
+    reconciled._match_spacings_downward()
+
+    assert searched._A_s_bot + searched._A_s_top <= reconciled._A_s_bot + reconciled._A_s_top
 
 
 def test_matching_the_mat_never_undoes_the_design(steel_b500s: SteelBar) -> None:
@@ -562,13 +582,23 @@ def test_the_mat_keeps_each_face_within_the_spacing_range(steel_b500s: SteelBar)
         assert 100.0 <= spacing.to("mm").magnitude <= 300.0
 
 
-def test_the_diameters_are_left_as_designed(steel_b500s: SteelBar) -> None:
+def test_each_face_keeps_its_own_diameter(steel_b500s: SteelBar) -> None:
     """Only the module is shared. A face carrying a fifth of the moment is
     still allowed its own, thinner bar."""
     concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
     footing, _ = _design_envelope(_strip(Footing, concrete, steel_b500s, "Z1"), 600 * kNm, 120 * kNm)
 
-    assert footing._d_b1_t < footing._d_b1_b
+    assert footing._d_b1_t <= footing._d_b1_b
+
+
+def test_no_mat_is_detailed_below_the_practical_bar(steel_b500s: SteelBar) -> None:
+    """A footing mesh is not drawn with the thinnest bar in the catalogue, even
+    where the arithmetic would allow it on the lightly loaded face."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing, _ = _design_envelope(_strip(Footing, concrete, steel_b500s, "Z1"), 600 * kNm, 20 * kNm)
+
+    assert footing._d_b1_t.to("mm").magnitude >= 10.0
+    assert footing._d_b1_b.to("mm").magnitude >= 10.0
 
 
 def test_a_footing_reinforced_on_one_face_gets_no_second_grid(steel_b500s: SteelBar) -> None:
@@ -590,12 +620,113 @@ def test_a_slab_still_details_its_faces_independently(steel_b500s: SteelBar) -> 
     assert slab._s_b1_b != slab._s_b1_t
 
 
-def test_matching_is_idempotent(steel_b500s: SteelBar) -> None:
-    """Running it on a mat that is already one leaves it alone."""
+def test_reconciling_an_existing_mat_is_a_no_op(steel_b500s: SteelBar) -> None:
+    """The fallback run on a mat that is already one leaves it alone."""
     concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
-    footing, _ = _design_envelope(_strip(Footing, concrete, steel_b500s, "Z1"), 600 * kNm, 120 * kNm)
+    footing = _strip(Footing, concrete, steel_b500s, "Z1")
+    footing.set_slab_longitudinal_rebar_bot(d_b1=16 * mm, s_b1=150 * mm)
+    footing.set_slab_longitudinal_rebar_top(d_b1=12 * mm, s_b1=150 * mm)
     before = (footing._s_b1_b, footing._s_b1_t, footing._A_s_bot, footing._A_s_top)
 
-    footing._finalize_longitudinal_design()
+    footing._match_spacings_downward()
 
     assert (footing._s_b1_b, footing._s_b1_t, footing._A_s_bot, footing._A_s_top) == before
+
+
+def test_the_top_may_be_set_out_at_twice_the_bottom(steel_b500s: SteelBar) -> None:
+    """The modular option is real and gets used.
+
+    A top face carrying a tenth of the bottom's moment is drawn at double the
+    bottom's module -- one top bar on every second bottom bar -- rather than
+    matched to it and given steel it has no use for.
+    """
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    doubled = 0
+    for h, M_bot, M_top in [(50, 300, 30), (60, 400, 40), (40, 200, 20), (70, 600, 60)]:
+        footing, _ = _design_envelope(
+            _strip(Footing, concrete, steel_b500s, "Z1", height=h * cm), M_bot * kNm, M_top * kNm
+        )
+        ratio = footing._s_b1_t.to("mm").magnitude / footing._s_b1_b.to("mm").magnitude
+        assert ratio in (1.0, 2.0)
+        doubled += ratio == 2.0
+
+    assert doubled, "the double module was never taken, so the option is not doing anything"
+
+
+# ---------------------------------------------------------------------------
+# The edges of the mat search
+# ---------------------------------------------------------------------------
+
+
+def test_a_section_needing_nothing_is_offered_no_mat(steel_b500s: SteelBar) -> None:
+    """No steel required on either face is not a mat problem."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _strip(Footing, concrete, steel_b500s, "Z1")
+
+    assert list(footing._mat_candidates(0 * cm**2, 0 * cm**2)) == []
+
+
+def test_a_face_no_bar_can_cover_drops_that_module(steel_b500s: SteelBar) -> None:
+    """A top face wanting more steel than the widest module can carry does not
+    veto the search -- that module is simply not one of the candidates."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _strip(Footing, concrete, steel_b500s, "Z1")
+
+    # 60 cm² over the four bars a 300 mm module fits in the strip is beyond any
+    # bar in the catalogue, so the wide modules drop out and the close ones stay.
+    candidates = list(footing._mat_candidates(20 * cm**2, 60 * cm**2))
+    assert candidates
+    assert all(s_top <= 150 for (_, s_top), _ in candidates)
+
+
+def test_the_fallback_leaves_a_single_grid_alone(steel_b500s: SteelBar) -> None:
+    """Reconciling needs two grids; with one there is nothing to reconcile."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _strip(Footing, concrete, steel_b500s, "Z1")
+    footing.set_slab_longitudinal_rebar_bot(d_b1=16 * mm, s_b1=150 * mm)
+    before = (footing._s_b1_b, footing._d_b1_b, footing._A_s_bot)
+
+    footing._match_spacings_downward()
+
+    assert (footing._s_b1_b, footing._d_b1_b, footing._A_s_bot) == before
+
+
+def test_a_mat_that_does_not_verify_is_passed_over(steel_b500s: SteelBar) -> None:
+    """The search proposes, the capacity check disposes.
+
+    Driven with a verifier that refuses everything, so the design falls back to
+    reconciling the two spacings it had already proved -- which is the point of
+    keeping that rule around.
+    """
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _strip(Footing, concrete, steel_b500s, "Z1")
+    footing.set_slab_longitudinal_rebar_bot(d_b1=16 * mm, s_b1=120 * mm)
+    footing.set_slab_longitudinal_rebar_top(d_b1=12 * mm, s_b1=250 * mm)
+
+    footing._finalize_longitudinal_design(20 * cm**2, 5 * cm**2, lambda: False)
+
+    # Not a searched mat: the layout it started from, with the spacings matched.
+    assert footing._d_b1_b.to("mm").magnitude == pytest.approx(16.0)
+    assert footing._d_b1_t.to("mm").magnitude == pytest.approx(12.0)
+    assert footing._s_b1_b == footing._s_b1_t == 120 * mm
+
+
+@pytest.mark.parametrize(
+    "height, M_bot, M_top",
+    [(25 * cm, 200 * kNm, -20 * kNm), (30 * cm, 100 * kNm, -600 * kNm)],
+    ids=["bottom-short", "top-short"],
+)
+def test_a_section_that_cannot_carry_the_moment_falls_back(steel_b500s, height, M_bot, M_top) -> None:  # type: ignore[no-untyped-def]
+    """No mat verifies when the section is too small for the demand on a face.
+
+    Each candidate is applied and rejected in turn -- the first case runs the
+    bottom out of capacity, the second the top -- and the design still returns
+    a layout, leaving the check to report DCR > 1 rather than raising.
+    """
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _strip(Footing, concrete, steel_b500s, "Z1", height=height)
+    combo = [Forces(label="C1", M_y=M_bot), Forces(label="C2", M_y=M_top)]
+    Node(section=footing, forces=combo).design()
+
+    results = footing.flexure_check_results(combo)
+    assert max(max(r.bottom.DCR, r.top.DCR) for r in results) > 1

--- a/tests/test_footing.py
+++ b/tests/test_footing.py
@@ -7,6 +7,8 @@ motivated the class: the design returns the largest applicable minimum already
 applied, so a consumer never has to correct the engine's answer.
 """
 
+import warnings
+
 import pytest
 
 from mento.codes.aci_318_19.equations import flexure as aci_flexure
@@ -273,3 +275,163 @@ def test_a_footing_still_carries_its_moment(steel_b500s: SteelBar) -> None:
 
     assert footing._A_s_bot > footing._A_s_min_bot
     assert footing.flexure_check_results(combo)[0].bottom.DCR <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Detailing: how far apart the bars sit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "concrete, steel",
+    [
+        (Concrete_ACI_318_19(name="H25", f_c=25 * MPa), SteelBar(name="ADN 420", f_y=420 * MPa)),
+        (Concrete_EN_1992_2004(name="C25", f_c=25 * MPa), SteelBar(name="B500S", f_y=500 * MPa)),
+    ],
+    ids=["aci", "en"],
+)
+def test_footing_bars_are_capped_at_300_mm(concrete, steel) -> None:  # type: ignore[no-untyped-def]
+    """3h stops binding on a section this thick, so the footing cap is what holds."""
+    footing = _strip(Footing, concrete, steel, "Z1")
+
+    assert footing._max_bar_spacing().to("mm").magnitude == pytest.approx(300.0)
+
+
+@pytest.mark.parametrize(
+    "concrete, steel",
+    [
+        (Concrete_ACI_318_19(name="H25", f_c=25 * MPa), SteelBar(name="ADN 420", f_y=420 * MPa)),
+        (Concrete_EN_1992_2004(name="C25", f_c=25 * MPa), SteelBar(name="B500S", f_y=500 * MPa)),
+    ],
+    ids=["aci", "en"],
+)
+def test_footing_bars_are_floored_at_100_mm(concrete, steel) -> None:  # type: ignore[no-untyped-def]
+    assert _strip(Footing, concrete, steel, "Z1")._min_bar_spacing().to("mm").magnitude == pytest.approx(100.0)
+
+
+def test_a_slab_keeps_the_wider_slab_limits(steel_b500s: SteelBar) -> None:
+    """The tighter pair is a footing's, not every slab's."""
+    slab = _strip(OneWaySlab, Concrete_EN_1992_2004(name="C25", f_c=25 * MPa), steel_b500s, "L1")
+
+    assert slab._max_bar_spacing().to("mm").magnitude == pytest.approx(400.0)
+    assert slab._min_bar_spacing() is None
+
+
+@pytest.mark.parametrize("M_y", [50, 150, 300, 450, 600, 750, 900, 1100])
+def test_a_designed_footing_stays_inside_the_spacing_range(steel_b500s: SteelBar, M_y: int) -> None:
+    """Across the range a metre strip can carry, the design answers with a
+    bigger bar rather than with bars closer than 100 mm."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _design(_strip(Footing, concrete, steel_b500s, "Z1"), M_y=M_y * kNm)
+
+    spacing = footing._s_b1_b.to("mm").magnitude
+    assert 100.0 <= spacing <= 300.0
+    assert footing.flexure_check_results([Forces(label="C1", M_y=M_y * kNm)])[0].bottom.DCR <= 1.0
+
+
+def test_the_floor_is_what_holds_the_footing_apart(steel_b500s: SteelBar) -> None:
+    """The same demand on a slab, which has no floor, is detailed tighter."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _design(_strip(Footing, concrete, steel_b500s, "Z1"), M_y=900 * kNm)
+    slab = _design(_strip(OneWaySlab, concrete, steel_b500s, "L1"), M_y=900 * kNm)
+
+    assert slab._s_b1_b.to("mm").magnitude < 100.0
+    assert footing._s_b1_b.to("mm").magnitude >= 100.0
+
+
+def test_the_spacing_row_of_a_footing_reports_both_bounds(steel_b500s: SteelBar) -> None:
+    """The check table carries the range, so a footing detailed outside it fails."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _design(_strip(Footing, concrete, steel_b500s, "Z1"))
+
+    row = footing._data_min_max_flexure
+    index = row["Check"].index("Bar spacing bottom")
+    assert row["Min."][index] == pytest.approx(100.0)
+    assert row["Max."][index] == pytest.approx(300.0)
+
+
+# ---------------------------------------------------------------------------
+# Detailing: how thin the section may be
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "concrete, steel, height, limit",
+    [
+        (Concrete_ACI_318_19(name="H25", f_c=25 * MPa), SteelBar(name="ADN 420", f_y=420 * MPa), 18 * cm, "200"),
+        (Concrete_EN_1992_2004(name="C25", f_c=25 * MPa), SteelBar(name="B500S", f_y=500 * MPa), 22 * cm, "250"),
+    ],
+    ids=["aci", "en"],
+)
+def test_a_thin_footing_warns(concrete, steel, height, limit) -> None:  # type: ignore[no-untyped-def]
+    with pytest.warns(UserWarning, match=f"below the {limit} mm"):
+        _strip(Footing, concrete, steel, "Z1", height=height)
+
+
+@pytest.mark.parametrize(
+    "concrete, steel",
+    [
+        (Concrete_ACI_318_19(name="H25", f_c=25 * MPa), SteelBar(name="ADN 420", f_y=420 * MPa)),
+        (Concrete_EN_1992_2004(name="C25", f_c=25 * MPa), SteelBar(name="B500S", f_y=500 * MPa)),
+    ],
+    ids=["aci", "en"],
+)
+def test_a_footing_of_the_usual_depth_does_not_warn(concrete, steel) -> None:  # type: ignore[no-untyped-def]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _strip(Footing, concrete, steel, "Z1")
+
+
+def test_a_thin_slab_does_not_warn(steel_b500s: SteelBar) -> None:
+    """The thickness rule is a footing's; a suspended slab is as thin as it is."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _strip(OneWaySlab, Concrete_EN_1992_2004(name="C25", f_c=25 * MPa), steel_b500s, "L1", height=15 * cm)
+
+
+def test_a_thin_footing_is_still_designed(steel_b500s: SteelBar) -> None:
+    """The warning is advice. The thickness is the engineer's to choose, and the
+    design that follows is still the right design for the section given."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    with pytest.warns(UserWarning):
+        footing = _strip(Footing, concrete, steel_b500s, "Z1", height=20 * cm)
+    _design(footing, M_y=20 * kNm)
+
+    assert footing._A_s_bot >= footing._A_s_min_bot
+    assert footing._A_s_bot.magnitude > 0
+
+
+def test_the_warning_names_the_footing_and_the_code() -> None:
+    concrete = Concrete_ACI_318_19(name="H25", f_c=25 * MPa)
+    steel = SteelBar(name="ADN 420", f_y=420 * MPa)
+    with pytest.warns(UserWarning) as caught:
+        _strip(Footing, concrete, steel, "Z7", height=15 * cm)
+
+    message = str(caught[0].message)
+    assert "Z7" in message
+    assert "ACI 318-19" in message
+
+
+# ---------------------------------------------------------------------------
+# A section with nothing on the tension face
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "concrete, steel",
+    [
+        (Concrete_ACI_318_19(name="H25", f_c=25 * MPa), SteelBar(name="ADN 420", f_y=420 * MPa)),
+        (Concrete_EN_1992_2004(name="C25", f_c=25 * MPa), SteelBar(name="B500S", f_y=500 * MPa)),
+    ],
+    ids=["aci", "en"],
+)
+def test_an_unreinforced_face_reports_a_failing_dcr(concrete, steel) -> None:  # type: ignore[no-untyped-def]
+    """Both codes answer a moment on a bare face with a DCR far above 1.
+
+    EN used to divide by zero here. It is what a footing too thin to be
+    reinforced within its spacing range now reports, so it has to be a number.
+    """
+    section = _strip(OneWaySlab, concrete, steel, "L1")
+    combo = [Forces(label="C1", M_y=50 * kNm)]
+
+    assert section.flexure_check_results(combo)[0].bottom.DCR > 1

--- a/tests/test_footing.py
+++ b/tests/test_footing.py
@@ -417,6 +417,7 @@ def test_the_warning_names_the_footing_and_the_code() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("face", ["bot", "top"], ids=["bottom", "top"])
 @pytest.mark.parametrize(
     "concrete, steel",
     [
@@ -425,13 +426,62 @@ def test_the_warning_names_the_footing_and_the_code() -> None:
     ],
     ids=["aci", "en"],
 )
-def test_an_unreinforced_face_reports_a_failing_dcr(concrete, steel) -> None:  # type: ignore[no-untyped-def]
+def test_an_unreinforced_face_reports_a_failing_dcr(concrete, steel, face) -> None:  # type: ignore[no-untyped-def]
     """Both codes answer a moment on a bare face with a DCR far above 1.
 
-    EN used to divide by zero here. It is what a footing too thin to be
-    reinforced within its spacing range now reports, so it has to be a number.
+    EN used to divide by zero here, on either face. It is what a footing too
+    thin to be reinforced within its spacing range now reports, so it has to be
+    a number -- and a slab reinforced on one face only is checked for the
+    combination that puts the other one in tension, so both branches are real.
     """
     section = _strip(OneWaySlab, concrete, steel, "L1")
-    combo = [Forces(label="C1", M_y=50 * kNm)]
+    # A positive moment puts the bottom in tension, a negative one the top.
+    combo = [Forces(label="C1", M_y=(50 if face == "bot" else -50) * kNm)]
 
-    assert section.flexure_check_results(combo)[0].bottom.DCR > 1
+    result = section.flexure_check_results(combo)[0]
+    assert getattr(result, "bottom" if face == "bot" else "top").DCR > 1
+
+
+# ---------------------------------------------------------------------------
+# A design code that states none of these rules
+# ---------------------------------------------------------------------------
+
+
+def test_a_code_without_the_footing_rules_imposes_none() -> None:
+    """A rule a code does not have is not a rule an element can fail.
+
+    ``min_bar_spacing_slab`` and ``min_thickness_on_soil`` are optional hooks:
+    both registered codes fill them in, so this registers one that does not and
+    drives a footing through it. Nothing is capped and nothing is warned about
+    -- silence, rather than an error about a limit that was never stated.
+    """
+    import dataclasses
+
+    from mento.codes.registry import _REGISTRY, DesignCode, design_code, register
+
+    reference = design_code(Concrete_ACI_318_19(name="H25", f_c=25 * MPa))
+    invented = DesignCode(
+        **{
+            **{f.name: getattr(reference, f.name) for f in dataclasses.fields(reference)},
+            "title": "NBR 6118-2023",
+            "year": 2023,
+            "min_bar_spacing_slab": None,
+            "min_thickness_on_soil": None,
+        }
+    )
+    register(invented)
+    try:
+        concrete = Concrete_ACI_318_19(name="H25", f_c=25 * MPa)
+        concrete.design_code = invented.title
+        steel = SteelBar(name="ADN 420", f_y=420 * MPa)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            # Thin enough that either registered code would have warned.
+            footing = _strip(Footing, concrete, steel, "Z1", height=15 * cm)
+
+        assert footing._min_bar_spacing() is None
+        # And the bar count is left at the slab default, since nothing bounds it.
+        assert footing.settings.max_bars_per_layer >= 200
+    finally:
+        _REGISTRY.pop(invented.title, None)

--- a/tests/test_footing.py
+++ b/tests/test_footing.py
@@ -485,3 +485,117 @@ def test_a_code_without_the_footing_rules_imposes_none() -> None:
         assert footing.settings.max_bars_per_layer >= 200
     finally:
         _REGISTRY.pop(invented.title, None)
+
+
+# ---------------------------------------------------------------------------
+# One mat: both faces at one spacing
+# ---------------------------------------------------------------------------
+
+
+def _design_envelope(section, M_bot, M_top):  # type: ignore[no-untyped-def]
+    """Design for an envelope with a moment on each face, and return it."""
+    combo = [Forces(label="C1", M_y=M_bot), Forces(label="C2", M_y=-M_top)]
+    Node(section=section, forces=combo).design()
+    return section, combo
+
+
+@pytest.mark.parametrize(
+    "concrete, steel",
+    [
+        (Concrete_ACI_318_19(name="H25", f_c=25 * MPa), SteelBar(name="ADN 420", f_y=420 * MPa)),
+        (Concrete_EN_1992_2004(name="C25", f_c=25 * MPa), SteelBar(name="B500S", f_y=500 * MPa)),
+    ],
+    ids=["aci", "en"],
+)
+def test_a_designed_footing_is_one_mat(concrete, steel) -> None:  # type: ignore[no-untyped-def]
+    """Both faces come out set out at the same spacing.
+
+    The bottom carries five times the top's moment here, so the two faces would
+    otherwise be detailed at spacings nobody would draw on one mat.
+    """
+    footing, _ = _design_envelope(_strip(Footing, concrete, steel, "Z1"), 600 * kNm, 120 * kNm)
+
+    assert footing._s_b1_b.to("mm").magnitude == pytest.approx(footing._s_b1_t.to("mm").magnitude)
+
+
+def test_the_mat_takes_the_smaller_of_the_two_spacings(steel_b500s: SteelBar) -> None:
+    """The face that governed keeps the spacing it needed; the other closes up
+    to it, which can only add bars.
+
+    Driven from a layout set by hand rather than from a design, so that the two
+    spacings going in are known and the rule can be read off the result.
+    """
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _strip(Footing, concrete, steel_b500s, "Z1")
+    footing.set_slab_longitudinal_rebar_bot(d_b1=16 * mm, s_b1=120 * mm)
+    footing.set_slab_longitudinal_rebar_top(d_b1=12 * mm, s_b1=250 * mm)
+    A_s_top_before = footing._A_s_top
+
+    footing._finalize_longitudinal_design()
+
+    assert footing._s_b1_b.to("mm").magnitude == pytest.approx(120.0)
+    assert footing._s_b1_t.to("mm").magnitude == pytest.approx(120.0)
+    # Closing the top up added bars, and left its bar alone.
+    assert footing._A_s_top > A_s_top_before
+    assert footing._d_b1_t.to("mm").magnitude == pytest.approx(12.0)
+
+
+def test_matching_the_mat_never_undoes_the_design(steel_b500s: SteelBar) -> None:
+    """Closing the wider face up only adds steel, so both faces still pass."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing, combo = _design_envelope(_strip(Footing, concrete, steel_b500s, "Z1"), 600 * kNm, 120 * kNm)
+
+    results = footing.flexure_check_results(combo)
+    assert max(r.bottom.DCR for r in results) <= 1.0
+    assert max(r.top.DCR for r in results) <= 1.0
+    assert footing._A_s_bot >= footing._A_s_min_bot
+    assert footing._A_s_top >= footing._A_s_min_top
+
+
+def test_the_mat_keeps_each_face_within_the_spacing_range(steel_b500s: SteelBar) -> None:
+    """Matching down cannot push a face below the 100 mm floor: the module is
+    one of the two spacings the design already chose."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing, _ = _design_envelope(_strip(Footing, concrete, steel_b500s, "Z1"), 900 * kNm, 100 * kNm)
+
+    for spacing in (footing._s_b1_b, footing._s_b1_t):
+        assert 100.0 <= spacing.to("mm").magnitude <= 300.0
+
+
+def test_the_diameters_are_left_as_designed(steel_b500s: SteelBar) -> None:
+    """Only the module is shared. A face carrying a fifth of the moment is
+    still allowed its own, thinner bar."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing, _ = _design_envelope(_strip(Footing, concrete, steel_b500s, "Z1"), 600 * kNm, 120 * kNm)
+
+    assert footing._d_b1_t < footing._d_b1_b
+
+
+def test_a_footing_reinforced_on_one_face_gets_no_second_grid(steel_b500s: SteelBar) -> None:
+    """Nothing to reconcile, and a grid is not invented to reconcile with."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _design(_strip(Footing, concrete, steel_b500s, "Z1"), M_y=300 * kNm)
+
+    assert footing._s_b1_b.magnitude > 0
+    assert footing._s_b1_t.magnitude == 0
+    assert footing._d_b1_t.magnitude == 0
+
+
+def test_a_slab_still_details_its_faces_independently(steel_b500s: SteelBar) -> None:
+    """The mat is a footing's; a suspended slab keeps the spacing each face
+    actually needed."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    slab, _ = _design_envelope(_strip(OneWaySlab, concrete, steel_b500s, "L1"), 600 * kNm, 120 * kNm)
+
+    assert slab._s_b1_b != slab._s_b1_t
+
+
+def test_matching_is_idempotent(steel_b500s: SteelBar) -> None:
+    """Running it on a mat that is already one leaves it alone."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing, _ = _design_envelope(_strip(Footing, concrete, steel_b500s, "Z1"), 600 * kNm, 120 * kNm)
+    before = (footing._s_b1_b, footing._s_b1_t, footing._A_s_bot, footing._A_s_top)
+
+    footing._finalize_longitudinal_design()
+
+    assert (footing._s_b1_b, footing._s_b1_t, footing._A_s_bot, footing._A_s_top) == before

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -225,6 +225,7 @@ def test_all_exports_in_all() -> None:
         "Node",
         "Forces",
         "OneWaySlab",
+        "Footing",
         "Concrete_ACI_318_19",
         "SteelBar",
         "Concrete_CIRSOC_201_25",

--- a/tests/test_slab.py
+++ b/tests/test_slab.py
@@ -3,6 +3,7 @@ import math
 import pytest
 from pint import Quantity
 
+from mento.beam import RectangularBeam
 from mento.node import Node
 from mento.slab import OneWaySlab, _bars_at_spacing
 from mento.material import Concrete_ACI_318_19, SteelBar, Concrete_EN_1992_2004
@@ -692,6 +693,97 @@ def test_a_hogging_slab_is_designed_on_its_top_face_by_a_spacing() -> None:
     assert top.layers[0].s is not None
     assert _bars_at_spacing(slab._s_b1_t, slab.width) == top.layers[0].n
     assert top.A_s >= slab.flexure_design.top.A_s_req
+
+
+@pytest.mark.parametrize(
+    ("concrete", "height", "expected_cm"),
+    [
+        (Concrete_ACI_318_19(name="H25", f_c=25 * MPa), 12 * cm, 36),  # 3h governs
+        (Concrete_ACI_318_19(name="H25", f_c=25 * MPa), 25 * cm, 45),  # 450 mm governs
+        (Concrete_EN_1992_2004(name="C25", f_c=25 * MPa), 12 * cm, 36),  # 3h governs
+        (Concrete_EN_1992_2004(name="C25", f_c=25 * MPa), 25 * cm, 40),  # 400 mm governs
+    ],
+    ids=["ACI_3h", "ACI_450mm", "EN_3h", "EN_400mm"],
+)
+def test_the_code_caps_how_far_apart_the_bars_of_a_slab_may_sit(
+    concrete: Concrete_ACI_318_19 | Concrete_EN_1992_2004, height: Quantity, expected_cm: float
+) -> None:
+    """ACI 318-19 7.7.2.3 is 3h or 450 mm; EN 1992-1-1 9.3.1.1(3) is 3h or 400 mm."""
+    slab = OneWaySlab(
+        label="Slab s_max",
+        concrete=concrete,
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=height,
+        c_c=20 * mm,
+    )
+
+    assert slab._max_bar_spacing().to("cm").magnitude == pytest.approx(expected_cm)
+
+
+def test_a_design_is_never_spaced_beyond_the_code_maximum() -> None:
+    """Area alone is not a layout.
+
+    A light strip needs so little steel that the search covers it with the two
+    bars it starts from, which on a metre of slab is a bar every half metre:
+    the area is there and most of the slab is not reinforced. The spacing is
+    capped at what the code allows, which only ever adds bars.
+    """
+    slab = OneWaySlab(
+        label="Slab lightly loaded",
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=12 * cm,
+        c_c=20 * mm,
+    )
+    Node(section=slab, forces=Forces(label="C1", M_y=2 * kNm)).design()
+
+    s_max = slab._max_bar_spacing()
+    assert s_max.to("cm").magnitude == 36  # 3h on a 12 cm slab
+    assert slab._s_b1_b <= s_max
+    assert slab.reinforcement.bottom.layers[0].n == _bars_at_spacing(s_max, slab.width)
+    assert slab.reinforcement.bottom.A_s >= slab.flexure_design.bottom.A_s_req
+
+
+def test_a_slab_spaced_beyond_the_code_maximum_fails_the_check() -> None:
+    """The bars add up to the area and the slab between them is still bare."""
+    slab = OneWaySlab(
+        label="Slab too spread out",
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=25 * cm,
+        c_c=25 * mm,
+    )
+    slab.set_slab_longitudinal_rebar_bot(d_b1=20 * mm, s_b1=60 * cm)
+
+    Node(section=slab, forces=Forces(label="C1", M_y=20 * kNm)).check_flexure()
+
+    rows = slab._data_min_max_flexure
+    assert rows["Check"][3] == "Bar spacing bottom"
+    assert rows["Value"][3] == pytest.approx(600)
+    assert rows["Max."][3] == pytest.approx(450)
+    assert rows["Ok?"][3] == "❌"
+    assert slab._all_flexure_checks_passed is False
+
+
+def test_a_beam_still_reports_the_clear_distance_between_its_bars() -> None:
+    """The max-spacing row is the slab's; a beam has no such limit to report."""
+    beam = RectangularBeam(
+        label="B1",
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=20 * cm,
+        height=50 * cm,
+        c_c=25 * mm,
+    )
+    Node(section=beam, forces=Forces(label="C1", M_y=100 * kNm)).design()
+
+    rows = beam._data_min_max_flexure
+    assert rows["Check"][3] == "Minimum spacing bottom"
+    assert rows["Value"][3] == pytest.approx(beam._available_s_bot.to("mm").magnitude, rel=1e-9)
+    assert rows["Max."][3] == ""
 
 
 def test_the_flexure_report_of_a_slab_names_the_spacing() -> None:

--- a/tests/test_slab.py
+++ b/tests/test_slab.py
@@ -4,7 +4,7 @@ import pytest
 from pint import Quantity
 
 from mento.node import Node
-from mento.slab import OneWaySlab
+from mento.slab import OneWaySlab, _bars_at_spacing
 from mento.material import Concrete_ACI_318_19, SteelBar, Concrete_EN_1992_2004
 from mento.units import kip, inch, mm, cm, kN, MPa, kNm, ksi
 from mento.forces import Forces
@@ -553,6 +553,157 @@ def test_slab_shear_design_is_the_least_steel_the_spacing_limits_allow() -> None
                     assert A_v.to("cm**2/m").magnitude >= chosen * (1 - 1e-9), (
                         f"Ø{row['d_b']} at {s_l} cm x {s_w} cm covers A_v_req with less steel"
                     )
+
+
+##########################################################
+# HOW A DESIGN IS WRITTEN ONTO A SLAB
+##########################################################
+
+
+def test_a_designed_slab_is_detailed_by_a_spacing_not_by_a_bar_count() -> None:
+    """The search is the beam's; what it produces has to be read as a slab.
+
+    Its answer is groups of bars -- ``n_1`` and ``n_2`` are one and the same
+    layer -- and the beam applies it as such. A slab that went through it came
+    out split into "2Ø12 + 4Ø12", two layers that are really one, with the
+    spacing that actually details a slab left empty: there was no way to read
+    the result other than by counting bars.
+    """
+    slab = _designed_slab(Concrete_ACI_318_19(name="H25", f_c=25 * MPa), V_z=0 * kN)
+
+    bottom = slab.reinforcement.bottom
+    assert len(bottom.layers) == 1
+    layer = bottom.layers[0]
+    assert layer.s is not None and layer.s.to("cm").magnitude > 0
+    assert str(bottom) == f"Ø{layer.d_b:.4g~P}/{layer.s:.4g~P}"
+    # Positions 2 and 4 stay empty: a slab layer is one bar at one spacing.
+    assert slab._n2_b == 0 and slab._n4_b == 0
+    # The spacing is the state, and the count is what it produces.
+    assert _bars_at_spacing(slab._s_b1_b, slab.width) == layer.n
+
+
+def test_the_spacing_a_design_leaves_is_one_that_can_be_drawn() -> None:
+    """Rounded to the centimetre, and up, so the bars the search chose stay."""
+    slab = _designed_slab(Concrete_ACI_318_19(name="H25", f_c=25 * MPa), V_z=0 * kN)
+
+    spacing = slab._s_b1_b.to("cm").magnitude
+    assert spacing == pytest.approx(round(spacing))
+    n = slab.reinforcement.bottom.layers[0].n
+    # Rounding up cannot cost a bar: n bars at width/n rounded up still ask for n.
+    assert spacing >= slab.width.to("cm").magnitude / n
+    assert slab.reinforcement.bottom.A_s >= slab.flexure_design.bottom.A_s_req
+
+
+def test_a_spacing_is_never_rounded_into_fewer_bars_than_the_design_chose() -> None:
+    """Rounding up is the rule, but it does not always hold.
+
+    ``ceil(width / n)`` normally asks for the same ``n`` bars back. Once the
+    bars are close enough that a whole centimetre spans more than one of them
+    -- from about eleven in a metre -- rounding up drops one, so the spacing is
+    checked against the count it produces and rounded down instead.
+    """
+    slab = OneWaySlab(
+        label="Slab spacing",
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=20 * cm,
+        c_c=20 * mm,
+    )
+
+    # 100/6 = 16.7 -> 17 cm, and 17 cm still asks for 6 bars.
+    assert slab._spacing_for_bars(6).to("cm").magnitude == 17
+    # 100/11 = 9.1 -> 10 cm would only ask for 10, so it rounds the other way.
+    assert slab._spacing_for_bars(11).to("cm").magnitude == 9
+    for n in range(1, 30):
+        assert _bars_at_spacing(slab._spacing_for_bars(n), slab.width) >= n
+    assert slab._spacing_for_bars(0).magnitude == 0
+
+
+def test_an_imperial_slab_is_designed_to_a_whole_inch_spacing() -> None:
+    slab = OneWaySlab(
+        label="Slab imperial flexure",
+        concrete=Concrete_ACI_318_19(name="C4", f_c=4 * ksi),
+        steel_bar=SteelBar(name="G60", f_y=60 * ksi),
+        width=36 * inch,
+        height=10 * inch,
+        c_c=0.75 * inch,
+    )
+    Node(section=slab, forces=Forces(label="C1", M_y=20 * kNm)).design()
+
+    spacing = slab._s_b1_b.to("inch").magnitude
+    assert spacing == pytest.approx(round(spacing))
+    assert _bars_at_spacing(slab._s_b1_b, slab.width) == slab._n1_b
+
+
+def test_designing_a_slab_that_needs_no_top_steel_clears_the_top_spacing() -> None:
+    """A cleared face has to lose its spacing, or the bars come back.
+
+    The beam clears a face by zeroing the bar counts. On a slab those counts are
+    derived from the spacing, so a spacing left behind would be turned back into
+    bars by the next recalculation -- the following design of the bottom face.
+    """
+    slab = OneWaySlab(
+        label="Slab top cleared",
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=20 * cm,
+        c_c=20 * mm,
+    )
+    slab.set_slab_longitudinal_rebar_top(d_b1=12 * mm, s_b1=15 * cm)
+
+    # Sagging only: nothing is required on the top face.
+    Node(section=slab, forces=Forces(label="C1", M_y=30 * kNm)).design()
+
+    assert slab._s_b1_t.magnitude == 0
+    assert slab._n1_t == 0
+    assert slab.reinforcement.top.layers == ()
+    assert slab.reinforcement.top.A_s.magnitude == 0
+
+    # The same, through the path the design takes when the face has no layout
+    # at all to apply rather than an empty one.
+    slab.set_slab_longitudinal_rebar_top(d_b1=12 * mm, s_b1=15 * cm)
+    assert slab.reinforcement.top.n_bars > 0
+
+    slab._clear_top_longitudinal()
+
+    assert slab._s_b1_t.magnitude == 0
+    assert slab._s_b3_t.magnitude == 0
+    assert slab.reinforcement.top.layers == ()
+    # And the bars stay gone once another face is recalculated.
+    slab.set_slab_longitudinal_rebar_bot(d_b1=10 * mm, s_b1=20 * cm)
+    assert slab.reinforcement.top.layers == ()
+
+
+def test_a_hogging_slab_is_designed_on_its_top_face_by_a_spacing() -> None:
+    slab = OneWaySlab(
+        label="Slab hogging",
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=100 * cm,
+        height=20 * cm,
+        c_c=20 * mm,
+    )
+    Node(section=slab, forces=Forces(label="C1", M_y=-30 * kNm)).design()
+
+    top = slab.reinforcement.top
+    assert len(top.layers) == 1
+    assert top.layers[0].s is not None
+    assert _bars_at_spacing(slab._s_b1_t, slab.width) == top.layers[0].n
+    assert top.A_s >= slab.flexure_design.top.A_s_req
+
+
+def test_the_flexure_report_of_a_slab_names_the_spacing() -> None:
+    """The count row gives way to the notation the strip is drawn in."""
+    slab = _designed_slab(Concrete_ACI_318_19(name="H25", f_c=25 * MPa), V_z=0 * kN)
+
+    rows = slab._flexure_capacity_bot
+    assert rows["Variable"][:2] == ["Ø1/s1", "Ø3/s3"]
+    assert rows["Value"][0] == str(slab.reinforcement.bottom.layers[0])
+    assert rows["Value"][1] == "-"
+    # Every column of the table still has one entry per row.
+    assert len({len(column) for column in rows.values()}) == 1
 
 
 ##########################################################


### PR DESCRIPTION
# Description

Adds `Footing`, a `OneWaySlab` that bears directly on the ground, so that a footing
comes out of mento already detailed the way it is built — minimum reinforcement, bar
spacing and mat layout included — instead of being corrected by the consumer afterwards.

**Why it belongs here.** A_s,min is section design, and section design is mento's. The
exemption that motivates it is a code clause — ACI 318-19 §9.6.1.1(b), members supported
on the ground — and mento already has the code layer to express it per registered code.
Today a downstream consumer has to correct the engine's output, which is exactly what
the separation of responsibilities is meant to avoid, and it duplicates a rule mento
already models.

**How it is expressed.** Not as a branch in the element, but as `Section.support`
(`"free"` / `"soil"`), a ClassVar the design codes read. `Footing` sets it to `"soil"`;
each code picks the clause that applies. Nothing outside `codes/` decides anything, and
the architecture-boundary tests stay green.

> **mento does no geotechnical calculation.** Bearing pressure, settlement, sliding,
> overturning and plan sizing stay outside its scope, and so does choosing the
> thickness. `Footing` designs the section those decisions produced. Both doc pages open
> on this.

## What changed

### 1. Minimum reinforcement (`09e0801`)

| Code | A_s,min |
| --- | --- |
| ACI 318-19, CIRSOC 201-25 | §9.6.1.1(b) exempts the member and §13.3.1.2 substitutes the shrinkage and temperature reinforcement of Table 24.4.3.2: `max(0.0018·420/f_y, 0.0014) · b · h`, on the gross section. The 4/3 relief of §9.6.1.3 is not applied — it belongs to the clause the exemption removed. |
| EN 1992-2004 | The halved geometric minimum of a foundation (0.0010·b·h at f_yk = 400, 0.0009·b·h at 500) on **every face** — it is shrinkage and restraint steel — and on a face that is **bending**, the larger of that and the crack-control minimum of §7.3.2(2) Eq. (7.1), `k_c·k·f_ct,eff·A_ct/σ_s`. The second is written on A_ct, the area in tension, so a face asked for with no moment has no crack to control. It governs the **thin** footings: its ratio goes with k/2, and k decays from 1.00 to 0.65 between 300 and 800 mm, so the geometric minimum takes over around h = 640 mm for C25/B500S. |

Applied on both the check and the design path, so `node.design()` returns the governing
minimum already resolved. A `Footing` still reinforces a face only when one is asked
for: given no negative moment it leaves the top empty, because whether a footing carries
top steel is the consumer's call — the only one that sees both orthogonal sections.

### 2. Detailing limits (`fcc4294`)

Bar spacing kept between **100 and 300 mm**, both bounds supplied by the code through
the registry. A section thinner than the code asks of a footing on soil — 200 mm in ACI
§13.3.1.2, 250 mm in EN practice — warns when it is built, and is still designed.

### 3. One mat (`fb5aa9f`, `71ecd78`, `04c93ad`)

A footing is placed as a single grid, not as two independently detailed faces, so a
design ends on **one module**: the top at the bottom's spacing or at exactly twice it,
so one top bar lands on every second bottom bar.

The first attempt simply reconciled the two spacings the per-face design arrived at,
taking the smaller. Running twenty typical footings showed that is safe but expensive:
the face governed by the minimum is detailed as many thin bars, so it is usually the
*lightly loaded* face that holds the smaller spacing, and adopting it closes the loaded
face up — the bottom's DCR fell to 0.57 in the worst case. About 20% more longitudinal
steel than the two faces require.

So the mat is now **chosen rather than reconciled**: over the modules the code allows
and the bars the catalogue holds, the lightest combination of module and two diameters
that covers both faces, with the top at `s` or `2s`. A triple module was tried and
carries nothing `s` and `2s` do not.

| Rule | vs. what the two faces require | vs. mento's per-face design |
| --- | --- | --- |
| Smaller of the two spacings | +20% / +21% | +12% / +13% |
| **Chosen mat (merged)** | **+7% / +11%** | **+1% / +4%** |

*(EN / ACI, over twenty typical footings: h = 40–80 cm, M⁺ = 150–900 kNm, M⁻ between 5%
and 20% of M⁺.)*

Every candidate is verified before it is kept, because the choice feeds back into
itself: a thicker bar sits deeper and lowers the effective depth the required area was
computed against. Candidates are tried lightest first; if none verifies — a section too
small for its demand — the design falls back to reconciling the two spacings it had
already proved, which needs no verification because it only ever adds bars. A sweep
found 156 cases that exercise that path; two are pinned as tests.

The mat is also floored at **Ø10**: without it the search reaches for the thinnest bar
in the catalogue to shave the lightly loaded face, which is not a mesh anyone lays over
the ground.

### 4. Documentation (`aced903`, `79f5dfc`)

`docs/source/user_guide/footings.rst` for usage and `docs/source/theory/footing.rst` for
the clauses, the equations, the implementation decisions and a validation table mapping
every rule to the test that pins it.

## Two things a reviewer should look at

1. **An unrelated EN bug is fixed here.** `_check_flexure_EN_1992_2004` formed the DCR
   straight off `M_Rd`, so checking any EN section with no reinforcement on the tension
   face raised `ZeroDivisionError`, where ACI reported DCR ≫ 1 through its
   `_MOMENT_FLOOR`. EN now keeps the same 0.01 kNm floor. Pre-existing and independent
   of footings, but the spacing floor makes footings reach it.
2. **`_finalize_longitudinal_design` is a new hook on the flexure driver.** It is a
   no-op for `RectangularBeam`, whose two faces are detailed independently, and runs at
   the very end of `_run_flexure_design` — after the final capacity verification, so
   what it starts from is a layout already known to work.

*(#149 was merged first and is now in `main`; this branch had merged it at `647dab7` so
that the footing spacing limits could extend its `max_bar_spacing_slab` hook. Nothing of
it is left in this diff — the 10 commits and 21 files below are the footing work only.)*

## Type of change

- [x] Bug fix
- [x] New feature or design code implementation
- [x] Documentation
- [ ] Maintenance (tooling, CI, refactoring with no behaviour change)

## Checklist

- [x] Tests added or updated, and `pytest` passes locally (1239 passed, 1 skipped)
- [x] `mypy mento/` passes
- [x] `pre-commit run --all-files` reports no changes
- [x] Documentation updated where the change is user facing
- [x] Public class and method names left unchanged, or the change was agreed beforehand

Coverage stays at 100% (4983 statements, 0 missed), `sphinx-build -W` is clean, and
`Footing` is exported from `mento` alongside `OneWaySlab`.

## Calculation validation

- [ ] Validated in CalcPad, and the file is included in this PR
- **Reference example:** the clauses themselves — ACI 318-19 Table 24.4.3.2 with
  §9.6.1.1(b) and §13.3.1.2; EN 1992-1-1 §7.3.2(2) Eq. (7.1) with §9.2.1.1 — plus the
  office reference case, a 1 m strip, h = 600 mm, C25 (f_ctm = 2.565 MPa), B500S.
- **Result comparison:** on that strip, EN gives k = 0.79 and A_s,min = 5.59 cm² (crack
  control governing over the 5.40 cm² geometric minimum) against 7.26 cm² under the beam
  rule it replaces; ACI with f_y = 420 MPa gives 10.80 cm² = 0.0018·b·h against
  18.13 cm². Each equation is pinned to an exact expected value in `tests/test_footing.py`
  (82 tests) at pytest's default tolerance, and every rule is mapped to its test in the
  validation table of the theory page. No CalcPad file: these are minimum-reinforcement
  and detailing clauses read directly, not a capacity calculation to cross-check against
  an independent implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
