### PR TITLE
feat(i18n): the summaries speak the report language, and the axes state their signs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,15 +1,15 @@
 {
   "permissions": {
     "allow": [
-      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\py312\\python.exe\" -m pytest tests/ --override-ini=\"addopts=\" -v --no-header)",
-      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\py312\\python.exe\" -m pytest tests/ --override-ini=\"addopts=\" -q --no-header)",
-      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\py312\\python.exe\" -m pytest tests/ --override-ini=\"addopts=\" --cov=mento --cov-report=term-missing -q)",
-      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\py312\\python.exe\" -m pytest tests/*.py --override-ini=\"addopts=\" -v --no-header)",
-      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\py312\\python.exe\" -m pytest tests/*.py --override-ini=\"addopts=\" -q --no-header)",
-      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\py312\\python.exe\" -m pytest tests/*.py --override-ini=\"addopts=\" --cov=mento --cov-report=term-missing -q)",
-      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\py312\\python.exe\" -m ruff check . --fix)",
-      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\py312\\python.exe\" -m ruff format .)",
-      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\py312\\python.exe\" -m mypy mento/)",
+      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\rame-env\\python.exe\" -m pytest tests/ --override-ini=\"addopts=\" -v --no-header)",
+      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\rame-env\\python.exe\" -m pytest tests/ --override-ini=\"addopts=\" -q --no-header)",
+      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\rame-env\\python.exe\" -m pytest tests/ --override-ini=\"addopts=\" --cov=mento --cov-report=term-missing -q)",
+      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\rame-env\\python.exe\" -m pytest tests/*.py --override-ini=\"addopts=\" -v --no-header)",
+      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\rame-env\\python.exe\" -m pytest tests/*.py --override-ini=\"addopts=\" -q --no-header)",
+      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\rame-env\\python.exe\" -m pytest tests/*.py --override-ini=\"addopts=\" --cov=mento --cov-report=term-missing -q)",
+      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\rame-env\\python.exe\" -m ruff check . --fix)",
+      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\rame-env\\python.exe\" -m ruff format .)",
+      "Bash(& \"C:\\Users\\mihdi\\anaconda3\\envs\\rame-env\\python.exe\" -m mypy mento/)",
       "Bash(python -m pytest tests/foundations/test_footings.py -v)",
       "Bash(uv run pytest tests/foundations/test_footings.py -v)",
       "Bash(python3 -m pytest tests/foundations/test_footings.py -v)",
@@ -45,10 +45,10 @@
       "PowerShell(& \"c:\\\\Users\\\\mihdi\\\\anaconda3\\\\python.exe\" -m pytest \"c:\\\\Users\\\\mihdi\\\\Documents\\\\GitHub\\\\mako\\\\tests\\\\quantities\\\\test_bbs_slab.py\" -v --no-header -p no:cacheprovider --override-ini=\"addopts=\" 2>&1)",
       "PowerShell(& \"c:\\\\Users\\\\mihdi\\\\anaconda3\\\\python.exe\" -c \"import sys; sys.path.insert\\(0, 'c:/Users/mihdi/Documents/GitHub/mako'\\); import mako; print\\(mako.__file__\\)\" 2>&1)",
       "PowerShell(where.exe pytest 2>&1; Get-Item \\(where.exe pytest 2>&1 | Select-Object -First 1\\) 2>&1)",
-      "PowerShell($env:PYTHONIOENCODING=\"utf-8\"; C:\\\\Users\\\\mihdi\\\\anaconda3\\\\envs\\\\py312\\\\python.exe C:\\\\Users\\\\mihdi\\\\Documents\\\\GitHub\\\\mento\\\\_tmp_design.py)",
-      "PowerShell(& \"C:\\\\Users\\\\mihdi\\\\anaconda3\\\\envs\\\\py312\\\\python.exe\" -c \"import importlib.metadata as m, mento; print\\(m.version\\('mento'\\)\\); print\\(mento.__file__\\)\")",
-      "PowerShell(& \"C:\\\\Users\\\\mihdi\\\\anaconda3\\\\envs\\\\py312\\\\python.exe\" -m pip show mento)",
-      "PowerShell(& \"C:\\\\Users\\\\mihdi\\\\anaconda3\\\\envs\\\\py312\\\\python.exe\" -c \"import mento, os; print\\(os.path.dirname\\(mento.__file__\\)\\)\")"
+      "PowerShell($env:PYTHONIOENCODING=\"utf-8\"; C:\\\\Users\\\\mihdi\\\\anaconda3\\\\envs\\\\rame-env\\\\python.exe C:\\\\Users\\\\mihdi\\\\Documents\\\\GitHub\\\\mento\\\\_tmp_design.py)",
+      "PowerShell(& \"C:\\\\Users\\\\mihdi\\\\anaconda3\\\\envs\\\\rame-env\\\\python.exe\" -c \"import importlib.metadata as m, mento; print\\(m.version\\('mento'\\)\\); print\\(mento.__file__\\)\")",
+      "PowerShell(& \"C:\\\\Users\\\\mihdi\\\\anaconda3\\\\envs\\\\rame-env\\\\python.exe\" -m pip show mento)",
+      "PowerShell(& \"C:\\\\Users\\\\mihdi\\\\anaconda3\\\\envs\\\\rame-env\\\\python.exe\" -c \"import mento, os; print\\(os.path.dirname\\(mento.__file__\\)\\)\")"
     ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,36 @@ from the release history and are summaries rather than complete lists.
 
 ## [Unreleased]
 
+### Added
+
+- **`set_language` now reaches the summaries.** It translated every detailed report but
+  stopped at `BeamSummary` and `ShearWallSummary`, which printed English tables and wrote
+  English Word documents whatever the language was set to — the user guide said as much.
+  `check()`, `flexure_results()` and `shear_results()` now return their DataFrames in the
+  active language, and `results_detailed_doc()` writes a translated document: it was
+  building its `DocumentBuilder` without passing the language along, and naming its
+  headings with f-strings, so the interpolated text could never match a catalog key. Only
+  the columns holding words are translated — `Beam`, `Label`, `Level`, `Position` and its
+  `Top`/`Bottom`, `Status`. `b`, `As,bot`, `Av` and `DCRv` are the notation of the design
+  code and stay identical in every language, as everywhere else in the catalog. English
+  output is unchanged. (#155)
+
+- **The sign convention is documented.** `N_x` is positive in compression, which is what
+  feeds σ_Nu into v_c under ACI 318-19 §22.5.5.1 and σ_cp under EN 1992-1-1 §6.2.2(1), so
+  a tension force entered positive is unconservative and silent; `M_y` is positive
+  sagging and selects the tension face; `V_z` is a magnitude, and the design routine sizes
+  stirrups from the largest required `A_v`, so a negative one reads as a smaller demand.
+  The coordinate system page states all three with the clause each comes from, and the
+  forces page states them where the components are introduced. No behaviour change — this
+  is what the code already did, written down. (#155)
+
+### Fixed
+
+- **A translated summary table lost its pass/fail shading.** The Word builder looked its
+  verdict column up by the English name and raised `KeyError` on a frame that had already
+  been translated. It resolves the name against the document's language now, so the
+  shading finds its column whichever spelling arrives. (#155)
+
 ## [1.1.0] - 2026-09-02
 
 A footing is a section mento now designs as it is built, and the results a check returns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Reinforced concrete design Python package. Covers beams, slabs, sections, materi
 
 ## Python environment
 
-**Always use the `rame-env` conda environment.** The base `anaconda3` env should never be used for mento. (The old `py312` env no longer exists.)
+**Always use the `rame-env` conda environment.** The base `anaconda3` env should never be used for mento.
 
 ```
 C:\Users\mihdi\anaconda3\envs\rame-env\python.exe

--- a/docs/source/examples/shear_wall_summary_ACI_318-19 Design.ipynb
+++ b/docs/source/examples/shear_wall_summary_ACI_318-19 Design.ipynb
@@ -1074,7 +1074,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py312",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/source/user_guide/forces.rst
+++ b/docs/source/user_guide/forces.rst
@@ -8,15 +8,33 @@ them in different stages of a structural analysis or design workflow.
 Key Concepts
 ------------
 
-- **Axial Force (`N_x`)**: Force applied along the axis of the element, along the x-x axis.
-- **Shear Force (`V_z`)**: Force acting perpendicular to the axis of the element, along the z-z local axis.
-- **Bending Moment (`M_y`)**: The moment caused by forces that induce bending about the y-y axis.
+- **Axial Force (`N_x`)**: Force applied along the axis of the element, along the x-x axis. **Positive in compression.**
+- **Shear Force (`V_z`)**: Force acting perpendicular to the axis of the element, along the z-z local axis. **Always entered as a positive magnitude.**
+- **Bending Moment (`M_y`)**: The moment caused by forces that induce bending about the y-y axis. **Positive when it produces tension at the bottom** of the section.
 - **Unit System**: You can define the unit system to display the forces for a Force object, *metric* or *imperial*.
 
 These are the main forces considered to  analyze a beam along it's main axis.
 For Columns analysis in future releases, the Forces object will have to have shear and bending moment in both axis.
 
 These forces are defined using compatible units from the `Pint` library, like `kN` or `kip` for forces and `kN*m` or `ft*kip` for moments.
+
+Sign Convention
+---------------
+
+The signs are part of the input, not a formatting detail — they change the result of a check:
+
+- **`N_x` is positive in compression**, negative in tension. Compression adds to the concrete
+  shear strength (:math:`\sigma_{Nu} = N_u / 6 A_g` in ACI 318-19 §22.5.5.1,
+  :math:`\sigma_{cp} = N_{Ed} / A_c` in EN 1992-1-1 §6.2.2(1)); a tensile force subtracts from
+  it. Entering a tension force as a positive number is unconservative.
+- **`M_y` is positive for sagging**, i.e. tension at the bottom fibre. The sign selects the
+  tension face, so a support moment must be entered as negative for the top reinforcement to
+  be designed.
+- **`V_z` is the magnitude of the design shear.** The demand-capacity ratio uses its absolute
+  value, but the design routine sizes stirrups from the largest required :math:`A_v` across the
+  combinations, so a negative value would be read as a smaller demand.
+
+See :doc:`local_axes` for the axes these components refer to.
 
 Usage
 -----

--- a/docs/source/user_guide/language.rst
+++ b/docs/source/user_guide/language.rst
@@ -60,11 +60,18 @@ The language applies to the detailed reports of every element — ``RectangularB
 - ``flexure_results_detailed()`` and ``shear_results_detailed()``, printed to the console
 - ``flexure_results_detailed_doc()`` and ``shear_results_detailed_doc()``, written to Word
 
+and to the summaries, :doc:`beam_summary` and :doc:`shear_wall_summary`:
+
+- ``check()``, ``flexure_results()`` and ``shear_results()``, whose DataFrames come back
+  with their headers translated
+- ``results_detailed_doc()``, written to Word
+
 Table headers, row labels and document headings are translated. These are deliberately
 left as they are:
 
 - **Variable names** — ``fc``, ``Av``, ``ØVn``, ``DCR`` are the notation of the design
-  code and stay identical in every language.
+  code and stay identical in every language. This is why a summary table translates
+  ``Beam`` and ``Position`` but leaves ``As,bot`` and ``DCRv`` alone.
 - **Units and numbers** — ``cm``, ``MPa``, ``kNm``.
 - **The design code designation** — ``CIRSOC 201-25`` keeps its official name.
 - **Generated file names** — a project keeps one naming scheme regardless of the language
@@ -76,8 +83,8 @@ renders.
 
 .. note::
 
-   Summary tables (:doc:`beam_summary`, :doc:`shear_wall_summary`) and the Jupyter output
-   of the ``results`` properties are not translated yet, and stay in English.
+   The Jupyter output of the ``results`` properties is not translated yet, and stays in
+   English.
 
 Adding a language
 -----------------

--- a/docs/source/user_guide/local_axes.rst
+++ b/docs/source/user_guide/local_axes.rst
@@ -25,3 +25,57 @@ Below is an illustration of the cross-section with the local **y-axis** and **z-
    :alt: Cross-section of a member with local y and z axes
    :align: center
    :width: 25%
+
+Sign Convention
+---------------
+
+The sign of each force component is not merely descriptive — it changes the result of
+a check, so it must match the convention below.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 25 60
+
+   * - Component
+     - Positive means
+     - Effect on the design
+   * - ``N_x``
+     - **Compression**
+     - Compression adds to the concrete shear strength; tension (a negative
+       ``N_x``) subtracts from it.
+   * - ``M_y``
+     - **Sagging** (tension at the bottom fibre)
+     - Selects which face is the tension face: a positive ``M_y`` designs the
+       bottom reinforcement, a negative ``M_y`` the top.
+   * - ``V_z``
+     - **Magnitude of the design shear**
+     - Shear is checked against a symmetric resistance, so its direction does not
+       change the outcome. Always pass it as a positive value.
+
+Axial force
+***********
+
+``N_x`` is **positive in compression** and negative in tension. This follows the axial
+term of both implemented codes, which is added to the concrete contribution:
+
+- ACI 318-19 §22.5.5.1 — :math:`\sigma_{Nu} = N_u / (6 A_g)`, capped at :math:`0.05 f'_c`.
+- EN 1992-1-1 §6.2.2(1) — :math:`\sigma_{cp} = N_{Ed} / A_c`, capped at :math:`0.2 f_{cd}`.
+
+A tensile axial force therefore reduces the concrete shear strength, which is the
+intended behaviour. Passing a tension force as a positive number is unconservative.
+
+Bending moment
+**************
+
+``M_y`` is **positive when it produces tension at the bottom** of the section (sagging).
+The check uses the sign to pick the tension face, so a support moment must be entered as
+negative for the top reinforcement to be designed.
+
+Shear force
+***********
+
+``V_z`` is the design shear at the section under consideration. The demand-capacity ratio
+is formed from its absolute value, so a sign error does not change a *check* — but the
+*design* routine sizes stirrups from the largest required :math:`A_v` across the load
+combinations, and a negative ``V_z`` would be read as a smaller demand. Always enter
+shear as a positive magnitude.

--- a/mento/beam_summary.py
+++ b/mento/beam_summary.py
@@ -11,10 +11,32 @@ from mento.material import (
 from mento.forces import Forces
 from mento.beam import RectangularBeam
 from mento.codes.registry import design_code
+from mento.i18n import translate, translate_dataframe
 from mento.results import FAIL_MARK, PASS_MARK, VERDICT_COLUMN
 from mento import mm, cm, kN, MPa, m, inch, ft, kNm
 from mento.node import Node
 from mento.reports.summaries import beam_summary_doc
+
+
+#: Summary-table columns that hold words rather than a number, a symbol or a
+#: check mark. ``translate_dataframe`` already covers the first column -- the
+#: element label -- but "Position" sits in the middle of the flexure table and
+#: would otherwise print "Top"/"Bottom" in an otherwise translated row.
+_WORD_COLUMNS = ("Position",)
+
+
+def _translated(df: DataFrame) -> DataFrame:
+    """A summary table in the language reports are currently rendered in.
+
+    Only the columns holding words are touched. The symbol columns -- ``b``,
+    ``As,bot``, ``Av``, ``Mu``, ``DCRv`` -- are variable names, and units and
+    numbers read the same in every language, so they are left alone.
+    """
+    out = df.copy()
+    for column in _WORD_COLUMNS:
+        if column in out.columns:
+            out[column] = [translate(value) if isinstance(value, str) else value for value in out[column]]
+    return translate_dataframe(out)
 
 
 class BeamSummary:
@@ -323,7 +345,7 @@ class BeamSummary:
 
         # Combine the units row with the results DataFrame
         final_df = pd.concat([units_row, results_df], ignore_index=True)
-        return final_df
+        return _translated(final_df)
 
     def design(self) -> DataFrame:
         """
@@ -414,7 +436,7 @@ class BeamSummary:
 
         # Recombine units + data
         df_final = pd.concat([units_row, data_rows], ignore_index=True)
-        return df_final
+        return _translated(df_final)
 
     def flexure_results(self, index: Optional[int] = None, capacity_check: bool = False) -> DataFrame:
         """
@@ -448,7 +470,7 @@ class BeamSummary:
 
         # Recombine units + data
         df_final = pd.concat([units_row, data_rows], ignore_index=True)
-        return df_final
+        return _translated(df_final)
 
     def _process_beam_for_check(self, node: Node, check_type: str, capacity_check: bool) -> DataFrame:
         """

--- a/mento/i18n.py
+++ b/mento/i18n.py
@@ -162,6 +162,28 @@ ES: Dict[str, str] = {
     "Vertical bar spacing (E.F.)": "Separación de barras verticales (en cada cara)",
     "Horizontal reinforcement ratio": "Cuantía de armadura horizontal",
     "Minimum vertical reinf. ratio": "Cuantía vertical mínima",
+    # -- summary tables: headers and cell values ---------------------------
+    # Only the columns that hold words. The symbol columns (b, h, As,bot, Av,
+    # Mu, DCRv) are variable names and stay as they are, like everywhere else.
+    "Beam": "Viga",
+    "Label": "Etiqueta",
+    "Level": "Nivel",
+    "Position": "Posición",
+    "Top": "Superior",
+    "Bottom": "Inferior",
+    "Status": "Estado",
+    # -- summary Word reports ----------------------------------------------
+    "Beam Summary Analysis": "Análisis del resumen de vigas",
+    "Shear Wall Summary Analysis": "Análisis del resumen de tabiques",
+    "This report presents the detailed results for the first beam of the summary, followed by summary tables for all beams.": "Este informe presenta los resultados detallados de la primera viga del resumen, seguidos de las tablas resumen de todas las vigas.",
+    "Wall {storey} - {label} shear check": "Verificación a corte del tabique {storey} - {label}",
+    "Summary - All Beams": "Resumen - Todas las vigas",
+    "Summary - All Walls": "Resumen - Todos los tabiques",
+    "Beam Data": "Datos de las vigas",
+    "Wall Data": "Datos de los tabiques",
+    "Flexure Results": "Resultados de flexión",
+    "Shear Results": "Resultados de corte",
+    "Design Check Summary": "Resumen de verificaciones",
 }
 
 # English is the source language, so its catalog is empty: every lookup falls

--- a/mento/reports/summaries.py
+++ b/mento/reports/summaries.py
@@ -18,6 +18,7 @@ from docx.shared import Cm
 
 from mento._version import __version__ as MENTO_VERSION
 from mento.codes.registry import design_code
+from mento.i18n import get_language
 from mento.results import DocumentBuilder
 
 if TYPE_CHECKING:
@@ -146,15 +147,19 @@ def beam_summary_doc(self: "BeamSummary", index: int = 1) -> None:
     node.check_shear()
 
     # Create document with smaller font
-    doc_builder = DocumentBuilder(title="Beam Summary Analysis", font_size=8)
+    doc_builder = DocumentBuilder(title="Beam Summary Analysis", font_size=8, language=get_language())
     doc_builder.add_heading("Beam Summary Analysis", level=1)
-    doc_builder.add_text(f"Made with mento {MENTO_VERSION}. Design code: {self.concrete.design_code}")
+    doc_builder.add_text(
+        "Made with mento {version}. Design code: {design_code}",
+        version=MENTO_VERSION,
+        design_code=self.concrete.design_code,
+    )
     doc_builder.add_text(
         "This report presents the detailed results for the first beam of the summary, followed by summary tables for all beams."
     )
 
     # --- DETAILED FLEXURE RESULTS FOR SELECTED BEAM ---
-    doc_builder.add_heading(f"Beam {beam.label} flexure check", level=2)
+    doc_builder.add_heading("Beam {label} flexure check", level=2, label=beam.label)
 
     # Build dataframes same as flexure_results_detailed_doc
     top_details = _details(beam._limiting_case_flexure_top_details)
@@ -226,7 +231,7 @@ def beam_summary_doc(self: "BeamSummary", index: int = 1) -> None:
     doc_builder.add_table_dcr(df_flex_capacity_bot)
 
     # --- DETAILED SHEAR RESULTS FOR SELECTED BEAM ---
-    doc_builder.add_heading(f"Beam {beam.label} shear check", level=2)
+    doc_builder.add_heading("Beam {label} shear check", level=2, label=beam.label)
 
     result_data = _details(beam._limiting_case_shear_details)
     df_shear_materials = pd.DataFrame(beam._materials_shear)
@@ -305,12 +310,18 @@ def wall_summary_doc(self: "ShearWallSummary", index: int = 1) -> None:
 
     node.check_shear()
 
-    doc_builder = DocumentBuilder(title="Shear Wall Summary Analysis", font_size=8)
+    doc_builder = DocumentBuilder(title="Shear Wall Summary Analysis", font_size=8, language=get_language())
     doc_builder.add_heading("Shear Wall Summary Analysis", level=1)
-    doc_builder.add_text(f"Made with mento {MENTO_VERSION}. Design code: {self.concrete.design_code}")
+    doc_builder.add_text(
+        "Made with mento {version}. Design code: {design_code}",
+        version=MENTO_VERSION,
+        design_code=self.concrete.design_code,
+    )
 
     # --- DETAILED RESULTS FOR SELECTED WALL ---
-    doc_builder.add_heading(f"Wall {wall.level} - {wall.label} shear check", level=2)
+    # The placeholder is `storey`, not `level`: `level` is add_heading's own
+    # argument for the heading depth.
+    doc_builder.add_heading("Wall {storey} - {label} shear check", level=2, storey=wall.level, label=wall.label)
 
     result_data = _details(wall._limiting_case_shear_details)
     df_materials = pd.DataFrame(wall._materials_shear_wall)

--- a/mento/results.py
+++ b/mento/results.py
@@ -637,13 +637,31 @@ class DocumentBuilder:
         """
         self.add_table(df, column_widths, font_size=font_size or self.font_size)
 
+    def _verdict_column(self, df: pd.DataFrame, column: str) -> Optional[str]:
+        """``column`` as ``df`` spells it -- in English, or already translated.
+
+        A summary frame arrives translated, so its verdict column is "¿Ok?"
+        rather than "Ok?" in Spanish, while a detail table arrives in English and
+        is translated on its way into the Word table. Accepting either spelling
+        means the shading finds its column in both cases. ``None`` when the frame
+        has no such column, which is a table without a verdict rather than an
+        error.
+        """
+        if column in df.columns:
+            return column
+        translated = translate(column, self.language)
+        return translated if translated in df.columns else None
+
     def _shade_verdicts(self, table: Any, df: pd.DataFrame, column: str) -> None:
         """Shade every cell of ``column`` that holds a verdict, green or red.
 
         Cells that hold neither mark -- a units row, a blank -- are left alone,
         so the colouring says something wherever it appears.
         """
-        column_idx = df.columns.get_loc(column)
+        resolved = self._verdict_column(df, column)
+        if resolved is None:
+            return
+        column_idx = df.columns.get_loc(resolved)
         for row_offset in range(df.shape[0]):
             verdict = str(df.iat[row_offset, column_idx])
             if verdict not in (PASS_MARK, FAIL_MARK):
@@ -707,8 +725,7 @@ class DocumentBuilder:
         cross is what the colour saves.
         """
         self.add_table(df, LIMIT_TABLE_WIDTHS, font_size=self.font_size)
-        if verdict_column in df.columns:
-            self._shade_verdicts(self.doc.tables[-1], df, verdict_column)
+        self._shade_verdicts(self.doc.tables[-1], df, verdict_column)
 
     def add_figure(self, fig: "plt.Figure", width: float = 16) -> None:
         """

--- a/mento/shear_wall_summary.py
+++ b/mento/shear_wall_summary.py
@@ -10,6 +10,7 @@ from mento.material import Concrete, SteelBar
 from mento.forces import Forces
 from mento.shear_wall import ShearWall
 from mento import mm, cm, kN, m, kNm, MPa, inch, ft
+from mento.i18n import translate_dataframe
 from mento.node import Node
 from mento.reports.summaries import wall_summary_doc
 
@@ -225,7 +226,7 @@ class ShearWallSummary:
         )
 
         results_df = pd.DataFrame(results_list)
-        return pd.concat([units_row, results_df], ignore_index=True)
+        return translate_dataframe(pd.concat([units_row, results_df], ignore_index=True))
 
     # ------------------------------------------------------------------
     # Design
@@ -261,7 +262,7 @@ class ShearWallSummary:
             if index < 1 or index > len(self.nodes):
                 raise IndexError(f"Index {index} is out of range. Valid: 1 to {len(self.nodes)}")
             node = self.nodes[index - 1]
-            return node.check_shear()
+            return translate_dataframe(node.check_shear())
 
         results = []
         units_row_added = False
@@ -272,7 +273,7 @@ class ShearWallSummary:
                 units_row_added = True
             results.append(df.iloc[1:])
         out: DataFrame = pd.concat(results, ignore_index=True)
-        return out
+        return translate_dataframe(out)
 
     # ------------------------------------------------------------------
     # Excel I/O

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -34,9 +34,11 @@ from mento.material import (
     Concrete_EN_1992_2004,
     SteelBar,
 )
+from mento.beam_summary import BeamSummary
 from mento.node import Node
 from mento.results import DocumentBuilder, TablePrinter
 from mento.shear_wall import ShearWall
+from mento.shear_wall_summary import ShearWallSummary
 from mento.slab import OneWaySlab
 from mento.units import MPa, cm, kN, kNm, m, mm
 
@@ -286,7 +288,13 @@ def _rendered_strings(monkeypatch: pytest.MonkeyPatch, render: Any) -> Set[str]:
     def tp_print(self: Any, data: Dict[str, List[Any]], **kwargs: Any) -> None:
         record(data)
 
+    document_init = DocumentBuilder.__init__
+
     def db_init(self: Any, title: str, font_name: str = "Lato", font_size: int = 9, language: str = "en") -> None:
+        # The real one, so the builder has a document: the summary reports
+        # measure their column widths against the page. Nothing reaches disk --
+        # `save` is stubbed out below.
+        document_init(self, title, font_name, font_size, language)
         found.add(title)
 
     def db_heading(self: Any, text: str, level: int, font_size: float = 10, **fields: Any) -> None:
@@ -307,6 +315,7 @@ def _rendered_strings(monkeypatch: pytest.MonkeyPatch, render: Any) -> Set[str]:
     monkeypatch.setattr(DocumentBuilder, "add_table_data", db_table)
     monkeypatch.setattr(DocumentBuilder, "add_table_dcr", db_table)
     monkeypatch.setattr(DocumentBuilder, "add_table_min_max", db_table)
+    monkeypatch.setattr(DocumentBuilder, "add_table_status", db_table)
     monkeypatch.setattr(DocumentBuilder, "save", lambda self, filename: None)
 
     render()
@@ -470,3 +479,178 @@ class TestEndToEnd:
         """Summaries are out of scope; they must not pick the language up."""
         set_language("es")
         assert DocumentBuilder(title="Beam Summary Analysis", font_size=8).language == i18n.DEFAULT_LANGUAGE
+
+
+# ---------------------------------------------------------------------------
+# Summaries
+# ---------------------------------------------------------------------------
+#
+# `BeamSummary` and `ShearWallSummary` return DataFrames rather than printing,
+# so they translate on the way out instead of going through `TablePrinter`.
+# Only the columns holding words are translated: the symbol columns are
+# variable names, and a report that renamed `Av` would be reporting something
+# else.
+
+
+def _beam_summary() -> BeamSummary:
+    data = {
+        "Label": ["", "V101", "V102"],
+        "Comb.": ["", "ELU 1", "ELU 2"],
+        "b": ["cm", 20, 20],
+        "h": ["cm", 50, 50],
+        "cc": ["mm", 25, 25],
+        "Nx": ["kN", 0, 0],
+        "Vz": ["kN", 20, 50],
+        "My": ["kNm", 30, -35],
+        "ns": ["", 1.0, 1.0],
+        "dbs": ["mm", 6, 6],
+        "sl": ["cm", 20, 20],
+        "n1": ["", 2.0, 2.0],
+        "db1": ["mm", 12, 12],
+        "n2": ["", 1.0, 1.0],
+        "db2": ["mm", 10, 16],
+        "n3": ["", 2.0, 2.0],
+        "db3": ["mm", 12, 12],
+        "n4": ["", 0, 0],
+        "db4": ["mm", 0, 0],
+    }
+    return BeamSummary(
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        beam_list=pd.DataFrame(data),
+    )
+
+
+def _wall_summary() -> ShearWallSummary:
+    data = {
+        "Level": ["", "Level 1", "Level 1"],
+        "Label": ["", "M1", "M1"],
+        "Comb.": ["", "ELU 1", "ELU 2"],
+        "t": ["cm", 20, 20],
+        "lw": ["m", 3.0, 3.0],
+        "hw": ["m", 3.0, 3.0],
+        "cc": ["mm", 25, 25],
+        "Nx": ["kN", 0, -301],
+        "Vz": ["kN", 264, 152],
+        "My": ["kNm", -172, -234],
+        "dbh": ["mm", 0, 0],
+        "sh": ["cm", 0, 0],
+        "dbv": ["mm", 0, 0],
+        "sv": ["cm", 0, 0],
+    }
+    summary = ShearWallSummary(
+        concrete=Concrete_ACI_318_19(name="H25", f_c=25 * MPa),
+        steel_bar=SteelBar(name="ADN 420", f_y=420 * MPa),
+        wall_list=pd.DataFrame(data),
+    )
+    summary.design()
+    return summary
+
+
+class TestSummaryTables:
+    def test_beam_check_headers_are_translated(self) -> None:
+        set_language("es")
+        columns = list(_beam_summary().check().columns)
+        assert ES["Beam"] in columns
+        assert ES["Ok?"] in columns
+        assert "Beam" not in columns
+
+    def test_beam_check_keeps_variable_names(self) -> None:
+        """`Av` and `DCRv` name quantities, not prose: they read the same in both."""
+        set_language("es")
+        columns = list(_beam_summary().check().columns)
+        for symbol in ("b", "h", "As,top", "As,bot", "Av", "DCRv"):
+            assert symbol in columns
+
+    def test_flexure_results_translate_the_position_column(self) -> None:
+        """The header and its values: a row reading "Top" under "Posición" is
+        the half-translated output this covers."""
+        set_language("es")
+        df = _beam_summary().flexure_results()
+        assert ES["Position"] in df.columns
+        positions = set(df[ES["Position"]])
+        assert ES["Top"] in positions
+        assert ES["Bottom"] in positions
+        assert "Top" not in positions
+
+    def test_shear_results_are_translated(self) -> None:
+        set_language("es")
+        columns = list(_beam_summary().shear_results().columns)
+        assert ES["Label"] in columns
+        assert "Label" not in columns
+
+    def test_wall_check_is_translated(self) -> None:
+        set_language("es")
+        columns = list(_wall_summary().check().columns)
+        assert ES["Level"] in columns
+        assert ES["Status"] in columns
+        assert "Status" not in columns
+
+    def test_english_is_unchanged(self) -> None:
+        """The default output is the one every existing notebook reads."""
+        columns = list(_beam_summary().check().columns)
+        assert "Beam" in columns
+        assert "Ok?" in columns
+
+
+def _rendered_prose(monkeypatch: pytest.MonkeyPatch, render: Any) -> Set[str]:
+    """The headings and paragraphs ``render`` writes, in English.
+
+    Narrower than :func:`_rendered_strings`, which also records table headers:
+    a summary table's headers are mostly symbols -- `Av`, `My`, `DCR` -- and
+    those are deliberately the same in every language. What has to be
+    translated, and what a new report line is likely to forget, is the prose.
+    The tables are left to run for real, so the document is built the way it
+    would be for a user; only ``save`` is stubbed out.
+    """
+    found: Set[str] = set()
+    heading, text = DocumentBuilder.add_heading, DocumentBuilder.add_text
+
+    def db_heading(self: Any, text_: str, level: int, font_size: float = 10, **fields: Any) -> None:
+        found.add(text_)
+        heading(self, text_, level, font_size, **fields)
+
+    def db_text(self: Any, text_: str, **fields: Any) -> None:
+        found.add(text_)
+        text(self, text_, **fields)
+
+    monkeypatch.setattr(DocumentBuilder, "add_heading", db_heading)
+    monkeypatch.setattr(DocumentBuilder, "add_text", db_text)
+    monkeypatch.setattr(DocumentBuilder, "save", lambda self, filename: None)
+
+    render()
+    return found
+
+
+class TestSummaryCatalogCoverage:
+    """Same guard as :class:`TestCatalogCoverage`, for the summary reports: a
+    heading added without a translation fails here instead of printing English
+    inside a Spanish document."""
+
+    def test_beam_summary_doc(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        summary = _beam_summary()
+        prose = _rendered_prose(monkeypatch, lambda: summary.results_detailed_doc(index=1))
+        assert "Beam Summary Analysis" in prose, "the harness saw no report"
+        assert sorted(s for s in prose if s not in ES) == []
+
+    def test_wall_summary_doc(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        summary = _wall_summary()
+        prose = _rendered_prose(monkeypatch, lambda: summary.results_detailed_doc(index=1))
+        assert "Shear Wall Summary Analysis" in prose, "the harness saw no report"
+        assert sorted(s for s in prose if s not in ES) == []
+
+    def test_the_summary_document_renders_in_spanish(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """End to end: the headings reach the document translated, and the
+        status column still finds itself once the table is translated."""
+        saved: Dict[str, Any] = {}
+        monkeypatch.setattr(
+            DocumentBuilder, "save", lambda self, filename: saved.update(doc=self.doc, filename=filename)
+        )
+        set_language("es")
+        _beam_summary().results_detailed_doc(index=1)
+
+        text = "\n".join(p.text for p in saved["doc"].paragraphs)
+        assert ES["Beam Summary Analysis"] in text
+        assert ES["Design Check Summary"] in text
+        assert "Design Check Summary" not in text
+        assert saved["filename"] == "Beam_Summary_ACI 318-19.docx"


### PR DESCRIPTION
# Description

Two things that turned out to be the same kind of gap: something the code
decided correctly but never told anyone.

**`set_language("es")` stopped at the summaries.** It reached every detailed
report, but `BeamSummary` and `ShearWallSummary` printed English tables and
wrote English Word documents whatever the language was set to. Three
independent causes, each hiding the next:

- the summary classes returned their DataFrames untranslated;
- `summaries.py` built its `DocumentBuilder` without passing the language, so
  the one report path that already knew how to translate was told to stay in
  English;
- and it named its headings with f-strings, so the interpolated text could
  never match a catalog key — `"Beam V101 flexure check"` is not
  `"Beam {label} flexure check"`, and the catalog already carried the second.

Fixing the first surfaced a fourth: `_shade_verdicts` looked its verdict column
up by the English name and raised `KeyError` once `check()` handed it a
translated frame. It resolves the name against the document language now, so it
finds its column whether the frame arrives translated or not.

**The sign convention was written down nowhere.** Worse than it sounds, because
the signs are load-bearing: `N_x` positive in compression feeds `σ_Nu` into
`v_c` under ACI 318-19 §22.5.5.1 and `σ_cp` under EN 1992-1-1 §6.2.2(1), so a
tension force entered positive is unconservative and silent. `M_y` positive is
sagging and picks the tension face. `V_z` is a magnitude, and the design routine
sizes stirrups from the largest required `A_v` across the combinations, so a
negative one reads as a smaller demand rather than as an error. The coordinate
system page now states all three with the clause each comes from, and the forces
page states them where the components are introduced.

## What is translated, and what is not

Only the columns holding words: `Beam`, `Label`, `Level`, `Position` and its
`Top`/`Bottom`, `Status`. `b`, `As,bot`, `Av`, `DCRv` are the notation of the
design code and stay identical in every language — the rule the rest of the
catalog already follows. A summary that renamed `Av` would be reporting
something else.

## Type of change

- [x] Bug fix
- [ ] New feature or design code implementation
- [x] Documentation
- [x] Maintenance (tooling, CI, refactoring with no behaviour change)

## Checklist

- [x] Tests added or updated, and `pytest` passes locally
- [x] `mypy mento/` passes
- [x] `pre-commit run --all-files` reports no changes
- [x] Documentation updated where the change is user facing
- [x] Public class and method names left unchanged, or the change was agreed beforehand

`1256 passed, 1 skipped`. Nine new tests in `tests/test_i18n.py`, including a
coverage guard on the summary reports: a heading added without a translation now
fails the suite instead of printing English inside a Spanish document. Sphinx
builds clean under `-W`.

## Notes for the reviewer

- **English output is unchanged** — the English catalog is empty, so every
  lookup falls through to the key. Existing notebooks read the same tables.
- **The translations are data.** `Beam`→Viga, `Label`→Etiqueta, `Level`→Nivel,
  `Position`→Posición, `Top`/`Bottom`→Superior/Inferior, `Status`→Estado,
  `Design Check Summary`→"Resumen de verificaciones". Revise freely; the tests
  assert `ES["<english>"]`, never a Spanish literal, so terminology changes do
  not break them.
- **`As,req top` stays half-English.** It is a variable name, so the rule above
  leaves it alone. Worth a decision if that reads badly in a Spanish report.
- The wall Word heading uses a `{storey}` placeholder rather than `{level}`,
  because `level` is already `add_heading`'s own argument for heading depth.
- The last commit is unrelated housekeeping: the `py312` environment no longer
  exists, and the permission entries, `CLAUDE.md` and one notebook kernel label
  still named it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
