### PR TITLE
feat(results): the frozen results carry the capacity the DCR was formed from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ from the release history and are summaries rather than complete lists.
 
 ## [Unreleased]
 
+### Added
+
+- **The frozen results carry the capacity the DCR was formed from.** `FlexureFaceCheck`
+  and `FlexureFaceDesign` gain `M_capacity`; `ShearCheck` and `ShearDesign` gain
+  `V_capacity`. One neutral name for every code: `ØMn` and `ØVn` (capped by `ØVmax`)
+  under ACI 318-19 and CIRSOC 201-25, `MRd` and `VRd` under EN 1992-1-1. A caller
+  printing the resistance next to the demand no longer divides the demand by a rounded
+  ratio, gets a real number for a face reinforced against no demand, and needs none of
+  the `_phi_M_n_*`, `_M_Rd_*`, `_phi_V_n` or `_V_Rd` attributes of the compatibility
+  layer. On a design the capacity is the governing combination's, so `demand / DCR`
+  gives it back there too. Brief: `docs/architecture/capacity-in-design-results.md`.
+
+### Fixed
+
+- **`flexure_check_results()` returned `A_s_req`, `A_s_min` and `A_s_max` as bare
+  floats** in the design code's canonical units (mm² or in²), where `check_flexure()`
+  returned them as quantities in cm² or in². Both entry points now read the check state
+  through the same path and return quantities.
+
 ## [1.0.1] - 2026-08-31
 
 ### Changed

--- a/docs/architecture/capacity-in-design-results.md
+++ b/docs/architecture/capacity-in-design-results.md
@@ -1,7 +1,8 @@
 # Brief — the frozen results should carry the capacity
 
-Status: proposed (2026-09-02). Raised from mako, which hit it building the footing
-reinforcement tables.
+Status: implemented (2026-09-02). Raised from mako, which hit it building the footing
+reinforcement tables. See *Outcome* at the end for where the implementation departs from
+the proposal.
 
 ## The gap in one sentence
 
@@ -159,3 +160,33 @@ mako's `get_footing_rebar_summary()`, one row per footing type, direction and fa
 | 3 | y | inferior | 2.0 | 38.6 | 0.0 | *(vacío)* | Ø10/24 | 0.051 |
 
 The `MRd` column is the division above; the blank `VRd` is the `DCR = 0` case.
+
+## Outcome
+
+Implemented as proposed -- `M_capacity` on `FlexureFaceCheck` / `FlexureFaceDesign`,
+`V_capacity` on `ShearCheck` / `ShearDesign`, populated for ACI 318-19, CIRSOC 201-25 and
+EN 1992-1-1 on beams, slabs and footings -- with two departures the numbers forced:
+
+1. **ACI shear reports `min(ØVn, ØVmax)`, not `ØVn`.** The check ratios the demand
+   against the smaller of the two (`_calculate_total_shear_strength_aci`), so that is the
+   resistance the ratio was formed from. Reporting `ØVn` alone would break
+   `demand / DCR == capacity` on every section governed by the 22.5.1.2 cap.
+2. **The envelope takes the governing combination's capacity, not the minimum.** The
+   proposal assumed a capacity is the section's alone. Under ACI 318-19 the shear
+   resistance moves with the combination -- `Vc` depends on the axial load and on which
+   face is in tension -- and a beam checked against three combinations reported three
+   different `ØVn`. The minimum would have left `shear_design.DCR` and
+   `shear_design.V_capacity` formed from different combinations, so the triple mako
+   prints would not have been a ratio. The envelope now carries the capacity of the
+   combination with the largest DCR; among ties (every combination, when nothing is
+   demanded) the smallest, which is the reading the proposal wanted.
+
+The wrinkle on EN's dynamic state attributes had already been resolved before this landed:
+`ENFlexureCheckState` declares `M_Rd_bot` / `M_Rd_top` and `ENShearCheckState` declares
+`V_Rd`. Each state hands its capacity to the frozen result through one method
+(`face_quantities`, `shear_capacity_quantity`), so the result never has to know which
+name a code uses.
+
+One thing fixed on the way: `flexure_check_results()` was handing `A_s_req`, `A_s_min` and
+`A_s_max` to the frozen result as bare floats in canonical units, where `check_flexure()`
+returned quantities. Both paths now read the state through `face_quantities` and agree.

--- a/docs/architecture/capacity-in-design-results.md
+++ b/docs/architecture/capacity-in-design-results.md
@@ -1,0 +1,161 @@
+# Brief — the frozen results should carry the capacity
+
+Status: proposed (2026-09-02). Raised from mako, which hit it building the footing
+reinforcement tables.
+
+## The gap in one sentence
+
+A checked or designed section publishes **a ratio but not the resistance the ratio was
+formed from**, so a caller that wants to print `ØMn` / `MRd` / `ØVn` / `VRd` next to the
+demand has nowhere public to read it.
+
+## What the public results carry today
+
+`mento/design_results.py`:
+
+```python
+@dataclass(frozen=True)
+class FlexureFaceCheck:
+    A_s_req: Optional[Quantity]
+    A_s_min: Optional[Quantity]
+    A_s_max: Optional[Quantity]
+    DCR: float
+
+@dataclass(frozen=True)
+class FlexureFaceDesign:
+    layers: Tuple[RebarLayer, ...]
+    A_s: Quantity
+    A_s_req: Quantity
+    A_s_min: Quantity
+    A_s_max: Quantity
+    DCR: float
+
+@dataclass(frozen=True)
+class ShearCheck:
+    label: str
+    A_v_req: Optional[Quantity]
+    A_v_min: Optional[Quantity]
+    DCR: float
+
+@dataclass(frozen=True)
+class ShearDesign:
+    n_stirrups: int
+    ...
+    A_v_req: Quantity
+    A_v_min: Quantity
+    DCR: float
+```
+
+Areas, ratios, bars. No resistance anywhere.
+
+## The value already exists — it just does not leave the check
+
+It is computed and held in the check state, one file away from the frozen result:
+
+- `mento/codes/check_state.py` → `FlexureCheckState.phi_M_n_bot` / `.phi_M_n_top`
+- `mento/codes/check_state.py` → `ShearCheckState.phi_V_n`
+- `mento/codes/ACI_318_19_beam.py:818` → `st.DCR_bot = st.M_u_bot / st.phi_M_n_bot`
+- `mento/codes/EN_1992_2004_beam.py:677` → `st.DCR_bot = round(st.M_Ed_bot / st.M_Rd_bot, 3)`
+
+So the ratio the public result *does* publish is formed from a number the public result
+*does not*. From the outside the only route is the compatibility layer —
+`section._phi_M_n_bot`, `section._M_Rd_bot`, `section._phi_V_n`, `section._V_Rd` — which
+`mento/beam.py` declares under `TYPE_CHECKING` with the comment:
+
+> They leave with the compatibility layer. A new design code should not add to this list —
+> its report tables should read the check state instead.
+
+A consumer reading those is coupling to something mento has already announced it will
+delete, so mako does not.
+
+## What mako does instead, and why it is not good enough
+
+mako divides the demand back out:
+
+```python
+capacity = demand / DCR   # exact by definition, when DCR > 0
+```
+
+Two problems, both visible in office output:
+
+1. **It inherits the ratio's rounding.** EN rounds `DCR` to 3 decimals, so two faces
+   carrying identical reinforcement come back with different resistances — a real footing
+   printed `MRd` 43.3 on one face and 43.4 on the other.
+2. **It says nothing when `DCR = 0`.** A footing's top mat usually carries minimum
+   reinforcement against no demand. It has a real flexural capacity; nothing published
+   says what it is, so the cell goes blank.
+
+Neither is worth working around downstream: computing a section capacity in mako would be
+a second implementation of mento's own equations, diverging the first time either changes.
+
+## Proposal
+
+Add one field to each of the four frozen results.
+
+```python
+@dataclass(frozen=True)
+class FlexureFaceCheck:
+    ...
+    M_capacity: Optional[Quantity]   # ØM_n under ACI/CIRSOC, M_Rd under EN
+
+@dataclass(frozen=True)
+class FlexureFaceDesign:
+    ...
+    M_capacity: Quantity
+
+@dataclass(frozen=True)
+class ShearCheck:
+    ...
+    V_capacity: Optional[Quantity]   # ØV_n under ACI/CIRSOC, V_Rd under EN
+
+@dataclass(frozen=True)
+class ShearDesign:
+    ...
+    V_capacity: Quantity
+```
+
+Notes on the shape:
+
+- **One neutral name per quantity, not one per code.** The code already owns the
+  *symbol* — `DesignCode.summary_columns` publishes `ØMn,bot` against `MRd,bot` — so the
+  presentation layer keeps naming things per code and the data structure does not have to.
+  This is the same split ADR-0004 draws.
+- **The envelope helpers need a rule.** `envelope_flexure_face` and `envelope_shear`
+  currently take the worst of each quantity independently. A capacity is a property of the
+  section, not of the combination, so every combination should report the same one; taking
+  the minimum present is the safe reading if that ever stops holding.
+- **`Optional` on the check results only**, matching the fields beside them: a field is
+  `None` when the design code did not set it for that combination.
+- Nothing in `codes/` needs new physics. `phi_M_n_bot`, `phi_M_n_top` and `phi_V_n` are
+  already on the state; this is plumbing them into the frozen result the way `A_s_req`
+  already is.
+
+One wrinkle to decide on the way past: `EN_1992_2004_beam.py` writes `st.M_Rd_bot` and
+`st.M_Ed_bot`, which are **not** fields of `FlexureCheckState` — the dataclass is neither
+frozen nor slotted, so they attach dynamically. Either EN should fill the declared
+`phi_M_n_*` fields, or the state should declare the EN names too. Silent dynamic
+attributes on a state object are how two codes end up disagreeing about what a field
+means.
+
+## Acceptance
+
+- `beam.check_flexure(...)` / `check_shear(...)` and `slab.design(...)` /
+  `Footing.design(...)` all return results whose capacity field is populated for both ACI
+  318-19 and EN 1992-2004.
+- For any combination with `DCR > 0`, `demand / DCR == capacity` to within the code's own
+  rounding — a regression test worth writing, since it is the invariant mako is
+  currently leaning on.
+- A face carrying only minimum reinforcement reports a real capacity rather than nothing.
+- No consumer needs `section._phi_M_n_bot`, `_M_Rd_bot`, `_phi_V_n` or `_V_Rd` any more —
+  which is one more thing the compatibility layer can drop on its way out.
+
+## Who is waiting on it
+
+mako's `get_footing_rebar_summary()`, one row per footing type, direction and face:
+
+| Tipo | Dir. | Cara | MEd (kNm) | MRd (kNm) | VEd (kN) | VRd (kN) | Ø/s | DCR |
+|---|---|---|---|---|---|---|---|---|
+| 6 | x | inferior | 131.3 | 157.3 | 129.5 | 261.4 | Ø10/15 | 0.835 |
+| 3 | y | inferior | 2.0 | 38.6 | 0.0 | *(vacío)* | Ø10/24 | 0.051 |
+
+The `MRd` column is the division above; the blank `VRd` is the `DCR = 0` case.

--- a/docs/source/user_guide/design_results.rst
+++ b/docs/source/user_guide/design_results.rst
@@ -38,6 +38,7 @@ Flexure
     flexure.bottom.A_s_req.to("cm**2")  # 4.96 cm², steel required
     flexure.bottom.A_s_min, flexure.bottom.A_s_max
     flexure.bottom.DCR                  # 0.965
+    flexure.bottom.M_capacity           # 103.6 kN·m, ØMn here; MRd under EN 1992
     flexure.bottom.n_bars               # 3
 
     flexure.DCR                         # worst of the two faces
@@ -82,6 +83,7 @@ Shear
     shear.A_v.to("cm**2/m") # 5.82 cm²/m, provided
     shear.A_v_req, shear.A_v_min
     shear.DCR               # 0.462
+    shear.V_capacity        # 173 kN, ØVn here; VRd under EN 1992
 
     str(shear)              # '1eØ10 mm/27 cm'
 
@@ -103,6 +105,38 @@ be checked last:
 
 The provided reinforcement — ``A_s``, the layers and the stirrup layout — describes the
 section itself and does not depend on the combination.
+
+The capacity follows the DCR: it is the one of the combination that governs, so the two
+remain the ratio they were. Under ACI 318-19 the shear resistance can differ between
+combinations, since ``Vc`` depends on the axial load and on which face is in tension; the
+per-combination results keep each one's own.
+
+Capacities
+----------
+
+Each result also carries the resistance its ``DCR`` was formed from: ``M_capacity`` on a
+flexure face and ``V_capacity`` on the shear result. The name is the same under every
+design code — it holds ``ØMn`` and ``ØVn`` under ACI 318-19 and CIRSOC 201-25, ``MRd``
+and ``VRd`` under EN 1992-1-1 — so a report that prints the symbol names it per code and
+the data does not have to.
+
+For any combination with a demand, dividing the demand by its ``DCR`` gives the capacity
+back, to within the rounding the design code applies to the ratio. The field is there for
+the cases the ratio cannot cover: a face carrying minimum reinforcement against no demand
+has a ``DCR`` of zero and a real capacity, and two faces with identical reinforcement
+report exactly the same one.
+
+The per-combination results are available too, one per combination of the last check:
+
+.. code-block:: python
+
+    for check in beam.shear_checks:
+        check.label, check.DCR, check.V_capacity
+
+    for check in beam.flexure_checks:
+        check.label, check.bottom.DCR, check.bottom.M_capacity
+
+    beam.shear_design.V_capacity            # the governing combination's
 
 Reading results too early
 -------------------------

--- a/mento/beam.py
+++ b/mento/beam.py
@@ -772,7 +772,7 @@ class RectangularBeam(RectangularSection, _DesignCodeAttributes):
         self._flexure_checks = []
 
         for force in forces:
-            self._run_flexure_check(force, report=True)
+            state = self._run_flexure_check(force, report=True)
             result = self._flexure_report_row
             self._flexure_results_list.append(result)
 
@@ -785,9 +785,10 @@ class RectangularBeam(RectangularSection, _DesignCodeAttributes):
                 "checks_pass": self._all_flexure_checks_passed,
             }
 
-            # Capture this combination's result as a value, before the next one
-            # overwrites the attributes it just left on the beam.
-            self._flexure_checks.append(capture_flexure_check(self, force.label))
+            # The result is a value of the check itself, not a reading of the
+            # attributes it left on the beam -- those describe the last
+            # combination only, and are on their way out with them.
+            self._flexure_checks.append(capture_flexure_check(self, force.label, state))
 
             # Extract the DCR values for top and bottom from the results
             current_dcr_top = self._DCRb_top
@@ -921,7 +922,7 @@ class RectangularBeam(RectangularSection, _DesignCodeAttributes):
         self._shear_checks = []
 
         for force in forces:
-            self._run_shear_check(force, report=True)
+            state = self._run_shear_check(force, report=True)
             result = self._shear_report_row
             self._shear_results_list.append(result)
 
@@ -933,9 +934,9 @@ class RectangularBeam(RectangularSection, _DesignCodeAttributes):
                 "shear_concrete": self._shear_concrete.copy(),
             }
 
-            # Capture this combination's result as a value, before the next one
-            # overwrites the attributes it just left on the beam.
-            self._shear_checks.append(capture_shear_check(self, force.label))
+            # As in check_flexure: the value of the check, not the beam's
+            # attributes afterwards.
+            self._shear_checks.append(capture_shear_check(self, force.label, state))
 
             # Check if this result is the limiting case
             current_dcr = result["DCR"][0]

--- a/mento/codes/check_state.py
+++ b/mento/codes/check_state.py
@@ -62,6 +62,21 @@ def to_display(value: float, kind: str, imperial: bool) -> Any:
     return (value * CANONICAL[imperial][kind]).to(DISPLAY[imperial][kind])
 
 
+def _face_quantities(state: Any, face: str, capacity: str, imperial: bool) -> tuple[Any, Any, Any, Any]:
+    """``(A_s_req, A_s_min, A_s_max, capacity)`` of one face of a flexure state.
+
+    The two flexure states name their capacity differently -- ``phi_M_n`` and
+    ``M_Rd`` -- and share everything else, so each names its own field and
+    this does the wrapping.
+    """
+    return (
+        to_display(getattr(state, f"A_s_req_{face}"), "area", imperial),
+        to_display(getattr(state, f"A_s_min_{face}"), "area", imperial),
+        to_display(getattr(state, f"A_s_max_{face}"), "area", imperial),
+        to_display(getattr(state, capacity), "moment", imperial),
+    )
+
+
 @dataclass
 class ShearCheckState:
     """One combination's shear result, in the design code's own units.
@@ -100,6 +115,16 @@ class ShearCheckState:
             to_display(self.A_v_req, "per_length", imperial),
             to_display(self.A_v_min, "per_length", imperial),
         )
+
+    def shear_capacity_quantity(self, imperial: bool) -> Any:
+        """The design shear strength the DCR was formed from, as a quantity.
+
+        ``min(phi_V_n, phi_V_max)``: the check ratios the demand against the
+        smaller of the truss strength and the cap of ACI 318-19 22.5.1.2, so
+        that is the resistance the public result has to report for
+        ``demand / DCR`` to give it back.
+        """
+        return to_display(min(self.phi_V_n, self.phi_V_max), "force", imperial)
 
 
 def new_shear_state(section: "RectangularBeam") -> ShearCheckState:
@@ -216,6 +241,10 @@ class ENShearCheckState:
             to_display(self.A_v_req, "per_length", imperial),
             to_display(self.A_v_min, "per_length", imperial),
         )
+
+    def shear_capacity_quantity(self, imperial: bool) -> Any:
+        """``V_Rd``, the design shear resistance the DCR was formed from."""
+        return to_display(self.V_Rd, "force", imperial)
 
 
 def new_en_shear_state(section: "RectangularBeam") -> ENShearCheckState:
@@ -400,6 +429,14 @@ class FlexureCheckState:
     A_s_bool_top: bool
     doubly_reinforced: bool
 
+    def face_quantities(self, face: str, imperial: bool) -> tuple[Any, Any, Any, Any]:
+        """``(A_s_req, A_s_min, A_s_max, phi_M_n)`` of one face as quantities.
+
+        For the frozen public result; ``face`` is ``"bot"`` or ``"top"``. The
+        capacity is the ``phi_M_n`` the face's DCR was divided by.
+        """
+        return _face_quantities(self, face, f"phi_M_n_{face}", imperial)
+
 
 def new_flexure_state(section: "RectangularBeam") -> FlexureCheckState:
     """A zeroed flexure state. Every field is a float, so nothing is converted."""
@@ -498,6 +535,14 @@ class ENFlexureCheckState:
     rho_l_top: float
     DCR_bot: float
     DCR_top: float
+
+    def face_quantities(self, face: str, imperial: bool) -> tuple[Any, Any, Any, Any]:
+        """``(A_s_req, A_s_min, A_s_max, M_Rd)`` of one face as quantities.
+
+        For the frozen public result; ``face`` is ``"bot"`` or ``"top"``. The
+        capacity is the ``M_Rd`` the face's DCR was divided by.
+        """
+        return _face_quantities(self, face, f"M_Rd_{face}", imperial)
 
 
 def new_en_flexure_state(section: "RectangularBeam") -> ENFlexureCheckState:

--- a/mento/design_results.py
+++ b/mento/design_results.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING, Any, Optional, Sequence, Tuple
 
 from pint import Quantity
 
+from mento.codes.check_state import to_display
+
 if TYPE_CHECKING:
     from mento.beam import RectangularBeam
 
@@ -78,6 +80,13 @@ class RebarLayer:
 class FlexureFaceCheck:
     """What a single load combination demanded of one face.
 
+    ``M_capacity`` is the design moment resistance the ``DCR`` was formed
+    from -- ``ØMn`` under ACI 318-19 and CIRSOC 201-25, ``MRd`` under
+    EN 1992-1-1. One neutral name for every code: the symbol belongs to the
+    presentation layer, which already names it per code. A face carrying only
+    minimum reinforcement against no demand still reports it, which is what
+    the ratio alone cannot tell.
+
     A field is ``None`` when the design code did not set it for this
     combination; enveloping skips those rather than treating them as zero.
     """
@@ -86,6 +95,7 @@ class FlexureFaceCheck:
     A_s_min: Optional[Quantity]
     A_s_max: Optional[Quantity]
     DCR: float
+    M_capacity: Optional[Quantity] = None
 
 
 @dataclass(frozen=True)
@@ -99,12 +109,18 @@ class FlexureCheck:
 
 @dataclass(frozen=True)
 class ShearCheck:
-    """The shear result of one load combination."""
+    """The shear result of one load combination.
+
+    ``V_capacity`` is the design shear resistance the ``DCR`` was formed from
+    -- ``ØVn``, capped by ``ØVmax``, under ACI 318-19 and CIRSOC 201-25;
+    ``VRd`` under EN 1992-1-1. See :class:`FlexureFaceCheck` for the naming.
+    """
 
     label: str
     A_v_req: Optional[Quantity]
     A_v_min: Optional[Quantity]
     DCR: float
+    V_capacity: Optional[Quantity] = None
 
 
 def _worst(values: Sequence[Optional[Quantity]]) -> Optional[Quantity]:
@@ -113,12 +129,31 @@ def _worst(values: Sequence[Optional[Quantity]]) -> Optional[Quantity]:
     return max(present) if present else None
 
 
+def _governing(pairs: Sequence[Tuple[float, Optional[Quantity]]]) -> Optional[Quantity]:
+    """The capacity of the combination that governs, or None if none reported one.
+
+    ``pairs`` are ``(DCR, capacity)``, one per combination. The envelope's DCR
+    is the largest of them, and its capacity has to be the resistance that DCR
+    was formed from, so that ``demand / DCR`` gives it back on the envelope as
+    it does on each combination. That matters because a capacity is not always
+    the section's alone: under ACI 318-19 the shear resistance moves with the
+    combination, through the axial load and the face in tension that enter
+    ``V_c``. Among combinations tied on DCR -- every one of them, when nothing
+    is demanded -- the smallest capacity is the safe reading.
+    """
+    present = [(dcr, capacity) for dcr, capacity in pairs if capacity is not None]
+    if not present:
+        return None
+    return min(present, key=lambda pair: (-pair[0], pair[1]))[1]
+
+
 def envelope_flexure_face(checks: Sequence[FlexureCheck], face: str) -> FlexureFaceCheck:
     """Worst demand on one face across every combination checked.
 
     A pure function of the results: the governing combination differs per
-    quantity and per face, so each one is enveloped independently. ``face`` is
-    ``"bottom"`` or ``"top"``.
+    quantity and per face, so each one is enveloped independently -- except
+    the capacity, which follows the DCR so the two stay the ratio they were.
+    ``face`` is ``"bottom"`` or ``"top"``.
     """
     faces = [getattr(check, face) for check in checks]
     return FlexureFaceCheck(
@@ -126,6 +161,7 @@ def envelope_flexure_face(checks: Sequence[FlexureCheck], face: str) -> FlexureF
         A_s_min=_worst([f.A_s_min for f in faces]),
         A_s_max=_worst([f.A_s_max for f in faces]),
         DCR=max([f.DCR for f in faces], default=0.0),
+        M_capacity=_governing([(f.DCR, f.M_capacity) for f in faces]),
     )
 
 
@@ -136,59 +172,46 @@ def envelope_shear(checks: Sequence[ShearCheck]) -> ShearCheck:
         A_v_req=_worst([c.A_v_req for c in checks]),
         A_v_min=_worst([c.A_v_min for c in checks]),
         DCR=max([c.DCR for c in checks], default=0.0),
+        V_capacity=_governing([(c.DCR, c.V_capacity) for c in checks]),
     )
 
 
-def capture_flexure_check(beam: RectangularBeam, label: str, state: Any = None) -> FlexureCheck:
+def capture_flexure_check(beam: RectangularBeam, label: str, state: Any) -> FlexureCheck:
     """The flexure result of the combination just run.
 
-    Reads ``state`` when the design code returned one, so nothing had to be
-    written to the beam; falls back to its attributes for codes still on the
-    older path.
+    Reads the ``state`` the design code returned, so nothing has to have been
+    written to the beam: the result is a value of the check, not a reading of
+    the section afterwards.
     """
-    if state is not None:
-        return FlexureCheck(
-            label=label,
-            bottom=FlexureFaceCheck(
-                A_s_req=state.A_s_req_bot,
-                A_s_min=state.A_s_min_bot,
-                A_s_max=state.A_s_max_bot,
-                DCR=float(state.DCR_bot),
-            ),
-            top=FlexureFaceCheck(
-                A_s_req=state.A_s_req_top,
-                A_s_min=state.A_s_min_top,
-                A_s_max=state.A_s_max_top,
-                DCR=float(state.DCR_top),
-            ),
-        )
+    imperial = beam.concrete.is_imperial
 
     def face(suffix: str) -> FlexureFaceCheck:
+        A_s_req, A_s_min, A_s_max, M_capacity = state.face_quantities(suffix, imperial)
         return FlexureFaceCheck(
-            A_s_req=getattr(beam, f"_A_s_req_{suffix}", None),
-            A_s_min=getattr(beam, f"_A_s_min_{suffix}", None),
-            A_s_max=getattr(beam, f"_A_s_max_{suffix}", None),
-            DCR=float(getattr(beam, f"_DCRb_{suffix}", 0.0)),
+            A_s_req=A_s_req,
+            A_s_min=A_s_min,
+            A_s_max=A_s_max,
+            DCR=float(getattr(state, f"DCR_{suffix}")),
+            M_capacity=M_capacity,
         )
 
     return FlexureCheck(label=label, bottom=face("bot"), top=face("top"))
 
 
-def capture_shear_check(beam: RectangularBeam, label: str, state: Any = None) -> ShearCheck:
+def capture_shear_check(beam: RectangularBeam, label: str, state: Any) -> ShearCheck:
     """The shear result of the combination just run.
 
-    Reads ``state`` when the design code returned one — then nothing had to be
-    written to the beam for this to work. Falls back to the beam's attributes
-    for the codes still on the older path.
+    Reads the ``state`` the design code returned; see
+    :func:`capture_flexure_check`.
     """
-    if state is not None:
-        A_v_req, A_v_min = state.shear_reinforcement_quantities(beam.concrete.is_imperial)
-        return ShearCheck(label=label, A_v_req=A_v_req, A_v_min=A_v_min, DCR=float(state.DCR))
+    imperial = beam.concrete.is_imperial
+    A_v_req, A_v_min = state.shear_reinforcement_quantities(imperial)
     return ShearCheck(
         label=label,
-        A_v_req=getattr(beam, "_A_v_req", None),
-        A_v_min=getattr(beam, "_A_v_min", None),
-        DCR=float(getattr(beam, "_DCRv", 0.0)),
+        A_v_req=A_v_req,
+        A_v_min=A_v_min,
+        DCR=float(state.DCR),
+        V_capacity=state.shear_capacity_quantity(imperial),
     )
 
 
@@ -296,6 +319,11 @@ class FlexureFaceDesign:
     ``A_s`` is what the section carries. ``A_s_req``, ``A_s_min``, ``A_s_max``
     and ``DCR`` are the envelope over every load combination that was checked,
     so ``DCR`` is the one of the combination that governs this face.
+
+    ``M_capacity`` is the design moment resistance of the face as reinforced
+    -- ``ØMn`` under ACI 318-19 and CIRSOC 201-25, ``MRd`` under EN 1992-1-1
+    -- as the governing combination saw it, so it is the resistance ``DCR``
+    was formed from.
     """
 
     layers: Tuple[RebarLayer, ...]
@@ -304,6 +332,7 @@ class FlexureFaceDesign:
     A_s_min: Quantity
     A_s_max: Quantity
     DCR: float
+    M_capacity: Quantity
 
     @property
     def n_bars(self) -> int:
@@ -341,6 +370,13 @@ class ShearDesign:
 
     ``A_v_req``, ``A_v_min`` and ``DCR`` are the envelope over every load
     combination that was checked, so ``DCR`` is the governing one.
+
+    ``V_capacity`` is the design shear resistance of the section as reinforced
+    -- ``ØVn``, capped by ``ØVmax``, under ACI 318-19 and CIRSOC 201-25;
+    ``VRd`` under EN 1992-1-1 -- as the governing combination saw it, so it is
+    the resistance ``DCR`` was formed from. Under ACI it can differ between
+    combinations: ``V_c`` moves with the axial load and with which face is in
+    tension. The per-combination results carry each one's own.
     """
 
     n_stirrups: int
@@ -350,6 +386,7 @@ class ShearDesign:
     A_v_req: Quantity
     A_v_min: Quantity
     DCR: float
+    V_capacity: Quantity
     s_w: Quantity
     layout: str = STIRRUPS
 
@@ -401,6 +438,9 @@ def _face(beam: RectangularBeam, face: str) -> FlexureFaceDesign:
 
     # A_s is the reinforcement the section carries, not a per-combination result.
     A_s: Optional[Quantity] = getattr(beam, f"_A_s_{suffix}", None)
+    # Nothing checked means nothing to divide by; a zero moment in the display
+    # unit of this section keeps the field a quantity either way.
+    no_capacity: Quantity = to_display(0.0, "moment", beam.concrete.is_imperial)
 
     return FlexureFaceDesign(
         layers=_layers(beam, face),
@@ -409,6 +449,7 @@ def _face(beam: RectangularBeam, face: str) -> FlexureFaceDesign:
         A_s_min=zero if worst.A_s_min is None else worst.A_s_min,
         A_s_max=zero if worst.A_s_max is None else worst.A_s_max,
         DCR=worst.DCR,
+        M_capacity=no_capacity if worst.M_capacity is None else worst.M_capacity,
     )
 
 
@@ -462,6 +503,7 @@ def build_shear_design(beam: RectangularBeam) -> ShearDesign:
     # As in _face: the private attributes describe the combination that ran last,
     # so the envelope is taken over the results of every combination checked.
     worst = envelope_shear(getattr(beam, "_shear_checks", ()))
+    no_capacity: Quantity = to_display(0.0, "force", beam.concrete.is_imperial)
 
     return ShearDesign(
         n_stirrups=int(beam._stirrup_n),
@@ -471,6 +513,7 @@ def build_shear_design(beam: RectangularBeam) -> ShearDesign:
         A_v_req=zero if worst.A_v_req is None else worst.A_v_req,
         A_v_min=zero if worst.A_v_min is None else worst.A_v_min,
         DCR=worst.DCR,
+        V_capacity=no_capacity if worst.V_capacity is None else worst.V_capacity,
         s_w=beam._leg_spacing_across_width(),
         layout=transverse_layout(beam),
     )

--- a/tests/test_design_results.py
+++ b/tests/test_design_results.py
@@ -1,6 +1,7 @@
 """Tests for the public design results API (mento.design_results)."""
 
 import math
+from typing import Any
 
 import pytest
 from pandas import DataFrame
@@ -410,8 +411,12 @@ def test_values_only_checks_give_the_same_numbers_as_the_reporting_ones(concrete
 
     assert [c.DCR for c in shear] == [c.DCR for c in reporting.shear_checks]
     assert [c.A_v_req for c in shear] == [c.A_v_req for c in reporting.shear_checks]
+    assert [c.V_capacity for c in shear] == [c.V_capacity for c in reporting.shear_checks]
     assert [c.bottom.DCR for c in flexure] == [c.bottom.DCR for c in reporting.flexure_checks]
     assert [c.top.DCR for c in flexure] == [c.top.DCR for c in reporting.flexure_checks]
+    assert [c.bottom.A_s_req for c in flexure] == [c.bottom.A_s_req for c in reporting.flexure_checks]
+    assert [c.bottom.M_capacity for c in flexure] == [c.bottom.M_capacity for c in reporting.flexure_checks]
+    assert [c.top.M_capacity for c in flexure] == [c.top.M_capacity for c in reporting.flexure_checks]
 
 
 def test_values_only_checks_still_produce_readable_designs() -> None:
@@ -474,3 +479,164 @@ def test_results_are_frozen(designed_beam: RectangularBeam) -> None:
 
     with pytest.raises(FrozenInstanceError):
         designed_beam.flexure_design.bottom.A_s = 0 * cm**2  # type: ignore[misc]
+
+
+# ============================================================================
+# Capacity: the resistance the DCR was formed from
+# ============================================================================
+
+_BOTH_CODES = pytest.mark.parametrize(
+    "concrete, steel",
+    [
+        (Concrete_ACI_318_19(name="H25", f_c=25 * MPa), SteelBar(name="ADN 420", f_y=420 * MPa)),
+        (Concrete_EN_1992_2004(name="C25", f_c=25 * MPa), SteelBar(name="B500S", f_y=500 * MPa)),
+    ],
+    ids=["ACI", "EN"],
+)
+
+
+def _three_combinations() -> list[Forces]:
+    """The two of ``_two_combinations`` plus one that demands nothing at all."""
+    return [*_two_combinations(), Forces(label="C3")]
+
+
+@_BOTH_CODES
+def test_demand_over_dcr_gives_the_capacity_back(concrete, steel) -> None:  # type: ignore[no-untyped-def]
+    """The invariant a consumer used to lean on, now guaranteed by construction.
+
+    EN rounds the ratio to three decimals, so the comparison is made on the
+    ratio rather than on the moment: a rounded DCR of 0.051 is 1 % off, a
+    capacity is not.
+    """
+    beam = RectangularBeam(label="101", concrete=concrete, steel_bar=steel, width=20 * cm, height=60 * cm, c_c=25 * mm)
+    forces = _three_combinations()
+    Node(section=beam, forces=forces).design()
+
+    tested = 0
+    for check, force in zip(beam.flexure_checks, forces):
+        for face in (check.bottom, check.top):
+            if face.DCR > 0:
+                assert abs(force.M_y) / face.M_capacity == pytest.approx(face.DCR, abs=TABLE_ROUNDING)
+                tested += 1
+    for check, force in zip(beam.shear_checks, forces):
+        if check.DCR > 0:
+            assert abs(force.V_z) / check.V_capacity == pytest.approx(check.DCR, abs=TABLE_ROUNDING)
+            tested += 1
+    # Bottom, top and two shear combinations: nothing above was vacuous.
+    assert tested == 4
+
+
+@_BOTH_CODES
+def test_a_face_with_no_demand_still_reports_its_capacity(concrete, steel) -> None:  # type: ignore[no-untyped-def]
+    """The case the ratio cannot cover: a footing's top mat against nothing.
+
+    Its DCR is zero, and dividing by it says nothing. The capacity is a real
+    number -- and so is the shear resistance of a slab strip with no stirrups
+    and no shear, which printed as a blank cell downstream.
+    """
+    from mento.slab import Footing
+
+    footing = Footing(label="Z1", concrete=concrete, steel_bar=steel, width=100 * cm, height=40 * cm, c_c=50 * mm)
+    # The mild negative moment puts minimum reinforcement on the top face; the
+    # first combination then finds a reinforced face with no demand on it.
+    forces = [Forces(label="C1", M_y=50 * kNm), Forces(label="C2", M_y=-5 * kNm)]
+    Node(section=footing, forces=forces).design()
+
+    assert footing.flexure_design.top.A_s.magnitude > 0
+    unloaded = footing.flexure_checks[0].top
+    assert unloaded.DCR == 0
+    assert unloaded.M_capacity.magnitude > 0
+    assert footing.flexure_design.top.M_capacity == unloaded.M_capacity
+
+    shear = footing.shear_checks[0]
+    assert shear.DCR == 0
+    assert shear.V_capacity.magnitude > 0
+    assert footing.shear_design.V_capacity.magnitude > 0
+
+
+@_BOTH_CODES
+def test_two_faces_with_the_same_bars_report_the_same_capacity(concrete, steel) -> None:  # type: ignore[no-untyped-def]
+    """What dividing by a rounded ratio lost: the same section printed 43.3 on
+    one face and 43.4 on the other."""
+    beam = RectangularBeam(label="101", concrete=concrete, steel_bar=steel, width=20 * cm, height=60 * cm, c_c=25 * mm)
+    beam.set_longitudinal_rebar_bot(n1=3, d_b1=16 * mm)
+    beam.set_longitudinal_rebar_top(n1=3, d_b1=16 * mm)
+
+    bottom, top = beam.flexure_check_results([Forces(label="C1", M_y=43 * kNm), Forces(label="C2", M_y=-43 * kNm)])
+
+    assert bottom.bottom.M_capacity == top.top.M_capacity
+
+
+def test_design_capacity_is_the_one_the_governing_combination_saw() -> None:
+    """Under ACI 318-19 the shear resistance moves with the combination, so the
+    envelope has to pick one: the one its DCR came from, or the two stop being
+    a ratio."""
+    beam = RectangularBeam(
+        label="101",
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        width=20 * cm,
+        height=60 * cm,
+        c_c=25 * mm,
+    )
+    forces = _three_combinations()
+    Node(section=beam, forces=forces).design()
+
+    capacities = {c.V_capacity for c in beam.shear_checks}
+    assert len(capacities) > 1, "the premise: V_c differs between these combinations"
+
+    governing = max(beam.shear_checks, key=lambda c: c.DCR)
+    shear = beam.shear_design
+    assert shear.V_capacity == governing.V_capacity
+    assert abs(forces[0].V_z) / shear.V_capacity == pytest.approx(shear.DCR)
+
+    flexure = beam.flexure_design
+    assert abs(forces[0].M_y) / flexure.bottom.M_capacity == pytest.approx(flexure.bottom.DCR)
+    assert abs(forces[1].M_y) / flexure.top.M_capacity == pytest.approx(flexure.top.DCR)
+
+
+def test_envelope_capacity_follows_the_dcr() -> None:
+    """Built by hand, so the rule is visible: the governing combination's
+    capacity, the smallest among ties, and absent when no combination set one."""
+
+    def shear(label: str, DCR: float, V_capacity: Any) -> ShearCheck:
+        return ShearCheck(label=label, A_v_req=None, A_v_min=None, DCR=DCR, V_capacity=V_capacity)
+
+    # The largest capacity belongs to the combination that governs.
+    assert envelope_shear([shear("C1", 0.4, 150 * kN), shear("C2", 0.9, 200 * kN)]).V_capacity == 200 * kN
+    # Nothing demanded anywhere: the smallest is the safe reading.
+    assert envelope_shear([shear("C1", 0.0, 150 * kN), shear("C2", 0.0, 120 * kN)]).V_capacity == 120 * kN
+    # A code that did not set it is skipped, and stays absent if none did.
+    assert envelope_shear([shear("C1", 0.9, None), shear("C2", 0.4, 150 * kN)]).V_capacity == 150 * kN
+    assert envelope_shear([shear("C1", 0.9, None)]).V_capacity is None
+    assert envelope_shear([]).V_capacity is None
+
+    def face(DCR: float, M_capacity: Any) -> FlexureFaceCheck:
+        return FlexureFaceCheck(A_s_req=None, A_s_min=None, A_s_max=None, DCR=DCR, M_capacity=M_capacity)
+
+    checks = [
+        FlexureCheck(label="C1", bottom=face(0.4, 100 * kNm), top=face(0.0, 40 * kNm)),
+        FlexureCheck(label="C2", bottom=face(0.9, 90 * kNm), top=face(0.0, 30 * kNm)),
+    ]
+    assert envelope_flexure_face(checks, "bottom").M_capacity == 90 * kNm
+    assert envelope_flexure_face(checks, "top").M_capacity == 30 * kNm
+    assert envelope_flexure_face([], "bottom").M_capacity is None
+
+
+def test_capacity_is_reported_in_the_display_units_of_the_section() -> None:
+    """An imperial section reports kip·ft and kip, as every other quantity does."""
+    from mento.units import ft, inch, kip, ksi, psi
+
+    beam = RectangularBeam(
+        label="101",
+        concrete=Concrete_ACI_318_19(name="C4", f_c=4000 * psi),
+        steel_bar=SteelBar(name="G60", f_y=60 * ksi),
+        width=10 * inch,
+        height=16 * inch,
+        c_c=1.5 * inch,
+    )
+    Node(section=beam, forces=[Forces(label="C1", V_z=20 * kip, M_y=40 * kip * ft)]).design()
+
+    assert beam.flexure_design.bottom.M_capacity.units == kip * ft
+    assert beam.shear_design.V_capacity.units == kip
+    assert beam.flexure_design.bottom.M_capacity.magnitude > 0

--- a/tests/test_footing.py
+++ b/tests/test_footing.py
@@ -804,7 +804,7 @@ def test_both_faces_in_tension_both_get_the_crack_minimum(steel_b500s: SteelBar)
     Node(section=footing, forces=combo).design()
 
     results = footing.flexure_check_results(combo)
-    gross = (footing.width * footing.height).to("mm**2").magnitude
+    gross = footing.width * footing.height
     for face in ("bottom", "top"):
         governing = max(getattr(r, face).A_s_min for r in results)
-        assert governing / gross * 1000 == pytest.approx(1.097, abs=0.001)
+        assert (governing / gross).to("dimensionless").magnitude * 1000 == pytest.approx(1.097, abs=0.001)


### PR DESCRIPTION
# Description

A checked or designed section published a ratio but not the resistance the ratio was formed from, so a caller wanting to print `ØMn` / `MRd` / `ØVn` / `VRd` next to the demand had nowhere public to read it. mako divided the demand by the DCR, which inherits EN's three-decimal rounding (two faces with the same bars printed 43.3 and 43.4 kNm) and says nothing when the DCR is zero (a footing's top mat, a slab strip with no shear).

This PR implements the brief in `docs/architecture/capacity-in-design-results.md`:

- `FlexureFaceCheck` / `FlexureFaceDesign` gain `M_capacity`; `ShearCheck` / `ShearDesign` gain `V_capacity`. One neutral name for every code: `ØMn` and `ØVn` under ACI 318-19 and CIRSOC 201-25, `MRd` and `VRd` under EN 1992-1-1. The symbol stays in the presentation layer.
- Each check state hands its capacity to the frozen result through a method of its own (`face_quantities`, `shear_capacity_quantity`), so `design_results.py` never has to know which name a code uses.
- `check_flexure` / `check_shear` now pass the state to `capture_*`; the fallback that read the beam's private attributes is gone. No consumer needs `_phi_M_n_*`, `_M_Rd_*`, `_phi_V_n` or `_V_Rd` any more.
- User guide page, CHANGELOG entry, and an *Outcome* section on the brief.

## For the reviewer: two departures from the brief

1. **ACI shear reports `min(ØVn, ØVmax)`, not `ØVn`.** The check ratios the demand against the smaller of the two, so that is the only value for which `demand / DCR == capacity` holds on a section governed by the 22.5.1.2 cap.
2. **The envelope takes the governing combination's capacity, not the minimum.** The brief assumed a capacity is the section's alone. Under ACI 318-19 `Vc` moves with the axial load and with the face in tension, and a beam checked against three combinations reported three different `ØVn`. The minimum would have left `shear_design.DCR` and `shear_design.V_capacity` formed from different combinations, so the (demand, capacity, DCR) triple would not have been a ratio. Among ties (every combination, when nothing is demanded) the smallest wins.

## Fixed on the way

`flexure_check_results()` handed `A_s_req`, `A_s_min` and `A_s_max` to the frozen result as bare floats in canonical units (mm² / in²), where `check_flexure()` returned quantities in cm² / in². Both read the state through the same path now and agree; the existing values-only-vs-reporting test was extended to cover it.

## Tests

- `demand / DCR` gives the capacity back, both codes, flexure on both faces and shear.
- A footing's top mat against no demand reports a real `M_capacity`; a strip with no stirrups and no shear reports a real `V_capacity` (the blank `VRd` cell).
- Two faces with the same bars report exactly the same capacity.
- The design capacity is the governing combination's (ACI, where they differ).
- Envelope rule built by hand: governing, ties, `None` skipped, empty.
- Imperial sections report kip·ft and kip.

## Type of change

- [x] Bug fix
- [x] New feature or design code implementation
- [x] Documentation
- [ ] Maintenance (tooling, CI, refactoring with no behaviour change)

## Checklist

- [x] Tests added or updated, and `pytest` passes locally (1241 passed, 1 skipped)
- [x] `mypy mento/` passes
- [x] `ruff check` and `ruff format --check` report no changes
- [x] Documentation updated where the change is user facing (`sphinx -W` clean)
- [x] Public class and method names left unchanged, or the change was agreed beforehand — fields added only, with defaults on the check results

🤖 Generated with [Claude Code](https://claude.com/claude-code)
