### PR TITLE
feat(results): A_s_calc, the steel the moment alone asks for, next to A_s_req

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,17 @@ correct the engine's output for the first and divide it back out for the second.
   gives it back there too. Brief: `docs/architecture/capacity-in-design-results.md`.
   (#152)
 
+- **`A_s_calc`: the steel the moment alone asks for, next to `A_s_req`.** `A_s_req` on
+  `FlexureFaceCheck` and `FlexureFaceDesign` has the minimum folded in — `max(mechanical,
+  minimum)`, or the 4/3 rule under ACI — which is right for choosing bars and wrong for
+  anchoring them: a development length scaled by `A_s,nec / A_s,prov` needs the
+  mechanical area, and a footing mat governed by its minimum carries little of the
+  stress the minimum is sized for. Both design codes now return that area before the
+  `max` — `reinforcement_for_moment` or `A_s1_lim + A_s2` under EN, `A_s_calc` under
+  ACI — and it reaches the results as `A_s_calc`, enveloped over the combinations like
+  `A_s_req`. Zero with no moment; equal to `A_s_req` once the moment governs, compression
+  steel included. `A_s_req` does not change meaning.
+
 ### Fixed
 
 - **`flexure_check_results()` returned `A_s_req`, `A_s_min` and `A_s_max` as bare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,38 @@ from the release history and are summaries rather than complete lists.
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-09-02
+
+A footing is a section mento now designs as it is built, and the results a check returns
+carry the resistance their ratio was formed from. Both came from mako, which had to
+correct the engine's output for the first and divide it back out for the second.
+
 ### Added
+
+- **`Footing`: a one-way slab bearing on the ground.** Everything about it is a
+  `OneWaySlab`; what changes is the minimum longitudinal reinforcement, and that change is
+  the design codes' rather than the class's. `Section.support` (`"free"` / `"soil"`) is
+  a ClassVar the codes read, so the clause lives in `codes/`: ACI 318-19 §9.6.1.1(b)
+  grants the exemption and §13.3.1.2 substitutes the shrinkage and temperature steel of
+  §24.4.3.2 on the gross section (CIRSOC 201-25 shares the clause); EN 1992-1-1 takes the
+  halved geometric minimum of a foundation on every face and, on a face that is bending,
+  the larger of that and the crack-control minimum of §7.3.2(2). A footing is detailed
+  between 100 and 300 mm, both faces set out at one spacing (or the top at twice the
+  bottom), and a thin one warns. mento does no geotechnical calculation: bearing,
+  settlement, sliding, overturning, plan size and thickness stay with the caller, and
+  a face the moment does not put in tension is left unreinforced, because whether a
+  footing carries steel there is the consumer's call. A theory page and a user guide
+  page open on exactly that. (#150, #151)
+
+- **A designed slab reads as a spacing, and its bars may only sit so far apart.** The
+  rebar search answers in groups of bars, and `OneWaySlab` applied that answer the beam's
+  way, so a designed strip came out as `2Ø12 + 4Ø12` with the spacing that actually
+  details a slab left at zero. Each layer is now spread over the strip when the design is
+  applied and the spacing is what the slab stores — `str(slab.reinforcement.bottom)` is
+  `Ø12 mm/17 cm` — with `RebarLayer.s` carrying it and reading `None` on a beam. Both
+  codes also cap the centre-to-centre spacing (ACI 318-19 §7.7.2.3, EN 1992-1-1 §9.3.1.1)
+  through a registry hook, so a lightly loaded strip no longer covers its area with a bar
+  every half metre. Areas and DCRs are unchanged. (#149)
 
 - **The frozen results carry the capacity the DCR was formed from.** `FlexureFaceCheck`
   and `FlexureFaceDesign` gain `M_capacity`; `ShearCheck` and `ShearDesign` gain
@@ -23,13 +54,20 @@ from the release history and are summaries rather than complete lists.
   the `_phi_M_n_*`, `_M_Rd_*`, `_phi_V_n` or `_V_Rd` attributes of the compatibility
   layer. On a design the capacity is the governing combination's, so `demand / DCR`
   gives it back there too. Brief: `docs/architecture/capacity-in-design-results.md`.
+  (#152)
 
 ### Fixed
 
 - **`flexure_check_results()` returned `A_s_req`, `A_s_min` and `A_s_max` as bare
   floats** in the design code's canonical units (mm² or in²), where `check_flexure()`
   returned them as quantities in cm² or in². Both entry points now read the check state
-  through the same path and return quantities.
+  through the same path and return quantities. (#152)
+
+- **The EN crack-control minimum governs the thin footings, not the thick ones.** Two
+  docstrings had it inverted; the calculation and the theory page were right all along.
+  Written on `A_ct = b·h/2`, its ratio goes with `k/2`, and `k` decays from 1.00 to 0.65
+  between 300 and 800 mm, so the geometric minimum takes over around h = 640 mm for C25
+  with B500S. The trend is now pinned by tests. (#151)
 
 ## [1.0.1] - 2026-08-31
 
@@ -322,7 +360,8 @@ First public release on PyPI: rectangular concrete beam check and design for fle
 shear under ACI 318-19 and CIRSOC 201-25, unit aware calculations, results as pandas
 DataFrames, and Word calculation reports.
 
-[Unreleased]: https://github.com/mihdicaballero/mento/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/mihdicaballero/mento/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/mihdicaballero/mento/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/mihdicaballero/mento/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/mihdicaballero/mento/compare/v0.5.2...v1.0.0
 [0.5.2]: https://github.com/mihdicaballero/mento/compare/v0.5.1...v0.5.2

--- a/docs/source/user_guide/design_results.rst
+++ b/docs/source/user_guide/design_results.rst
@@ -36,6 +36,7 @@ Flexure
 
     flexure.bottom.A_s.to("cm**2")      # 5.15 cm², steel provided
     flexure.bottom.A_s_req.to("cm**2")  # 4.96 cm², steel required
+    flexure.bottom.A_s_calc.to("cm**2") # 4.96 cm², what the moment alone asks for
     flexure.bottom.A_s_min, flexure.bottom.A_s_max
     flexure.bottom.DCR                  # 0.965
     flexure.bottom.M_capacity           # 103.6 kN·m, ØMn here; MRd under EN 1992
@@ -53,6 +54,22 @@ Each face carries its layers, in order, and only the layers that hold bars:
 
 A face with no reinforcement has an empty ``layers`` tuple, which is what
 ``str(flexure.top)`` reports as ``'no reinforcement'``.
+
+``A_s_req`` and ``A_s_calc`` are the same number on this beam because the moment
+governs. They part on a face governed by its minimum: ``A_s_req`` is the steel to detail,
+``max(A_s_calc, A_s_min)`` — or the 4/3 rule under ACI — while ``A_s_calc`` is what the
+moment alone asked for, and is zero with no moment. Choose bars from the first. Scale an
+anchorage by ``A_s,nec / A_s,prov`` from the second: a footing mat governed by its
+minimum carries little of the stress that minimum is sized for, and charging it the full
+development length anchors a force that is not there.
+
+.. code-block:: python
+
+    face = footing.flexure_design.bottom      # a 1 m × 0.40 m strip under 20 kN·m, ACI
+
+    face.A_s_calc.to("cm**2")                 # 1.5 cm², the moment's own demand
+    face.A_s_min.to("cm**2")                  # 7.2 cm², the minimum on the ground
+    face.A_s_req == face.A_s_min              # True: the minimum governs
 
 A slab is detailed by a spacing rather than by a bar count, so each of its layers also
 carries the spacing it was designed with, and reads as one bar repeated across the strip.

--- a/mento/codes/ACI_318_19_beam.py
+++ b/mento/codes/ACI_318_19_beam.py
@@ -476,7 +476,7 @@ def _minimum_flexural_reinforcement_area_ACI_318_19(self: "RectangularBeam", M_u
 
 def _calculate_flexural_reinforcement_ACI_318_19(
     self: "RectangularBeam", M_u: float, d: float, d_prima: float
-) -> tuple[float, float, float, float, float, bool, bool]:
+) -> tuple[float, float, float, float, float, bool, bool, float]:
     """
     Calculates the flexural reinforcement for a given factored moment according to ACI 318-19.
 
@@ -501,6 +501,12 @@ def _calculate_flexural_reinforcement_ACI_318_19(
             - A_s_bool: Boolean indicating if 4/3*A_s_calc is adopted instead of A_s_min
             - doubly: True when compression reinforcement was required. Returned
               rather than written, so a check does not mark the section.
+            - A_s_calc: The steel the moment alone asks for, before any minimum
+              or the 4/3 rule -- zero with no moment, and the tension steel of
+              the couple when compression reinforcement is required. What an
+              anchorage scaled by A_s,nec / A_s,prov has to read, since a face
+              governed by its minimum carries little of the stress the minimum
+              is sized for.
     """
     concrete_aci = cast("Concrete_ACI_318_19", self.concrete)
     sec = section_floats(self)
@@ -612,8 +618,11 @@ def _calculate_flexural_reinforcement_ACI_318_19(
         f_s_prima_net = _f_s_prime_net_at_ductility_limit_ACI_318_19(self, d, d_prima)
         A_s_comp = M_n_prima / (f_s_prima_net * (d - d_prima))
         A_s_final = rho * b * d + A_s_comp * f_s_prima_net / f_y_mag
+        # Beyond the ductility limit the moment is carried as a couple, and the
+        # tension steel of that couple is what the moment asks for.
+        A_s_calc = A_s_final
 
-    return A_s_min, A_s_max, A_s_final, A_s_comp, c_d, A_s_bool, doubly
+    return A_s_min, A_s_max, A_s_final, A_s_comp, c_d, A_s_bool, doubly, clean_zero(A_s_calc)
 
 
 def _determine_nominal_moment_simple_reinf_ACI_318_19(self: "RectangularBeam", A_s: float, d: float) -> float:
@@ -805,6 +814,7 @@ def _check_flexure_ACI_318_19(self: "RectangularBeam", force: Forces) -> Flexure
             st.c_d_bot,
             st.A_s_bool_bot,
             st.doubly_reinforced,
+            st.A_s_calc_bot,
         ) = _calculate_flexural_reinforcement_ACI_318_19(
             self,
             st.M_u_bot,
@@ -827,6 +837,7 @@ def _check_flexure_ACI_318_19(self: "RectangularBeam", force: Forces) -> Flexure
             st.c_d_top,
             st.A_s_bool_top,
             st.doubly_reinforced,
+            st.A_s_calc_top,
         ) = _calculate_flexural_reinforcement_ACI_318_19(
             self,
             abs(st.M_u_top),
@@ -892,6 +903,7 @@ def _required_areas_ACI_318_19(
         c_d,
         A_s_bool,
         doubly,
+        _A_s_calc,  # the design sizes bars, so it wants the minimum folded in
     ) = _calculate_flexural_reinforcement_ACI_318_19(
         self,
         M.to(canonical["moment"]).magnitude,

--- a/mento/codes/EN_1992_2004_beam.py
+++ b/mento/codes/EN_1992_2004_beam.py
@@ -400,9 +400,16 @@ def _compression_zone_limits_EN_1992_2004(self: "RectangularBeam", d: float) -> 
 
 def _calculate_flexural_reinforcement_EN_1992_2004(
     self: "RectangularBeam", M_Ed: float, d: float, d_prima: float
-) -> tuple[float, float, float, float]:
+) -> tuple[float, float, float, float, float]:
     """
     Calculate the required top and bottom reinforcement areas for bending.
+
+    Returns ``(A_s_min, A_s_max, A_s1, A_s2, A_s_calc)``. ``A_s1`` is the
+    tension steel to detail, never below the minimum; ``A_s_calc`` is the steel
+    the moment alone asks for, before that minimum -- zero with no moment, and
+    ``A_s1_lim + A_s2`` once compression steel is needed. An anchorage scaled by
+    ``A_s,nec / A_s,prov`` reads the second, since a face governed by its
+    minimum carries little of the stress the minimum is sized for.
     """
     _, rho_max = _min_max_flexural_reinforcement_ratio_EN_1992_2004(self)
     # ADR-0005 boundary: convert once, compute in floats (N, mm, MPa, N·mm),
@@ -435,11 +442,10 @@ def _calculate_flexural_reinforcement_EN_1992_2004(
             # lambda must NOT be applied again to the lever arm below.
             x_eff = flexure_eq.compression_block_depth_for_moment(M, b, d_mm, eta, f_cd)
 
-            # Area of required tensile reinforcement, at least the minimum
-            A_s1 = max(
-                flexure_eq.reinforcement_for_moment(M, flexure_eq.lever_arm(d_mm, x_eff), f_yd),
-                A_s_min,
-            )
+            # Area the moment asks for, and the tensile reinforcement to
+            # detail: that or the minimum, whichever is larger
+            A_s_calc = flexure_eq.reinforcement_for_moment(M, flexure_eq.lever_arm(d_mm, x_eff), f_yd)
+            A_s1 = max(A_s_calc, A_s_min)
             # No compressive reinforcement required
             A_s2 = 0.0
 
@@ -464,10 +470,11 @@ def _calculate_flexural_reinforcement_EN_1992_2004(
             # (d - d') of the compression steel couple
             A_s2 = flexure_eq.reinforcement_for_moment(M - M_lim, d_mm - d_prime, f_sd)
 
-            # Required tensile reinforcement area
-            A_s1 = max(A_s1_lim + A_s2, A_s_min)
+            # Required tensile reinforcement area: the couple, or the minimum
+            A_s_calc = A_s1_lim + A_s2
+            A_s1 = max(A_s_calc, A_s_min)
 
-    return A_s_min, A_s_max, A_s1, A_s2
+    return A_s_min, A_s_max, A_s1, A_s2, A_s_calc
 
 
 def _simple_determine_nominal_moment_EN_1992_2004(
@@ -608,7 +615,8 @@ def _required_areas_EN_1992_2004(
     self: "RectangularBeam", face: str, M: Quantity, d: Quantity, d_prime: Quantity
 ) -> _FaceDemand:
     """Steel required by EN 1992-2004 on `face` for the moment `M`."""
-    A_s_min, A_s_max, A_s1, A_s2 = _calculate_flexural_reinforcement_EN_1992_2004(
+    # The design sizes bars, so it wants the minimum folded in, not A_s_calc.
+    A_s_min, A_s_max, A_s1, A_s2, _A_s_calc = _calculate_flexural_reinforcement_EN_1992_2004(
         self, M.to(_Nmm).magnitude, d.to(mm).magnitude, d_prime.to(mm).magnitude
     )
     # The design path speaks pint on both sides; only the calculation is floats.
@@ -669,6 +677,7 @@ def _check_flexure_EN_1992_2004(self: "RectangularBeam", force: Forces) -> ENFle
             st.A_s_max_bot,
             st.A_s_req_bot,
             st.A_s_req_top,
+            st.A_s_calc_bot,
         ) = _calculate_flexural_reinforcement_EN_1992_2004(self, st.M_Ed_bot, sec.d_bot, sec.c_mec_top)
         st.c_d_top = 0
         # Calculate the design capacity ratio for the bottom side.
@@ -683,6 +692,7 @@ def _check_flexure_EN_1992_2004(self: "RectangularBeam", force: Forces) -> ENFle
             st.A_s_max_top,
             st.A_s_req_top,
             st.A_s_req_bot,
+            st.A_s_calc_top,
         ) = _calculate_flexural_reinforcement_EN_1992_2004(self, abs(st.M_Ed_top), sec.d_top, sec.c_mec_bot)
         st.c_d_bot = 0
         # Calculate the design capacity ratio for the top side.

--- a/mento/codes/check_state.py
+++ b/mento/codes/check_state.py
@@ -62,8 +62,8 @@ def to_display(value: float, kind: str, imperial: bool) -> Any:
     return (value * CANONICAL[imperial][kind]).to(DISPLAY[imperial][kind])
 
 
-def _face_quantities(state: Any, face: str, capacity: str, imperial: bool) -> tuple[Any, Any, Any, Any]:
-    """``(A_s_req, A_s_min, A_s_max, capacity)`` of one face of a flexure state.
+def _face_quantities(state: Any, face: str, capacity: str, imperial: bool) -> tuple[Any, Any, Any, Any, Any]:
+    """``(A_s_req, A_s_min, A_s_max, capacity, A_s_calc)`` of one face of a flexure state.
 
     The two flexure states name their capacity differently -- ``phi_M_n`` and
     ``M_Rd`` -- and share everything else, so each names its own field and
@@ -74,6 +74,7 @@ def _face_quantities(state: Any, face: str, capacity: str, imperial: bool) -> tu
         to_display(getattr(state, f"A_s_min_{face}"), "area", imperial),
         to_display(getattr(state, f"A_s_max_{face}"), "area", imperial),
         to_display(getattr(state, capacity), "moment", imperial),
+        to_display(getattr(state, f"A_s_calc_{face}"), "area", imperial),
     )
 
 
@@ -415,6 +416,10 @@ class FlexureCheckState:
     A_s_max_top: float
     A_s_req_bot: float
     A_s_req_top: float
+    #: The steel the moment alone asks for, before the minimum folded into
+    #: A_s_req. Not on the compatibility layer: no report table prints it.
+    A_s_calc_bot: float
+    A_s_calc_top: float
     phi_M_n_bot: float
     phi_M_n_top: float
     c_d_bot: float
@@ -429,8 +434,8 @@ class FlexureCheckState:
     A_s_bool_top: bool
     doubly_reinforced: bool
 
-    def face_quantities(self, face: str, imperial: bool) -> tuple[Any, Any, Any, Any]:
-        """``(A_s_req, A_s_min, A_s_max, phi_M_n)`` of one face as quantities.
+    def face_quantities(self, face: str, imperial: bool) -> tuple[Any, Any, Any, Any, Any]:
+        """``(A_s_req, A_s_min, A_s_max, phi_M_n, A_s_calc)`` of one face as quantities.
 
         For the frozen public result; ``face`` is ``"bot"`` or ``"top"``. The
         capacity is the ``phi_M_n`` the face's DCR was divided by.
@@ -452,6 +457,8 @@ def new_flexure_state(section: "RectangularBeam") -> FlexureCheckState:
         A_s_max_top=0.0,
         A_s_req_bot=0.0,
         A_s_req_top=0.0,
+        A_s_calc_bot=0.0,
+        A_s_calc_top=0.0,
         phi_M_n_bot=0.0,
         phi_M_n_top=0.0,
         c_d_bot=0.0,
@@ -527,6 +534,9 @@ class ENFlexureCheckState:
     A_s_max_top: float
     A_s_req_bot: float
     A_s_req_top: float
+    #: As on :class:`FlexureCheckState`: the moment's own demand, no minimum.
+    A_s_calc_bot: float
+    A_s_calc_top: float
     c_d_bot: float
     c_d_top: float
     d_b_max_bot: float
@@ -536,8 +546,8 @@ class ENFlexureCheckState:
     DCR_bot: float
     DCR_top: float
 
-    def face_quantities(self, face: str, imperial: bool) -> tuple[Any, Any, Any, Any]:
-        """``(A_s_req, A_s_min, A_s_max, M_Rd)`` of one face as quantities.
+    def face_quantities(self, face: str, imperial: bool) -> tuple[Any, Any, Any, Any, Any]:
+        """``(A_s_req, A_s_min, A_s_max, M_Rd, A_s_calc)`` of one face as quantities.
 
         For the frozen public result; ``face`` is ``"bot"`` or ``"top"``. The
         capacity is the ``M_Rd`` the face's DCR was divided by.
@@ -562,6 +572,8 @@ def new_en_flexure_state(section: "RectangularBeam") -> ENFlexureCheckState:
         A_s_max_top=0.0,
         A_s_req_bot=0.0,
         A_s_req_top=0.0,
+        A_s_calc_bot=0.0,
+        A_s_calc_top=0.0,
         c_d_bot=0.0,
         c_d_top=0.0,
         d_b_max_bot=0.0,

--- a/mento/design_results.py
+++ b/mento/design_results.py
@@ -87,6 +87,12 @@ class FlexureFaceCheck:
     minimum reinforcement against no demand still reports it, which is what
     the ratio alone cannot tell.
 
+    ``A_s_req`` is the steel to detail: what the moment asks for or the
+    minimum, whichever is larger. ``A_s_calc`` is the first of those alone,
+    before the minimum -- zero with no moment. An anchorage scaled by
+    ``A_s,nec / A_s,prov`` reads it, because a face governed by its minimum
+    carries little of the stress that minimum is sized for.
+
     A field is ``None`` when the design code did not set it for this
     combination; enveloping skips those rather than treating them as zero.
     """
@@ -96,6 +102,7 @@ class FlexureFaceCheck:
     A_s_max: Optional[Quantity]
     DCR: float
     M_capacity: Optional[Quantity] = None
+    A_s_calc: Optional[Quantity] = None
 
 
 @dataclass(frozen=True)
@@ -162,6 +169,7 @@ def envelope_flexure_face(checks: Sequence[FlexureCheck], face: str) -> FlexureF
         A_s_max=_worst([f.A_s_max for f in faces]),
         DCR=max([f.DCR for f in faces], default=0.0),
         M_capacity=_governing([(f.DCR, f.M_capacity) for f in faces]),
+        A_s_calc=_worst([f.A_s_calc for f in faces]),
     )
 
 
@@ -186,13 +194,14 @@ def capture_flexure_check(beam: RectangularBeam, label: str, state: Any) -> Flex
     imperial = beam.concrete.is_imperial
 
     def face(suffix: str) -> FlexureFaceCheck:
-        A_s_req, A_s_min, A_s_max, M_capacity = state.face_quantities(suffix, imperial)
+        A_s_req, A_s_min, A_s_max, M_capacity, A_s_calc = state.face_quantities(suffix, imperial)
         return FlexureFaceCheck(
             A_s_req=A_s_req,
             A_s_min=A_s_min,
             A_s_max=A_s_max,
             DCR=float(getattr(state, f"DCR_{suffix}")),
             M_capacity=M_capacity,
+            A_s_calc=A_s_calc,
         )
 
     return FlexureCheck(label=label, bottom=face("bot"), top=face("top"))
@@ -320,6 +329,13 @@ class FlexureFaceDesign:
     and ``DCR`` are the envelope over every load combination that was checked,
     so ``DCR`` is the one of the combination that governs this face.
 
+    ``A_s_req`` is the steel to detail, never below the minimum. ``A_s_calc``
+    is what the moment alone asked for, before that minimum -- the envelope of
+    the same over the combinations, so the governing one's. Choose bars from
+    the first; scale an anchorage by ``A_s,nec / A_s,prov`` from the second,
+    since a face governed by its minimum carries little of the stress the
+    minimum is sized for.
+
     ``M_capacity`` is the design moment resistance of the face as reinforced
     -- ``ØMn`` under ACI 318-19 and CIRSOC 201-25, ``MRd`` under EN 1992-1-1
     -- as the governing combination saw it, so it is the resistance ``DCR``
@@ -329,6 +345,7 @@ class FlexureFaceDesign:
     layers: Tuple[RebarLayer, ...]
     A_s: Quantity
     A_s_req: Quantity
+    A_s_calc: Quantity
     A_s_min: Quantity
     A_s_max: Quantity
     DCR: float
@@ -446,6 +463,7 @@ def _face(beam: RectangularBeam, face: str) -> FlexureFaceDesign:
         layers=_layers(beam, face),
         A_s=zero if A_s is None else A_s,
         A_s_req=zero if worst.A_s_req is None else worst.A_s_req,
+        A_s_calc=zero if worst.A_s_calc is None else worst.A_s_calc,
         A_s_min=zero if worst.A_s_min is None else worst.A_s_min,
         A_s_max=zero if worst.A_s_max is None else worst.A_s_max,
         DCR=worst.DCR,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mento"
-version = "1.0.1"
+version = "1.1.0"
 description = "An intuitive tool for structural engineers to design concrete elements efficiently."
 readme = "README.md"
 authors = [

--- a/tests/test_beam.py
+++ b/tests/test_beam.py
@@ -52,11 +52,13 @@ def _flexural_reinforcement_in_pint(
     """
     imperial = beam.concrete.is_imperial
     canonical = CANONICAL[imperial]
-    A_s_min, A_s_max, A_s_final, A_s_comp, c_d, A_s_bool, doubly = _calculate_flexural_reinforcement_ACI_318_19(
-        beam,
-        M_u.to(canonical["moment"]).magnitude,
-        d.to(canonical["length"]).magnitude,
-        d_prima.to(canonical["length"]).magnitude,
+    A_s_min, A_s_max, A_s_final, A_s_comp, c_d, A_s_bool, doubly, _A_s_calc = (
+        _calculate_flexural_reinforcement_ACI_318_19(
+            beam,
+            M_u.to(canonical["moment"]).magnitude,
+            d.to(canonical["length"]).magnitude,
+            d_prima.to(canonical["length"]).magnitude,
+        )
     )
     return (
         to_display(A_s_min, "area", imperial),

--- a/tests/test_design_results.py
+++ b/tests/test_design_results.py
@@ -640,3 +640,78 @@ def test_capacity_is_reported_in_the_display_units_of_the_section() -> None:
     assert beam.flexure_design.bottom.M_capacity.units == kip * ft
     assert beam.shear_design.V_capacity.units == kip
     assert beam.flexure_design.bottom.M_capacity.magnitude > 0
+
+
+# ============================================================================
+# A_s_calc: what the moment alone asks for, before the minimum
+# ============================================================================
+
+
+def _footing_under(concrete, steel, M_y):  # type: ignore[no-untyped-def]
+    """A metre strip of a 40 cm footing, designed for one moment."""
+    from mento.slab import Footing
+
+    footing = Footing(label="Z1", concrete=concrete, steel_bar=steel, width=100 * cm, height=40 * cm, c_c=50 * mm)
+    Node(section=footing, forces=[Forces(label="C1", M_y=M_y)]).design()
+    return footing
+
+
+@_BOTH_CODES
+def test_a_face_governed_by_its_minimum_still_says_what_the_moment_asked_for(concrete, steel) -> None:  # type: ignore[no-untyped-def]
+    """The case the field is for: a footing mat sized by the minimum, barely
+    working. A_s_req is the minimum, as bar selection needs; A_s_calc is the
+    much smaller area the moment alone demands, as an anchorage needs."""
+    face = _footing_under(concrete, steel, 5 * kNm).flexure_design.bottom
+
+    assert face.A_s_req == face.A_s_min
+    assert 0 < face.A_s_calc.magnitude
+    assert face.A_s_calc < 0.5 * face.A_s_min
+
+
+@_BOTH_CODES
+def test_a_face_governed_by_the_moment_reports_the_same_area_twice(concrete, steel) -> None:  # type: ignore[no-untyped-def]
+    face = _footing_under(concrete, steel, 250 * kNm).flexure_design.bottom
+
+    assert face.A_s_calc == face.A_s_req
+    assert face.A_s_req > face.A_s_min
+
+
+@_BOTH_CODES
+def test_a_face_with_no_moment_asks_for_nothing(concrete, steel) -> None:  # type: ignore[no-untyped-def]
+    """Zero, not None and not the minimum: the top face of a footing bent one way."""
+    footing = _footing_under(concrete, steel, 50 * kNm)
+
+    assert footing.flexure_checks[0].top.A_s_calc.magnitude == 0
+    assert footing.flexure_design.top.A_s_calc.magnitude == 0
+
+
+@_BOTH_CODES
+def test_a_section_needing_compression_steel_asks_for_the_couple(concrete, steel) -> None:  # type: ignore[no-untyped-def]
+    """Beyond the ductility limit the moment is carried as a couple, and the
+    tension steel of that couple is what the moment asks for -- so A_s_calc
+    is A_s_req there too, above the singly reinforced maximum."""
+    beam = RectangularBeam(label="101", concrete=concrete, steel_bar=steel, width=20 * cm, height=40 * cm, c_c=25 * mm)
+    beam.set_longitudinal_rebar_bot(n1=4, d_b1=25 * mm)
+    beam.set_longitudinal_rebar_top(n1=2, d_b1=16 * mm)
+
+    beam.check_flexure([Forces(label="C1", M_y=220 * kNm)])
+    face = beam.flexure_checks[0].bottom
+
+    assert beam._doubly_reinforced
+    assert face.A_s_req > face.A_s_min
+    assert face.A_s_calc == face.A_s_req
+
+
+def test_a_s_calc_is_enveloped_like_a_s_req() -> None:
+    """The governing combination's, skipping the ones a code did not set."""
+
+    def face(A_s_calc: Any) -> FlexureFaceCheck:
+        return FlexureFaceCheck(A_s_req=None, A_s_min=None, A_s_max=None, DCR=0.0, A_s_calc=A_s_calc)
+
+    checks = [
+        FlexureCheck(label="C1", bottom=face(3 * cm**2), top=face(None)),
+        FlexureCheck(label="C2", bottom=face(5 * cm**2), top=face(None)),
+    ]
+    assert envelope_flexure_face(checks, "bottom").A_s_calc == 5 * cm**2
+    assert envelope_flexure_face(checks, "top").A_s_calc is None
+    assert envelope_flexure_face([], "bottom").A_s_calc is None


### PR DESCRIPTION
# Description

`FlexureFaceDesign.A_s_req` reads as "steel required", but what travels there already has the minimum folded in: `max(mechanical, A_s_min)` under EN (`A_s1`), `max(A_s_calc, A_s_min)` or the 4/3 rule under ACI (`A_s_final`). Right for choosing bars; wrong for anchoring them. A development length scaled by `A_s,nec / A_s,prov` needs the mechanical area, and a footing mat governed by its minimum carries little of the stress that minimum is sized for — charging it the full anchorage anchors a force that is not there. mako already applies that ratio (Calavera, fig. 2-16 and eq. 2.36) and, fed `A_s_req`, sees it land between 0.79 and 1.0 over 528 designed footing positions: the discount barely acts, exactly where it should.

## What changed

- **Both design codes return the mechanical area before the `max`.** `_calculate_flexural_reinforcement_EN_1992_2004` returns `(A_s_min, A_s_max, A_s1, A_s2, A_s_calc)` with `A_s_calc = reinforcement_for_moment(...)` in the singly reinforced branch and `A_s1_lim + A_s2` in the doubly one. `_calculate_flexural_reinforcement_ACI_318_19` appends `A_s_calc` to its tuple — the pre-minimum `A_s_calc` it already computed, rewritten as the tension steel of the couple beyond the ductility limit. Zero with no moment.
- **It reaches the results as `A_s_calc`.** New field on `FlexureCheckState` / `ENFlexureCheckState` (not on the compatibility layer: no table prints it), handed out through `face_quantities`, `Optional` with a default on `FlexureFaceCheck`, required on `FlexureFaceDesign`, enveloped over the combinations with `_worst` like `A_s_req` — so the governing combination's.
- **`A_s_req` does not change meaning.** Still `max(mechanical, minimum)`; the design path still sizes bars from it and ignores the new value.
- User guide paragraph with a footing example, CHANGELOG entry under `[1.1.0]`.

Branched from `release/1.1.0` so the changelog entry lands in the 1.1.0 section; once #153 merges this diff reduces to the feature alone. If this one goes first it carries the bump, which is the same release either way.

## For mako

`stress_ratio(A_s_req, A_s_real)` in `_rebar_detailing.py` becomes `stress_ratio(face.A_s_calc, A_s_real)`. One line, no adapters.

## Tests

Both codes, a 1 m strip of a 40 cm footing:

- 5 kN·m: `A_s_calc` under half of `A_s_min`, `A_s_req == A_s_min`.
- 250 kN·m: `A_s_calc == A_s_req > A_s_min`.
- Bent one way: the top face reports `A_s_calc == 0`, not `None` and not the minimum.
- A 20 × 40 beam under 220 kN·m, doubly reinforced under both codes: `A_s_calc == A_s_req`, the couple.
- The envelope takes the governing combination's and skips what a code did not set.

The ETABS validation helper in `test_beam.py` unpacks the longer ACI tuple; its assertions are unchanged.

## Type of change

- [ ] Bug fix
- [x] New feature or design code implementation
- [x] Documentation
- [ ] Maintenance (tooling, CI, refactoring with no behaviour change)

## Checklist

- [x] Tests added or updated, and `pytest` passes locally (1256 passed, 1 skipped)
- [x] `mypy mento/` passes
- [x] `pre-commit run --all-files` reports no changes
- [x] Documentation updated where the change is user facing (`sphinx -W` clean)
- [x] Public class and method names left unchanged, or the change was agreed beforehand — a field added, with a default on the check result

## Calculation validation

No new equation: `A_s_calc` is a value the two functions already computed and discarded in the `max`. The tests pin it against `A_s_req` and `A_s_min`, which the existing ETABS and EN validations cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
