### PR TITLE
fix(footing): the EN crack-control minimum governs the thin footings, not the thick

### DIFF
--- a/docs/source/theory/footing.rst
+++ b/docs/source/theory/footing.rst
@@ -71,26 +71,9 @@ On a 1 m strip 600 mm deep in H25 with :math:`f_y = 420` MPa, the footing rule g
 EN 1992-1-1:2004
 ----------------
 
-Two rules take the place of the exempted one, and **they do not apply to the same
-faces**:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 30 34 36
-
-   * - Rule
-     - Applies to
-     - Why
-   * - Geometric minimum
-     - **Every face**
-     - Shrinkage and restraint steel. It does not depend on the section bending.
-   * - Crack control, §7.3.2(2)
-     - **A face that is bending**
-     - Written on :math:`A_{ct}`, the area of the section *in tension*. A face
-       asked for with no moment on it has no tension zone and no crack to
-       control.
-
-Where both apply, the larger governs.
+Two rules apply and **the larger governs**. Both are asked only for a face the moment
+puts in tension: a face that is not in tension is given no minimum at all, not a smaller
+one.
 
 Geometric minimum
 ^^^^^^^^^^^^^^^^^
@@ -162,8 +145,8 @@ against a geometric minimum of :math:`0.0009 \times 1000 \times 600 = 540` mm²,
 crack control governs. The beam rule this replaces,
 :math:`\max(0.26 f_{ctm}/f_{yk},\ 0.0013)\, b\, d`, would give 7.26 cm².
 
-Which of the two governs a bending face depends only on :math:`k`, since both are
-proportional to :math:`h`. With :math:`A_{ct} = b\,h/2` the crack-control ratio goes
+Which of the two governs depends only on :math:`k`, since both are proportional to
+:math:`h`. With :math:`A_{ct} = b\,h/2` the crack-control ratio goes
 with :math:`k/2`, and :math:`k` decays from 1.00 to 0.65 between 300 and 800 mm — so
 crack control governs the **thin** footings and the geometric minimum takes over in the
 thick ones, the crossover falling around :math:`h = 640` mm for C25 with B500S:
@@ -173,8 +156,8 @@ thick ones, the crossover falling around :math:`h = 640` mm for C25 with B500S:
    :widths: 20 27 27 26
 
    * - :math:`h`
-     - Bending face
-     - Face with no moment
+     - A_s,min applied
+     - Geometric alone
      - Governing rule
    * - 0.40 m
      - 1.097 ‰
@@ -191,10 +174,15 @@ thick ones, the crossover falling around :math:`h = 640` mm for C25 with B500S:
 
 .. note::
 
-   Every face getting the geometric minimum does **not** mean mento places a face
-   nobody asked for. Whether a footing carries top steel is the consumer's call — it is
-   the only one that sees both orthogonal sections of the element — so a design given no
-   negative moment leaves the top face empty.
+   A footing bending both ways has a tension zone on each face, so each is owed the
+   crack-control minimum. A face the moment does not put in tension is given no minimum
+   at all: whether a footing carries steel there is the consumer's call — it is the only
+   one that sees both orthogonal sections of the element — so a design given no negative
+   moment leaves the top face empty.
+
+   The distribution reinforcement perpendicular to the span is the same question asked
+   of a different section, and is designed as one. mento never reasons about two
+   directions at once.
 
 Detailing
 ---------
@@ -413,17 +401,18 @@ Validation
    * - Eq. (7.1) as written
      - ``test_en_crack_control_min_reinforcement_is_equation_7_1``
      - EN 1992-1-1 §7.3.2(2)
-   * - The larger of the two rules governs a bending face
+   * - The larger of the two rules governs
      - ``test_en_footing_minimum_is_the_crack_control_rule``,
-       ``test_en_footing_minimum_is_the_larger_of_the_two_rules``,
-       ``test_a_bending_face_still_gets_the_larger_of_the_two``
+       ``test_en_footing_minimum_is_the_larger_of_the_two_rules``
      - Worked reference case above
-   * - Crack control only on a face in tension, and only in the thin sections
-     - ``test_only_a_bending_face_gets_the_crack_control_minimum``,
-       ``test_the_crack_rule_governs_the_thin_footings_not_the_thick``,
-       ``test_a_face_designed_without_a_moment_takes_only_the_geometric_minimum``
+   * - Crack control governs the thin sections, not the thick
+     - ``test_the_crack_rule_governs_the_thin_footings_not_the_thick``,
+       ``test_the_excess_over_the_geometric_minimum_shrinks_with_depth``
      - EN 1992-1-1 §7.3.2(2); the depth table above
-   * - A face nobody asked for is not placed
+   * - Both faces in tension are both owed it
+     - ``test_both_faces_in_tension_both_get_the_crack_minimum``
+     - EN 1992-1-1 §7.3.2(2)
+   * - A face not in tension is given no minimum
      - ``test_a_footing_with_no_top_moment_is_left_without_top_steel``
      - Internal consistency
    * - A design covers the minimum without correction

--- a/docs/source/theory/footing.rst
+++ b/docs/source/theory/footing.rst
@@ -71,7 +71,26 @@ On a 1 m strip 600 mm deep in H25 with :math:`f_y = 420` MPa, the footing rule g
 EN 1992-1-1:2004
 ----------------
 
-Two rules apply and **the larger governs**.
+Two rules take the place of the exempted one, and **they do not apply to the same
+faces**:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 34 36
+
+   * - Rule
+     - Applies to
+     - Why
+   * - Geometric minimum
+     - **Every face**
+     - Shrinkage and restraint steel. It does not depend on the section bending.
+   * - Crack control, §7.3.2(2)
+     - **A face that is bending**
+     - Written on :math:`A_{ct}`, the area of the section *in tension*. A face
+       asked for with no moment on it has no tension zone and no crack to
+       control.
+
+Where both apply, the larger governs.
 
 Geometric minimum
 ^^^^^^^^^^^^^^^^^
@@ -143,9 +162,39 @@ against a geometric minimum of :math:`0.0009 \times 1000 \times 600 = 540` mm²,
 crack control governs. The beam rule this replaces,
 :math:`\max(0.26 f_{ctm}/f_{yk},\ 0.0013)\, b\, d`, would give 7.26 cm².
 
-Which rule governs depends only on :math:`k`, since both are proportional to
-:math:`h`: crack control governs the shallower sections, and the geometric minimum
-takes over once :math:`k` has decayed — around :math:`h = 640` mm for C25 with B500S.
+Which of the two governs a bending face depends only on :math:`k`, since both are
+proportional to :math:`h`. With :math:`A_{ct} = b\,h/2` the crack-control ratio goes
+with :math:`k/2`, and :math:`k` decays from 1.00 to 0.65 between 300 and 800 mm — so
+crack control governs the **thin** footings and the geometric minimum takes over in the
+thick ones, the crossover falling around :math:`h = 640` mm for C25 with B500S:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 27 27 26
+
+   * - :math:`h`
+     - Bending face
+     - Face with no moment
+     - Governing rule
+   * - 0.40 m
+     - 1.097 ‰
+     - 0.900 ‰
+     - Crack control, +22%
+   * - 0.60 m
+     - 0.932 ‰
+     - 0.900 ‰
+     - Crack control, +4%
+   * - 0.90 m
+     - 0.900 ‰
+     - 0.900 ‰
+     - Geometric
+
+.. note::
+
+   Every face getting the geometric minimum does **not** mean mento places a face
+   nobody asked for. Whether a footing carries top steel is the consumer's call — it is
+   the only one that sees both orthogonal sections of the element — so a design given no
+   negative moment leaves the top face empty.
 
 Detailing
 ---------
@@ -364,10 +413,19 @@ Validation
    * - Eq. (7.1) as written
      - ``test_en_crack_control_min_reinforcement_is_equation_7_1``
      - EN 1992-1-1 §7.3.2(2)
-   * - The larger of the two rules governs
+   * - The larger of the two rules governs a bending face
      - ``test_en_footing_minimum_is_the_crack_control_rule``,
-       ``test_en_footing_minimum_is_the_larger_of_the_two_rules``
+       ``test_en_footing_minimum_is_the_larger_of_the_two_rules``,
+       ``test_a_bending_face_still_gets_the_larger_of_the_two``
      - Worked reference case above
+   * - Crack control only on a face in tension, and only in the thin sections
+     - ``test_only_a_bending_face_gets_the_crack_control_minimum``,
+       ``test_the_crack_rule_governs_the_thin_footings_not_the_thick``,
+       ``test_a_face_designed_without_a_moment_takes_only_the_geometric_minimum``
+     - EN 1992-1-1 §7.3.2(2); the depth table above
+   * - A face nobody asked for is not placed
+     - ``test_a_footing_with_no_top_moment_is_left_without_top_steel``
+     - Internal consistency
    * - A design covers the minimum without correction
      - ``test_design_already_covers_the_minimum``,
        ``test_aci_footing_with_no_moment_still_gets_the_minimum``,

--- a/docs/source/user_guide/footings.rst
+++ b/docs/source/user_guide/footings.rst
@@ -84,6 +84,10 @@ Three rules, and the design applies all of them for you:
   minimum written for a member spanning between supports, and each code puts a
   different rule in its place. `Footing` returns the largest applicable minimum
   **already applied**, so the reinforcement it reports needs no correction afterwards.
+  Under EN, a face that is bending takes the larger of the geometric and crack-control
+  minimums; a face asked for with no moment on it takes only the geometric one. A face
+  nobody asked for is not reinforced at all — whether a footing carries top steel is
+  yours to decide, since only you see both orthogonal sections of the element.
 - **Bar spacing.** Kept between 100 and 300 mm. A design answers a heavier demand with
   a larger bar rather than with bars closer than 100 mm, and both bounds appear in the
   flexure check table.

--- a/docs/source/user_guide/footings.rst
+++ b/docs/source/user_guide/footings.rst
@@ -84,10 +84,10 @@ Three rules, and the design applies all of them for you:
   minimum written for a member spanning between supports, and each code puts a
   different rule in its place. `Footing` returns the largest applicable minimum
   **already applied**, so the reinforcement it reports needs no correction afterwards.
-  Under EN, a face that is bending takes the larger of the geometric and crack-control
-  minimums; a face asked for with no moment on it takes only the geometric one. A face
-  nobody asked for is not reinforced at all — whether a footing carries top steel is
-  yours to decide, since only you see both orthogonal sections of the element.
+  A face the moment puts in tension takes the minimum; a face it does not is left
+  unreinforced — whether a footing carries top steel is yours to decide, since only you
+  see both orthogonal sections of the element. The distribution reinforcement across the
+  span is the same question asked of a different section, and is designed as one.
 - **Bar spacing.** Kept between 100 and 300 mm. A design answers a heavier demand with
   a larger bar rather than with bars closer than 100 mm, and both bounds appear in the
   flexure check table.

--- a/mento/codes/EN_1992_2004_beam.py
+++ b/mento/codes/EN_1992_2004_beam.py
@@ -316,23 +316,36 @@ def _min_max_flexural_reinforcement_ratio_EN_1992_2004(
 _K_C_BENDING = 0.4
 
 
-def _minimum_flexural_reinforcement_area_EN_1992_2004(self: "RectangularBeam", d: float) -> float:
-    """A_s,min on the tension face, for the way this element is supported.
+def _minimum_flexural_reinforcement_area_EN_1992_2004(self: "RectangularBeam", M_Ed: float, d: float) -> float:
+    """A_s,min on one face, for the way this element is supported.
 
     A member spanning between supports gets the non-fragility minimum of
     §9.2.1.1, ``rho_min * b_t * d``.
 
     A member bearing on the ground does not: the brittle failure that clause
     guards against needs the support to disappear when the section cracks, and
-    here the soil goes on carrying it. Two rules take its place, and the larger
-    governs:
+    here the soil goes on carrying it. Two rules take its place instead, and
+    they do not apply to the same faces:
 
-    * the halved geometric minimum of a foundation, on the gross section; and
-    * the crack-control minimum of §7.3.2(2), which is what actually sizes the
-      steel of a thick footing — the concrete releases its tension at the
-      instant of cracking and the bars have to take it without breaking.
+    * the halved geometric minimum of a foundation, on the gross section. It is
+      shrinkage and restraint steel, so every face gets it whether or not it is
+      bending.
+    * the crack-control minimum of §7.3.2(2), which sizes the steel that has to
+      carry the tension the concrete releases at the instant it cracks. It is
+      written on ``A_ct``, the area of the section *in tension*, so it only
+      applies to a face that has one. A face asked for with no moment on it has
+      no tension zone and no crack to control, and the geometric minimum is all
+      it is owed.
+
+    Where both apply, the larger governs. Which one that is depends on the
+    depth: with ``A_ct = b*h/2`` the crack-control ratio goes with ``k/2``, and
+    ``k`` decays from 1.00 to 0.65 between 300 and 800 mm, so it governs the
+    THIN footings and the geometric minimum takes over in the thick ones —
+    around h = 640 mm for C25 with B500S.
 
     Args:
+        M_Ed: Design moment on the face, as a positive magnitude (N·mm). Only
+            its being zero matters: a face with any moment has a tension zone.
         d: Effective depth of the tension reinforcement (mm).
 
     Returns:
@@ -345,6 +358,9 @@ def _minimum_flexural_reinforcement_area_EN_1992_2004(self: "RectangularBeam", d
 
     concrete_en = cast("Concrete_EN_1992_2004", self.concrete)
     A_s_geometric = flexure_eq.foundation_min_reinforcement_ratio(sec.f_y) * sec.width * sec.height
+    if M_Ed == 0:
+        return A_s_geometric
+
     A_s_crack = flexure_eq.crack_control_min_reinforcement(
         _K_C_BENDING,
         flexure_eq.crack_control_coefficient_k(sec.height),
@@ -401,7 +417,7 @@ def _calculate_flexural_reinforcement_EN_1992_2004(
     sec = section_floats(self)
     b = sec.width
     d_mm = d
-    A_s_min = _minimum_flexural_reinforcement_area_EN_1992_2004(self, d_mm)
+    A_s_min = _minimum_flexural_reinforcement_area_EN_1992_2004(self, M_Ed, d_mm)
     A_s_max = rho_max * d_mm * b
 
     # Constants and material properties
@@ -541,16 +557,21 @@ def _determine_nominal_moment_EN_1992_2004(self: "RectangularBeam", st: ENFlexur
     # section, so there is no single ratio both cases can be expressed in.
     sec = section_floats(self)
     tension_at_bottom = force._M_y > 0 * kNm
+    M_face = abs(force._M_y.to(_Nmm).magnitude)
 
     # Calculate minimum and maximum bottom reinforcement areas
-    st.A_s_min_bot = _minimum_flexural_reinforcement_area_EN_1992_2004(self, sec.d_bot) if tension_at_bottom else 0.0
+    st.A_s_min_bot = (
+        _minimum_flexural_reinforcement_area_EN_1992_2004(self, M_face, sec.d_bot) if tension_at_bottom else 0.0
+    )
     st.A_s_max_bot = rho_max * sec.d_bot * sec.width
     # Determine the nominal moment for positive moments
     st.M_Rd_bot = _simple_determine_nominal_moment_EN_1992_2004(
         self, sec.A_s_bot, sec.d_bot, sec.A_s_top, sec.c_mec_top
     )
     # Determine capacity for negative moment (tension at the top)
-    st.A_s_min_top = 0.0 if tension_at_bottom else _minimum_flexural_reinforcement_area_EN_1992_2004(self, sec.d_top)
+    st.A_s_min_top = (
+        0.0 if tension_at_bottom else _minimum_flexural_reinforcement_area_EN_1992_2004(self, M_face, sec.d_top)
+    )
     st.A_s_max_top = rho_max * sec.d_top * sec.width
     st.M_Rd_top = _simple_determine_nominal_moment_EN_1992_2004(
         self, sec.A_s_top, sec.d_top, sec.A_s_bot, sec.c_mec_bot

--- a/mento/codes/EN_1992_2004_beam.py
+++ b/mento/codes/EN_1992_2004_beam.py
@@ -316,36 +316,32 @@ def _min_max_flexural_reinforcement_ratio_EN_1992_2004(
 _K_C_BENDING = 0.4
 
 
-def _minimum_flexural_reinforcement_area_EN_1992_2004(self: "RectangularBeam", M_Ed: float, d: float) -> float:
-    """A_s,min on one face, for the way this element is supported.
+def _minimum_flexural_reinforcement_area_EN_1992_2004(self: "RectangularBeam", d: float) -> float:
+    """A_s,min on the tension face, for the way this element is supported.
 
     A member spanning between supports gets the non-fragility minimum of
     §9.2.1.1, ``rho_min * b_t * d``.
 
     A member bearing on the ground does not: the brittle failure that clause
     guards against needs the support to disappear when the section cracks, and
-    here the soil goes on carrying it. Two rules take its place instead, and
-    they do not apply to the same faces:
+    here the soil goes on carrying it. Two rules take its place, and the larger
+    governs:
 
-    * the halved geometric minimum of a foundation, on the gross section. It is
-      shrinkage and restraint steel, so every face gets it whether or not it is
-      bending.
+    * the halved geometric minimum of a foundation, on the gross section; and
     * the crack-control minimum of §7.3.2(2), which sizes the steel that has to
-      carry the tension the concrete releases at the instant it cracks. It is
-      written on ``A_ct``, the area of the section *in tension*, so it only
-      applies to a face that has one. A face asked for with no moment on it has
-      no tension zone and no crack to control, and the geometric minimum is all
-      it is owed.
+      carry the tension the concrete releases at the instant it cracks.
 
-    Where both apply, the larger governs. Which one that is depends on the
-    depth: with ``A_ct = b*h/2`` the crack-control ratio goes with ``k/2``, and
-    ``k`` decays from 1.00 to 0.65 between 300 and 800 mm, so it governs the
-    THIN footings and the geometric minimum takes over in the thick ones —
-    around h = 640 mm for C25 with B500S.
+    The second governs the THIN footings, not the thick ones: it is written on
+    ``A_ct = b*h/2``, so its ratio goes with ``k/2``, and ``k`` decays from 1.00
+    to 0.65 between 300 and 800 mm of depth. The geometric minimum takes over
+    once it has -- around h = 640 mm for C25 with B500S.
+
+    Only a face in tension is asked for this. The caller splits the two faces by
+    which one the moment puts in tension, and a face that is not in tension is
+    given no minimum at all rather than a smaller one: whether a footing carries
+    steel on that face is not a question a single section can answer.
 
     Args:
-        M_Ed: Design moment on the face, as a positive magnitude (N·mm). Only
-            its being zero matters: a face with any moment has a tension zone.
         d: Effective depth of the tension reinforcement (mm).
 
     Returns:
@@ -358,9 +354,6 @@ def _minimum_flexural_reinforcement_area_EN_1992_2004(self: "RectangularBeam", M
 
     concrete_en = cast("Concrete_EN_1992_2004", self.concrete)
     A_s_geometric = flexure_eq.foundation_min_reinforcement_ratio(sec.f_y) * sec.width * sec.height
-    if M_Ed == 0:
-        return A_s_geometric
-
     A_s_crack = flexure_eq.crack_control_min_reinforcement(
         _K_C_BENDING,
         flexure_eq.crack_control_coefficient_k(sec.height),
@@ -417,7 +410,7 @@ def _calculate_flexural_reinforcement_EN_1992_2004(
     sec = section_floats(self)
     b = sec.width
     d_mm = d
-    A_s_min = _minimum_flexural_reinforcement_area_EN_1992_2004(self, M_Ed, d_mm)
+    A_s_min = _minimum_flexural_reinforcement_area_EN_1992_2004(self, d_mm)
     A_s_max = rho_max * d_mm * b
 
     # Constants and material properties
@@ -557,21 +550,16 @@ def _determine_nominal_moment_EN_1992_2004(self: "RectangularBeam", st: ENFlexur
     # section, so there is no single ratio both cases can be expressed in.
     sec = section_floats(self)
     tension_at_bottom = force._M_y > 0 * kNm
-    M_face = abs(force._M_y.to(_Nmm).magnitude)
 
     # Calculate minimum and maximum bottom reinforcement areas
-    st.A_s_min_bot = (
-        _minimum_flexural_reinforcement_area_EN_1992_2004(self, M_face, sec.d_bot) if tension_at_bottom else 0.0
-    )
+    st.A_s_min_bot = _minimum_flexural_reinforcement_area_EN_1992_2004(self, sec.d_bot) if tension_at_bottom else 0.0
     st.A_s_max_bot = rho_max * sec.d_bot * sec.width
     # Determine the nominal moment for positive moments
     st.M_Rd_bot = _simple_determine_nominal_moment_EN_1992_2004(
         self, sec.A_s_bot, sec.d_bot, sec.A_s_top, sec.c_mec_top
     )
     # Determine capacity for negative moment (tension at the top)
-    st.A_s_min_top = (
-        0.0 if tension_at_bottom else _minimum_flexural_reinforcement_area_EN_1992_2004(self, M_face, sec.d_top)
-    )
+    st.A_s_min_top = 0.0 if tension_at_bottom else _minimum_flexural_reinforcement_area_EN_1992_2004(self, sec.d_top)
     st.A_s_max_top = rho_max * sec.d_top * sec.width
     st.M_Rd_top = _simple_determine_nominal_moment_EN_1992_2004(
         self, sec.A_s_top, sec.d_top, sec.A_s_bot, sec.c_mec_bot

--- a/mento/slab.py
+++ b/mento/slab.py
@@ -332,9 +332,11 @@ class Footing(OneWaySlab):
       flexural minimum with the shrinkage and temperature reinforcement of
       §24.4.3.2 -- 0.0018*b*h at f_y = 420 MPa, on the gross section. CIRSOC
       201-25 shares the clause.
-    * EN 1992-1-1 takes the larger of the halved geometric minimum of a
-      foundation and the crack-control minimum of §7.3.2(2), which is usually
-      the one that governs a thick footing.
+    * EN 1992-1-1 takes the halved geometric minimum of a foundation on every
+      face, and on a face that is bending, the larger of that and the
+      crack-control minimum of §7.3.2(2). The second governs the thin footings:
+      its ratio goes with k/2, and k decays from 1.00 to 0.65 between 300 and
+      800 mm of depth.
 
     Both are returned already resolved to the largest applicable minimum, so a
     caller designs a footing and takes the answer as it comes.

--- a/mento/slab.py
+++ b/mento/slab.py
@@ -332,11 +332,10 @@ class Footing(OneWaySlab):
       flexural minimum with the shrinkage and temperature reinforcement of
       §24.4.3.2 -- 0.0018*b*h at f_y = 420 MPa, on the gross section. CIRSOC
       201-25 shares the clause.
-    * EN 1992-1-1 takes the halved geometric minimum of a foundation on every
-      face, and on a face that is bending, the larger of that and the
-      crack-control minimum of §7.3.2(2). The second governs the thin footings:
-      its ratio goes with k/2, and k decays from 1.00 to 0.65 between 300 and
-      800 mm of depth.
+    * EN 1992-1-1 takes the larger of the halved geometric minimum of a
+      foundation and the crack-control minimum of §7.3.2(2). The second governs
+      the thin footings, not the thick ones: its ratio goes with k/2, and k
+      decays from 1.00 to 0.65 between 300 and 800 mm of depth.
 
     Both are returned already resolved to the largest applicable minimum, so a
     caller designs a footing and takes the answer as it comes.

--- a/tests/test_footing.py
+++ b/tests/test_footing.py
@@ -734,88 +734,77 @@ def test_a_section_that_cannot_carry_the_moment_falls_back(steel_b500s, height, 
 
 
 # ---------------------------------------------------------------------------
-# Which face each of the EN rules applies to
+# Which of the two EN rules governs, and at what depth
 # ---------------------------------------------------------------------------
 
 
-def _en_minimum_per_mille(footing, M_Ed):  # type: ignore[no-untyped-def]
-    """A_s,min on one face of a metre strip, as a ratio of the gross section."""
+def _en_minimum_per_mille(footing):  # type: ignore[no-untyped-def]
+    """A_s,min on the tension face of a metre strip, per mille of the gross section."""
     d = (footing.height - footing.c_c - 10 * mm).to("mm").magnitude
-    area = _minimum_flexural_reinforcement_area_EN_1992_2004(footing, M_Ed, d)
+    area = _minimum_flexural_reinforcement_area_EN_1992_2004(footing, d)
     gross = (footing.width * footing.height).to("mm**2").magnitude
     return area / gross * 1000
 
 
 @pytest.mark.parametrize(
-    "height, bending",
+    "height, expected",
     [(40 * cm, 1.097), (60 * cm, 0.932), (90 * cm, 0.900)],
     ids=["h040", "h060", "h090"],
 )
-def test_only_a_bending_face_gets_the_crack_control_minimum(steel_b500s, height, bending) -> None:  # type: ignore[no-untyped-def]
-    """§7.3.2 sizes the steel that carries the tension released at cracking, and
-    is written on A_ct, the area of the section in tension.
+def test_the_crack_rule_governs_the_thin_footings_not_the_thick(steel_b500s, height, expected) -> None:  # type: ignore[no-untyped-def]
+    """Crack control is written on A_ct = b*h/2, so its ratio goes with k/2, and
+    k decays from 1.00 to 0.65 between 300 and 800 mm.
 
-    A face asked for with no moment on it has no tension zone and no crack to
-    control, so only the geometric minimum is owed. A face that is bending
-    takes the larger of the two -- which is the crack rule until the section is
-    thick enough for k to have decayed.
+    Both rules are proportional to h, so only k separates them: crack control
+    governs while the section is thin, and the 0.9 per mille geometric minimum
+    takes over once k has decayed — by 0.90 m it already has.
     """
     concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
     footing = _strip(Footing, concrete, steel_b500s, "Z1", height=height)
 
-    assert _en_minimum_per_mille(footing, 100e6) == pytest.approx(bending, abs=0.001)
-    assert _en_minimum_per_mille(footing, 0.0) == pytest.approx(0.900, abs=0.001)
+    assert _en_minimum_per_mille(footing) == pytest.approx(expected, abs=0.001)
 
 
-def test_the_crack_rule_governs_the_thin_footings_not_the_thick(steel_b500s: SteelBar) -> None:
-    """The ratio goes with k/2, and k decays with the depth, so the excess over
-    the geometric minimum shrinks as the footing gets thicker."""
+def test_the_excess_over_the_geometric_minimum_shrinks_with_depth(steel_b500s: SteelBar) -> None:
+    """The same thing read as a trend rather than three numbers."""
     concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
     excess = [
-        _en_minimum_per_mille(_strip(Footing, concrete, steel_b500s, "Z1", height=h * cm), 100e6) - 0.900
-        for h in (40, 60, 90)
+        _en_minimum_per_mille(_strip(Footing, concrete, steel_b500s, "Z1", height=h * cm)) - 0.900 for h in (40, 60, 90)
     ]
 
     assert excess[0] > excess[1] > 0
     assert excess[2] == pytest.approx(0.0, abs=1e-9)
 
 
-def test_a_face_designed_without_a_moment_takes_only_the_geometric_minimum(steel_b500s: SteelBar) -> None:
-    """Through the design, not just the equation: a footing whose bottom face
-    is asked for with no positive moment gets the geometric minimum there."""
-    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
-    footing = _strip(Footing, concrete, steel_b500s, "Z1", height=40 * cm)
-    combo = [Forces(label="C1", M_y=-80 * kNm)]
-    Node(section=footing, forces=combo).design()
-
-    geometric = 0.0009 * (footing.width * footing.height)
-    assert footing._A_s_bot.to("cm**2").magnitude >= geometric.to("cm**2").magnitude
-    # And not the crack minimum, which on a 400 mm section is 22% above it.
-    assert footing._A_s_bot.to("cm**2").magnitude < 1.22 * geometric.to("cm**2").magnitude
-
-
-def test_a_bending_face_still_gets_the_larger_of_the_two(steel_b500s: SteelBar) -> None:
-    """The face that is bending is unaffected by the distinction."""
-    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
-    footing = _strip(Footing, concrete, steel_b500s, "Z1", height=40 * cm)
-    _design(footing, M_y=120 * kNm)
-
-    geometric = (0.0009 * footing.width * footing.height).to("cm**2").magnitude
-    assert footing._A_s_min_bot.to("cm**2").magnitude == pytest.approx(1.097 / 0.900 * geometric, rel=1e-3)
-
-
 def test_a_footing_with_no_top_moment_is_left_without_top_steel(steel_b500s: SteelBar) -> None:
-    """The geometric minimum applying to every face does not mean mento places
-    a face nobody asked for.
+    """A face that is not in tension is given no minimum, not a smaller one.
 
-    Whether a footing carries top steel is the consumer's call -- it is the only
-    one that sees both orthogonal sections of the element -- so a design given
-    no negative moment leaves the top empty.
+    Whether a footing carries top steel is the consumer's call — it is the only
+    one that sees both orthogonal sections of the element — so a design given no
+    negative moment leaves the top empty rather than reasoning about what
+    minimum an unloaded face would be owed.
     """
     concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
     footing = _strip(Footing, concrete, steel_b500s, "Z1", height=40 * cm)
-    Node(section=footing, forces=[Forces(label="C1", M_y=200 * kNm)]).design()
+    combo = [Forces(label="C1", M_y=200 * kNm)]
+    Node(section=footing, forces=combo).design()
 
     assert footing._A_s_top.magnitude == 0
     assert footing._d_b1_t.magnitude == 0
     assert footing._s_b1_t.magnitude == 0
+    assert max(r.top.A_s_min for r in footing.flexure_check_results(combo)) == 0
+
+
+def test_both_faces_in_tension_both_get_the_crack_minimum(steel_b500s: SteelBar) -> None:
+    """A footing bending both ways has a tension zone on each face, so each is
+    owed the crack-control minimum."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _strip(Footing, concrete, steel_b500s, "Z1", height=40 * cm)
+    combo = [Forces(label="M+", M_y=150 * kNm), Forces(label="M-", M_y=-60 * kNm)]
+    Node(section=footing, forces=combo).design()
+
+    results = footing.flexure_check_results(combo)
+    gross = (footing.width * footing.height).to("mm**2").magnitude
+    for face in ("bottom", "top"):
+        governing = max(getattr(r, face).A_s_min for r in results)
+        assert governing / gross * 1000 == pytest.approx(1.097, abs=0.001)

--- a/tests/test_footing.py
+++ b/tests/test_footing.py
@@ -21,6 +21,7 @@ from mento.material import (
     SteelBar,
 )
 from mento.node import Node
+from mento.codes.EN_1992_2004_beam import _minimum_flexural_reinforcement_area_EN_1992_2004
 from mento.slab import Footing, OneWaySlab
 from mento.units import cm, inch, kNm, kip, m, mm, MPa, psi
 
@@ -730,3 +731,91 @@ def test_a_section_that_cannot_carry_the_moment_falls_back(steel_b500s, height, 
 
     results = footing.flexure_check_results(combo)
     assert max(max(r.bottom.DCR, r.top.DCR) for r in results) > 1
+
+
+# ---------------------------------------------------------------------------
+# Which face each of the EN rules applies to
+# ---------------------------------------------------------------------------
+
+
+def _en_minimum_per_mille(footing, M_Ed):  # type: ignore[no-untyped-def]
+    """A_s,min on one face of a metre strip, as a ratio of the gross section."""
+    d = (footing.height - footing.c_c - 10 * mm).to("mm").magnitude
+    area = _minimum_flexural_reinforcement_area_EN_1992_2004(footing, M_Ed, d)
+    gross = (footing.width * footing.height).to("mm**2").magnitude
+    return area / gross * 1000
+
+
+@pytest.mark.parametrize(
+    "height, bending",
+    [(40 * cm, 1.097), (60 * cm, 0.932), (90 * cm, 0.900)],
+    ids=["h040", "h060", "h090"],
+)
+def test_only_a_bending_face_gets_the_crack_control_minimum(steel_b500s, height, bending) -> None:  # type: ignore[no-untyped-def]
+    """§7.3.2 sizes the steel that carries the tension released at cracking, and
+    is written on A_ct, the area of the section in tension.
+
+    A face asked for with no moment on it has no tension zone and no crack to
+    control, so only the geometric minimum is owed. A face that is bending
+    takes the larger of the two -- which is the crack rule until the section is
+    thick enough for k to have decayed.
+    """
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _strip(Footing, concrete, steel_b500s, "Z1", height=height)
+
+    assert _en_minimum_per_mille(footing, 100e6) == pytest.approx(bending, abs=0.001)
+    assert _en_minimum_per_mille(footing, 0.0) == pytest.approx(0.900, abs=0.001)
+
+
+def test_the_crack_rule_governs_the_thin_footings_not_the_thick(steel_b500s: SteelBar) -> None:
+    """The ratio goes with k/2, and k decays with the depth, so the excess over
+    the geometric minimum shrinks as the footing gets thicker."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    excess = [
+        _en_minimum_per_mille(_strip(Footing, concrete, steel_b500s, "Z1", height=h * cm), 100e6) - 0.900
+        for h in (40, 60, 90)
+    ]
+
+    assert excess[0] > excess[1] > 0
+    assert excess[2] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_a_face_designed_without_a_moment_takes_only_the_geometric_minimum(steel_b500s: SteelBar) -> None:
+    """Through the design, not just the equation: a footing whose bottom face
+    is asked for with no positive moment gets the geometric minimum there."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _strip(Footing, concrete, steel_b500s, "Z1", height=40 * cm)
+    combo = [Forces(label="C1", M_y=-80 * kNm)]
+    Node(section=footing, forces=combo).design()
+
+    geometric = 0.0009 * (footing.width * footing.height)
+    assert footing._A_s_bot.to("cm**2").magnitude >= geometric.to("cm**2").magnitude
+    # And not the crack minimum, which on a 400 mm section is 22% above it.
+    assert footing._A_s_bot.to("cm**2").magnitude < 1.22 * geometric.to("cm**2").magnitude
+
+
+def test_a_bending_face_still_gets_the_larger_of_the_two(steel_b500s: SteelBar) -> None:
+    """The face that is bending is unaffected by the distinction."""
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _strip(Footing, concrete, steel_b500s, "Z1", height=40 * cm)
+    _design(footing, M_y=120 * kNm)
+
+    geometric = (0.0009 * footing.width * footing.height).to("cm**2").magnitude
+    assert footing._A_s_min_bot.to("cm**2").magnitude == pytest.approx(1.097 / 0.900 * geometric, rel=1e-3)
+
+
+def test_a_footing_with_no_top_moment_is_left_without_top_steel(steel_b500s: SteelBar) -> None:
+    """The geometric minimum applying to every face does not mean mento places
+    a face nobody asked for.
+
+    Whether a footing carries top steel is the consumer's call -- it is the only
+    one that sees both orthogonal sections of the element -- so a design given
+    no negative moment leaves the top empty.
+    """
+    concrete = Concrete_EN_1992_2004(name="C25", f_c=25 * MPa)
+    footing = _strip(Footing, concrete, steel_b500s, "Z1", height=40 * cm)
+    Node(section=footing, forces=[Forces(label="C1", M_y=200 * kNm)]).design()
+
+    assert footing._A_s_top.magnitude == 0
+    assert footing._d_b1_t.magnitude == 0
+    assert footing._s_b1_t.magnitude == 0


### PR DESCRIPTION
# Description

Follow-up to #150, which merged just before this landed — the correction is not in
`main`.

The docstrings said the EN crack-control minimum of §7.3.2(2) "is usually the one that
governs a thick footing". It is the other way round. Written on `A_ct = b·h/2`, its
ratio goes with `k/2`, and `k` decays from 1.00 to 0.65 between 300 and 800 mm, so it
governs the **thin** footings and the geometric minimum takes over in the thick ones —
the crossover falling around h = 640 mm for C25 with B500S.

On a metre strip, C25 with B500S, against the 0.9 ‰ geometric minimum:

| h | A_s,min applied | geometric alone | governing rule |
| --- | --- | --- | --- |
| 0.40 m | 1.097 ‰ | 0.900 ‰ | crack control, +22% |
| 0.60 m | 0.932 ‰ | 0.900 ‰ | crack control, +4% |
| 0.90 m | 0.900 ‰ | 0.900 ‰ | geometric |

**The calculation was right all along** — the theory page already said this correctly.
Only the two docstrings had it inverted, which is the kind of error that survives review
precisely because the numbers around it are right.

## What is in the diff

- The corrected docstrings, in `EN_1992_2004_beam.py` and on the `Footing` class.
- The depth table above in the theory page, and the trend pinned as tests.
- A note, in both doc pages, on **what mento's scope actually is** here: it answers one
  section. A face the moment puts in tension is owed the minimum; a face it does not is
  left unreinforced, because whether a footing carries steel there is the consumer's
  call — the only one that sees both orthogonal sections. The distribution reinforcement
  across the span is the same question asked of a *different* section, and is designed
  as one. mento never reasons about two directions at once.

## A branch that was added and then dropped

The first commit also split the two minimums by face, giving a face asked for with no
moment only the geometric minimum. Measured against the cases that actually reach mento,
it changed nothing:

| case | with the branch | without |
| --- | --- | --- |
| only a bottom moment | bot 11.31, top 0.00 | identical |
| moment on both faces | bot 12.06, top 4.71 | identical |
| only a top moment | bot 4.71, top 12.06 | identical |
| no moment on either face | bot 3.93 | bot 4.52 |

A face not in tension is already given no minimum at all, so the only input that reached
the branch was a section with zero moment on both faces — which no consumer sends. It is
dropped in the second commit rather than kept as a rule nobody exercises. The two
commits are left as they happened; the net diff is the docstring correction and the
scope note.

## Type of change

- [x] Bug fix
- [ ] New feature or design code implementation
- [x] Documentation
- [ ] Maintenance (tooling, CI, refactoring with no behaviour change)

## Checklist

- [x] Tests added or updated, and `pytest` passes locally (1238 passed, 1 skipped)
- [x] `mypy mento/` passes
- [x] `pre-commit run --all-files` reports no changes
- [x] Documentation updated where the change is user facing
- [x] Public class and method names left unchanged, or the change was agreed beforehand

Coverage stays at 100% (4980 statements, 0 missed), `sphinx-build -W` is clean. No
behaviour change: `A_s,min` is what it was before this PR.

## Calculation validation

- [ ] Validated in CalcPad, and the file is included in this PR
- **Reference example:** EN 1992-1-1 §7.3.2(2), Eq. (7.1), with `k` from the same clause.
- **Result comparison:** the three depths above are pinned to their exact ratios in
  `test_the_crack_rule_governs_the_thin_footings_not_the_thick`, and the trend — the
  excess over the geometric minimum shrinking to zero with depth — in
  `test_the_excess_over_the_geometric_minimum_shrinks_with_depth`. No CalcPad file: the
  numbers were already validated in #150; this PR corrects prose about them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
